### PR TITLE
feat(preview): 增加安全文件预览与 Markdown 编辑

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ local `claude` or `codex` session through a WebSocket relay. Two independent lin
   the temp key. Emitting SessionFocus on id-capture = focus-steal by background
   sessions.
 - **History = on-demand bulk read; reconnect recovery = bounded ring replay**
-  (protocol v8; aligns
+  (protocol v9; aligns
   with cc-on-web / web chats): the client fetches a session's history via
   `GetHistory` → the wrapper reads the transcript (`get_session_messages` +
   `translate_history`, in a thread) and returns it as ONE `History` frame

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ local `claude` or `codex` session through a WebSocket relay. Two independent lin
   the temp key. Emitting SessionFocus on id-capture = focus-steal by background
   sessions.
 - **History = on-demand bulk read; reconnect recovery = bounded ring replay**
-  (protocol v9; aligns
+  (protocol v10; aligns
   with cc-on-web / web chats): the client fetches a session's history via
   `GetHistory` → the wrapper reads the transcript (`get_session_messages` +
   `translate_history`, in a thread) and returns it as ONE `History` frame

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ API key 烤进网页。
 | **双引擎** | 在同一个 Web UI 中使用 Claude Code 和 Codex；每个会话保持自己的模型、思考强度、权限与运行状态。 |
 | **远程操作** | 手机、平板或桌面浏览器实时看流式回复，发送附件，排队下一条消息，随时打断当前回合。 |
 | **完整过程** | 折叠展示引擎公开提供的 reasoning 摘要、计划、命令输出、文件 diff、MCP、协作代理、Hook 和终端交互事件。 |
+| **文件预览** | 点击回复中的本机文件链接可直接打开源码并定位行号；也可从变更卡片或 `/preview 路径` 打开 Markdown，切换渲染/源码并安全加载本地图片。 |
 | **人工确认** | 回传 Claude `can_use_tool`，以及 Codex 命令、文件修改、用户输入、通用权限和 MCP elicitation；终端占用时可只读镜像，也可由用户主动接管。 |
 | **会话管理** | 搜索、切换、重命名、归档和消息级派生；Codex 还可在 Git 仓库中派生到独立 worktree。 |
 | **运行控制** | 切换模型、思考强度、服务档位、权限和 Plan 模式；`/goal` 管理长目标，Codex `/status` 读取 app-server 状态、用量与限额。 |
@@ -220,12 +221,12 @@ npm --prefix web run build   # 产出 web/dist/
 
 > 现在网页**不再把 token 烤进 JS**：登录改为向中继 POST 口令换取短期会话 token。所以构建不需要任何 `VITE_*` 变量。
 
-> **升级到协议 v8**：线协议会严格拒绝版本不一致。请在同一次维护窗口部署
+> **升级到协议 v9**：线协议会严格拒绝版本不一致。请在同一次维护窗口部署
 > `cc_remote/` 和新的 `web/dist/`，然后依次重启 relay、wrapper；不要新旧版本滚动混跑。
 > 升级期间已有 WebSocket 会短暂重连，relay 重启也会要求浏览器重新登录。已打开的
 > 旧版页面必须做一次**硬刷新**（重新加载新的带 hash 静态资源），仅重新登录不够。
-> 手工发布时先停本机 wrapper，再停服更新 relay + web，最后启动 v8 relay 和
-> v8 wrapper；这样旧 wrapper 不会占住 relay 的单连接槽。
+> 手工发布时先停本机 wrapper，再停服更新 relay + web，最后启动 v9 relay 和
+> v9 wrapper；这样旧 wrapper 不会占住 relay 的单连接槽。
 
 ### 3）停服维护窗口内，从 staging 发布到 VPS
 
@@ -235,7 +236,7 @@ rsync -av --delete --exclude='.git' --exclude='.venv' \
   --exclude='web/node_modules' --exclude='.env' \
   ./ <vps-user>@<vps>:~/cc-remote-upload/
 
-# VPS：协议 v8 的 Python + web/dist 在停服窗口一起发布，避免混跑
+# VPS：协议 v9 的 Python + web/dist 在停服窗口一起发布，避免混跑
 ssh <vps-user>@<vps>
 sudo systemctl stop cc-remote-relay 2>/dev/null || true
 sudo mkdir -p /opt/cc-remote

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ API key 烤进网页。
 | **双引擎** | 在同一个 Web UI 中使用 Claude Code 和 Codex；每个会话保持自己的模型、思考强度、权限与运行状态。 |
 | **远程操作** | 手机、平板或桌面浏览器实时看流式回复，发送附件，排队下一条消息，随时打断当前回合。 |
 | **完整过程** | 折叠展示引擎公开提供的 reasoning 摘要、计划、命令输出、文件 diff、MCP、协作代理、Hook 和终端交互事件。 |
-| **文件预览** | 点击回复中的本机文件链接可直接打开源码并定位行号；也可从变更卡片或 `/preview 路径` 打开 Markdown，切换渲染/源码并安全加载本地图片。 |
+| **文件预览与 Markdown 编辑** | 点击回复中的本机文件链接可直接打开源码并定位行号；也可从变更卡片或 `/preview 路径` 打开 Markdown，在实时预览和源码编辑间切换，通过 Ctrl/⌘+S 或保存按钮执行带冲突检测的原子保存。 |
 | **人工确认** | 回传 Claude `can_use_tool`，以及 Codex 命令、文件修改、用户输入、通用权限和 MCP elicitation；终端占用时可只读镜像，也可由用户主动接管。 |
 | **会话管理** | 搜索、切换、重命名、归档和消息级派生；Codex 还可在 Git 仓库中派生到独立 worktree。 |
 | **运行控制** | 切换模型、思考强度、服务档位、权限和 Plan 模式；`/goal` 管理长目标，Codex `/status` 读取 app-server 状态、用量与限额。 |
@@ -221,12 +221,12 @@ npm --prefix web run build   # 产出 web/dist/
 
 > 现在网页**不再把 token 烤进 JS**：登录改为向中继 POST 口令换取短期会话 token。所以构建不需要任何 `VITE_*` 变量。
 
-> **升级到协议 v9**：线协议会严格拒绝版本不一致。请在同一次维护窗口部署
+> **升级到协议 v10**：线协议会严格拒绝版本不一致。请在同一次维护窗口部署
 > `cc_remote/` 和新的 `web/dist/`，然后依次重启 relay、wrapper；不要新旧版本滚动混跑。
 > 升级期间已有 WebSocket 会短暂重连，relay 重启也会要求浏览器重新登录。已打开的
 > 旧版页面必须做一次**硬刷新**（重新加载新的带 hash 静态资源），仅重新登录不够。
-> 手工发布时先停本机 wrapper，再停服更新 relay + web，最后启动 v9 relay 和
-> v9 wrapper；这样旧 wrapper 不会占住 relay 的单连接槽。
+> 手工发布时先停本机 wrapper，再停服更新 relay + web，最后启动 v10 relay 和
+> v10 wrapper；这样旧 wrapper 不会占住 relay 的单连接槽。
 
 ### 3）停服维护窗口内，从 staging 发布到 VPS
 
@@ -236,7 +236,7 @@ rsync -av --delete --exclude='.git' --exclude='.venv' \
   --exclude='web/node_modules' --exclude='.env' \
   ./ <vps-user>@<vps>:~/cc-remote-upload/
 
-# VPS：协议 v9 的 Python + web/dist 在停服窗口一起发布，避免混跑
+# VPS：协议 v10 的 Python + web/dist 在停服窗口一起发布，避免混跑
 ssh <vps-user>@<vps>
 sudo systemctl stop cc-remote-relay 2>/dev/null || true
 sudo mkdir -p /opt/cc-remote

--- a/README_en.md
+++ b/README_en.md
@@ -46,7 +46,7 @@ not proxy model APIs or bake API keys into the web client.
 | **Two engines** | Use Claude Code and Codex in the same web UI. Every session keeps its own model, reasoning effort, permissions, and runtime state. |
 | **Remote operation** | Watch streaming replies from a phone, tablet, or desktop browser; send attachments, queue the next message, and interrupt the current turn at any time. |
 | **Complete process** | Expand the reasoning summaries, plans, command output, file diffs, MCP calls, collaboration agents, Hooks, and terminal interaction events exposed by each engine. |
-| **File preview** | Open local file links from a reply directly in a source viewer at the referenced line. Changed-file chips and `/preview path` also open Markdown with rendered/source modes and bounded local images. |
+| **File preview and Markdown editing** | Open local file links from a reply directly in a source viewer at the referenced line. Changed-file chips and `/preview path` also open Markdown with live rendered/source modes, bounded local images, and conflict-safe atomic saves via Ctrl/Cmd+S or the Save button. |
 | **Human approval** | Return Claude `can_use_tool` decisions and Codex command, file-change, user-input, general-permission, and MCP elicitation responses. Mirror a terminal-owned session read-only or take it over explicitly. |
 | **Session management** | Search, switch, rename, archive, and fork from individual messages. Codex sessions can also fork into an isolated Git worktree. |
 | **Runtime controls** | Change the model, reasoning effort, service tier, permissions, and Plan mode. Use `/goal` for long-running goals and Codex `/status` for app-server status, usage, and rate limits. |
@@ -241,14 +241,14 @@ npm --prefix web run build   # produces web/dist/
 
 > The web client no longer bakes any token into the JS: login POSTs the password to the relay for a short-lived session token. So the build needs no `VITE_*` variables.
 
-> **Upgrading to protocol v9:** the wire gate rejects mixed versions. Deploy
+> **Upgrading to protocol v10:** the wire gate rejects mixed versions. Deploy
 > `cc_remote/` and the new `web/dist/` in one maintenance window, then restart the
 > relay and wrapper; do not run a rolling mixture. Existing sockets reconnect
 > briefly, and a relay restart intentionally requires browsers to log in again.
 > Any already-open older page also needs one **hard refresh** to load the new hashed
 > assets; logging in again inside the old JavaScript bundle isn't sufficient.
 > For a manual release, stop the local wrapper first, stop and update relay + web,
-> then start the v9 relay and v9 wrapper so the old wrapper cannot occupy the
+> then start the v10 relay and v10 wrapper so the old wrapper cannot occupy the
 > relay's single wrapper slot.
 
 ### 3) Publish from staging during a maintenance stop
@@ -259,7 +259,7 @@ rsync -av --delete --exclude='.git' --exclude='.venv' \
   --exclude='web/node_modules' --exclude='.env' \
   ./ <vps-user>@<vps>:~/cc-remote-upload/
 
-# VPS: publish protocol-v9 Python + web/dist together while relay is stopped
+# VPS: publish protocol-v10 Python + web/dist together while relay is stopped
 ssh <vps-user>@<vps>
 sudo systemctl stop cc-remote-relay 2>/dev/null || true
 sudo mkdir -p /opt/cc-remote

--- a/README_en.md
+++ b/README_en.md
@@ -46,6 +46,7 @@ not proxy model APIs or bake API keys into the web client.
 | **Two engines** | Use Claude Code and Codex in the same web UI. Every session keeps its own model, reasoning effort, permissions, and runtime state. |
 | **Remote operation** | Watch streaming replies from a phone, tablet, or desktop browser; send attachments, queue the next message, and interrupt the current turn at any time. |
 | **Complete process** | Expand the reasoning summaries, plans, command output, file diffs, MCP calls, collaboration agents, Hooks, and terminal interaction events exposed by each engine. |
+| **File preview** | Open local file links from a reply directly in a source viewer at the referenced line. Changed-file chips and `/preview path` also open Markdown with rendered/source modes and bounded local images. |
 | **Human approval** | Return Claude `can_use_tool` decisions and Codex command, file-change, user-input, general-permission, and MCP elicitation responses. Mirror a terminal-owned session read-only or take it over explicitly. |
 | **Session management** | Search, switch, rename, archive, and fork from individual messages. Codex sessions can also fork into an isolated Git worktree. |
 | **Runtime controls** | Change the model, reasoning effort, service tier, permissions, and Plan mode. Use `/goal` for long-running goals and Codex `/status` for app-server status, usage, and rate limits. |
@@ -240,14 +241,14 @@ npm --prefix web run build   # produces web/dist/
 
 > The web client no longer bakes any token into the JS: login POSTs the password to the relay for a short-lived session token. So the build needs no `VITE_*` variables.
 
-> **Upgrading to protocol v8:** the wire gate rejects mixed versions. Deploy
+> **Upgrading to protocol v9:** the wire gate rejects mixed versions. Deploy
 > `cc_remote/` and the new `web/dist/` in one maintenance window, then restart the
 > relay and wrapper; do not run a rolling mixture. Existing sockets reconnect
 > briefly, and a relay restart intentionally requires browsers to log in again.
 > Any already-open older page also needs one **hard refresh** to load the new hashed
 > assets; logging in again inside the old JavaScript bundle isn't sufficient.
 > For a manual release, stop the local wrapper first, stop and update relay + web,
-> then start the v8 relay and v8 wrapper so the old wrapper cannot occupy the
+> then start the v9 relay and v9 wrapper so the old wrapper cannot occupy the
 > relay's single wrapper slot.
 
 ### 3) Publish from staging during a maintenance stop
@@ -258,7 +259,7 @@ rsync -av --delete --exclude='.git' --exclude='.venv' \
   --exclude='web/node_modules' --exclude='.env' \
   ./ <vps-user>@<vps>:~/cc-remote-upload/
 
-# VPS: publish protocol-v8 Python + web/dist together while relay is stopped
+# VPS: publish protocol-v9 Python + web/dist together while relay is stopped
 ssh <vps-user>@<vps>
 sudo systemctl stop cc-remote-relay 2>/dev/null || true
 sudo mkdir -p /opt/cc-remote

--- a/cc_remote/protocol.py
+++ b/cc_remote/protocol.py
@@ -28,7 +28,7 @@ from cc_remote.attachments import (
     MAX_SINGLE_ATTACHMENT_BYTES,
 )
 
-PROTOCOL_VERSION = 9
+PROTOCOL_VERSION = 10
 
 State = Literal["idle", "running", "interrupting", "draining"]
 Engine = Literal["claude", "codex"]
@@ -89,6 +89,17 @@ def _valid_attachment_filename(value: str) -> str:
     return value
 
 
+def _valid_preview_content(value: str) -> str:
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError("file content must be valid UTF-8") from exc
+    if len(encoded) > FILE_PREVIEW_MAX_BYTES:
+        raise ValueError(
+            f"file content exceeds {FILE_PREVIEW_MAX_BYTES} UTF-8 bytes")
+    return value
+
+
 AttachmentFilename = Annotated[
     str,
     StringConstraints(min_length=1, max_length=MAX_FILENAME_BYTES),
@@ -114,7 +125,15 @@ PreviewPath = Annotated[
     str, StringConstraints(min_length=1, max_length=4096),
 ]
 PreviewContent = Annotated[
-    str, StringConstraints(max_length=FILE_PREVIEW_MAX_BYTES),
+    str,
+    StringConstraints(max_length=FILE_PREVIEW_MAX_BYTES),
+    AfterValidator(_valid_preview_content),
+]
+FileRevision = Annotated[
+    str, StringConstraints(min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$"),
+]
+FileMtimeNs = Annotated[
+    str, StringConstraints(min_length=1, max_length=20, pattern=r"^[0-9]+$"),
 ]
 PreviewAssetData = Annotated[
     str, StringConstraints(min_length=1, max_length=MAX_ENCODED_PREVIEW_ASSET_CHARS),
@@ -1041,7 +1060,35 @@ class FilePreview(_Base):
     content: PreviewContent = ""
     size: int = Field(default=0, ge=0)
     truncated: bool = False
-    mtime_ns: int = Field(default=0, ge=0)
+    mtime_ns: FileMtimeNs = "0"
+    revision: Optional[FileRevision] = None
+    error: Optional[str] = Field(default=None, max_length=512)
+
+
+class SaveMarkdown(_Command):
+    """client -> wrapper: atomically replace one existing Markdown file.
+
+    The three expected fields form an optimistic concurrency guard. A stale
+    editor receives ``conflict`` and never overwrites the newer file.
+    """
+    type: Literal["save_markdown"] = "save_markdown"
+    path: PreviewPath
+    request_id: WireId
+    content: PreviewContent
+    expected_size: int = Field(ge=0, le=FILE_PREVIEW_MAX_BYTES)
+    expected_mtime_ns: FileMtimeNs
+    expected_revision: FileRevision
+
+
+class FileSaveResult(_Base):
+    """wrapper -> requesting client: correlated Markdown save outcome."""
+    type: Literal["file_save_result"] = "file_save_result"
+    path: PreviewPath
+    request_id: WireId
+    status: Literal["saved", "conflict", "error"]
+    size: int = Field(default=0, ge=0)
+    mtime_ns: FileMtimeNs = "0"
+    revision: Optional[FileRevision] = None
     error: Optional[str] = Field(default=None, max_length=512)
 
 
@@ -1197,8 +1244,8 @@ class GoalState(_Base):
 
 
 AnyMessage = Union[
-    Hello, Query, Interrupt, Takeover, TakeoverState, SetModel, SetEffort, SetServiceTier, SetCollaborationMode, SetPerm, Fast, CollaborationMode, OpenBtw, CloseBtw, BtwOpened, GetContext, GetStatus, GetDiff, GetFilePreview, GetPreviewAsset, GetHistory, GetModels, ListSessions, SwitchSession, NewSession, ListDir, Ping, Pong, CommandAck,
-    ReplayStart, ReplayEnd, Snapshot, StateEvent, Model, Effort, Perm, ContextReport, StatusReport, Notice, RateLimitUpdate, DiffReport, FilePreview, PreviewAsset, History, Models, AskUser, AnswerQuestion,
+    Hello, Query, Interrupt, Takeover, TakeoverState, SetModel, SetEffort, SetServiceTier, SetCollaborationMode, SetPerm, Fast, CollaborationMode, OpenBtw, CloseBtw, BtwOpened, GetContext, GetStatus, GetDiff, GetFilePreview, SaveMarkdown, GetPreviewAsset, GetHistory, GetModels, ListSessions, SwitchSession, NewSession, ListDir, Ping, Pong, CommandAck,
+    ReplayStart, ReplayEnd, Snapshot, StateEvent, Model, Effort, Perm, ContextReport, StatusReport, Notice, RateLimitUpdate, DiffReport, FilePreview, FileSaveResult, PreviewAsset, History, Models, AskUser, AnswerQuestion,
     SessionList, SessionFocus, SessionRekey, RenameSession, ArchiveSession,
     ForkSession, ForkSessionWorktree, SessionForked, DirList,
     GetGoal, SetGoal, ClearGoal, GoalState,
@@ -1236,6 +1283,7 @@ _TYPE_MAP: dict[str, type[BaseModel]] = {
     "get_status": GetStatus,
     "get_diff": GetDiff,
     "get_file_preview": GetFilePreview,
+    "save_markdown": SaveMarkdown,
     "get_preview_asset": GetPreviewAsset,
     "get_history": GetHistory,
     "get_models": GetModels,
@@ -1268,6 +1316,7 @@ _TYPE_MAP: dict[str, type[BaseModel]] = {
     "rate_limit_update": RateLimitUpdate,
     "diff_report": DiffReport,
     "file_preview": FilePreview,
+    "file_save_result": FileSaveResult,
     "preview_asset": PreviewAsset,
     "history": History,
     "ask_user": AskUser,

--- a/cc_remote/protocol.py
+++ b/cc_remote/protocol.py
@@ -28,7 +28,7 @@ from cc_remote.attachments import (
     MAX_SINGLE_ATTACHMENT_BYTES,
 )
 
-PROTOCOL_VERSION = 8
+PROTOCOL_VERSION = 9
 
 State = Literal["idle", "running", "interrupting", "draining"]
 Engine = Literal["claude", "codex"]
@@ -73,6 +73,9 @@ ASK_OPTION_DESCRIPTION_MAX_CHARS = 2 * 1024
 ASK_ANSWER_MAX_CHARS = 4 * 1024
 ASK_OPTION_MIN_COUNT = 2
 ASK_OPTION_MAX_COUNT = 5
+FILE_PREVIEW_MAX_BYTES = 512 * 1024
+PREVIEW_ASSET_MAX_BYTES = 4 * 1024 * 1024
+MAX_ENCODED_PREVIEW_ASSET_CHARS = ((PREVIEW_ASSET_MAX_BYTES + 2) // 3) * 4
 
 
 def _valid_attachment_filename(value: str) -> str:
@@ -106,6 +109,15 @@ AskOptionDescription = Annotated[
 ]
 AskAnswerText = Annotated[
     str, StringConstraints(min_length=1, max_length=ASK_ANSWER_MAX_CHARS),
+]
+PreviewPath = Annotated[
+    str, StringConstraints(min_length=1, max_length=4096),
+]
+PreviewContent = Annotated[
+    str, StringConstraints(max_length=FILE_PREVIEW_MAX_BYTES),
+]
+PreviewAssetData = Annotated[
+    str, StringConstraints(min_length=1, max_length=MAX_ENCODED_PREVIEW_ASSET_CHARS),
 ]
 StatusErrorText = Annotated[
     str, StringConstraints(min_length=1, max_length=384),
@@ -1013,6 +1025,47 @@ class DiffReport(_Base):
     diff: str
 
 
+class GetFilePreview(_Command):
+    """client -> wrapper: read one UTF-8 text file below the session cwd."""
+    type: Literal["get_file_preview"] = "get_file_preview"
+    path: PreviewPath
+    request_id: WireId
+
+
+class FilePreview(_Base):
+    """wrapper -> requesting client: bounded text source or a safe error."""
+    type: Literal["file_preview"] = "file_preview"
+    path: PreviewPath
+    request_id: WireId
+    format: Literal["markdown", "text"] = "text"
+    content: PreviewContent = ""
+    size: int = Field(default=0, ge=0)
+    truncated: bool = False
+    mtime_ns: int = Field(default=0, ge=0)
+    error: Optional[str] = Field(default=None, max_length=512)
+
+
+class GetPreviewAsset(_Command):
+    """client -> wrapper: load one image referenced by an open Markdown preview."""
+    type: Literal["get_preview_asset"] = "get_preview_asset"
+    path: PreviewPath
+    preview_id: WireId
+    request_id: WireId
+
+
+class PreviewAsset(_Base):
+    """wrapper -> requesting client: bounded base64 image for one preview."""
+    type: Literal["preview_asset"] = "preview_asset"
+    path: PreviewPath
+    preview_id: WireId
+    request_id: WireId
+    media_type: Optional[Literal[
+        "image/png", "image/jpeg", "image/gif", "image/webp", "image/avif",
+    ]] = None
+    data: Optional[PreviewAssetData] = None
+    error: Optional[str] = Field(default=None, max_length=512)
+
+
 class GetHistory(_Command):
     """client -> wrapper: request a session's history, read ON-DEMAND from its
     transcript (NOT the ring buffer, NOT requiring the session to be resident).
@@ -1144,8 +1197,8 @@ class GoalState(_Base):
 
 
 AnyMessage = Union[
-    Hello, Query, Interrupt, Takeover, TakeoverState, SetModel, SetEffort, SetServiceTier, SetCollaborationMode, SetPerm, Fast, CollaborationMode, OpenBtw, CloseBtw, BtwOpened, GetContext, GetStatus, GetDiff, GetHistory, GetModels, ListSessions, SwitchSession, NewSession, ListDir, Ping, Pong, CommandAck,
-    ReplayStart, ReplayEnd, Snapshot, StateEvent, Model, Effort, Perm, ContextReport, StatusReport, Notice, RateLimitUpdate, DiffReport, History, Models, AskUser, AnswerQuestion,
+    Hello, Query, Interrupt, Takeover, TakeoverState, SetModel, SetEffort, SetServiceTier, SetCollaborationMode, SetPerm, Fast, CollaborationMode, OpenBtw, CloseBtw, BtwOpened, GetContext, GetStatus, GetDiff, GetFilePreview, GetPreviewAsset, GetHistory, GetModels, ListSessions, SwitchSession, NewSession, ListDir, Ping, Pong, CommandAck,
+    ReplayStart, ReplayEnd, Snapshot, StateEvent, Model, Effort, Perm, ContextReport, StatusReport, Notice, RateLimitUpdate, DiffReport, FilePreview, PreviewAsset, History, Models, AskUser, AnswerQuestion,
     SessionList, SessionFocus, SessionRekey, RenameSession, ArchiveSession,
     ForkSession, ForkSessionWorktree, SessionForked, DirList,
     GetGoal, SetGoal, ClearGoal, GoalState,
@@ -1182,6 +1235,8 @@ _TYPE_MAP: dict[str, type[BaseModel]] = {
     "get_context": GetContext,
     "get_status": GetStatus,
     "get_diff": GetDiff,
+    "get_file_preview": GetFilePreview,
+    "get_preview_asset": GetPreviewAsset,
     "get_history": GetHistory,
     "get_models": GetModels,
     "models": Models,
@@ -1212,6 +1267,8 @@ _TYPE_MAP: dict[str, type[BaseModel]] = {
     "notice": Notice,
     "rate_limit_update": RateLimitUpdate,
     "diff_report": DiffReport,
+    "file_preview": FilePreview,
+    "preview_asset": PreviewAsset,
     "history": History,
     "ask_user": AskUser,
     "answer_question": AnswerQuestion,

--- a/cc_remote/wrapper/machine.py
+++ b/cc_remote/wrapper/machine.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import codecs
+import hashlib
 import json
 import os
 import re
@@ -69,7 +70,7 @@ from cc_remote.protocol import (
     ASK_OPTION_MAX_COUNT, FILE_PREVIEW_MAX_BYTES, PREVIEW_ASSET_MAX_BYTES,
     Error, Hello, Query, Interrupt, CommandAck, Model, Models, Effort, Fast,
     CollaborationMode, Perm, BtwOpened, ContextReport, StatusReport, Notice,
-    RateLimitUpdate, DiffReport, FilePreview, PreviewAsset, History, AskUser,
+    RateLimitUpdate, DiffReport, FilePreview, FileSaveResult, PreviewAsset, History, AskUser,
     GoalState, Pong, Snapshot, StateEvent, State, TakeoverState, UserMsg,
     TurnEnd, TurnResult, is_downstream, is_reliable_command,
     SessionInfo, SessionList, SessionFocus, SessionRekey, SessionForked, DirList,
@@ -174,6 +175,17 @@ class _ForkOutcomeUncertain(RuntimeError):
     """A persistent fork may have committed and must not be ACKed/replayed."""
 
 
+class _FileRevisionConflict(RuntimeError):
+    """The Markdown file changed after the editor loaded it."""
+
+    def __init__(self, message: str, *, size: int = 0, mtime_ns: int = 0,
+                 revision: Optional[str] = None):
+        super().__init__(message)
+        self.size = size
+        self.mtime_ns = mtime_ns
+        self.revision = revision
+
+
 class WrapperMachine:
     # Browser/TUI outboxes hold at most 256 commands. Keep a 2x retry window per
     # client and at most the relay's configured maximum of 64 client identities;
@@ -215,7 +227,7 @@ class WrapperMachine:
     BTW_SID_COMMANDS = frozenset({
         "query", "interrupt", "takeover", "set_model", "set_effort",
         "set_service_tier", "set_collaboration_mode", "open_btw", "close_btw", "set_perm",
-        "get_context", "get_status", "get_diff", "get_file_preview",
+        "get_context", "get_status", "get_diff", "get_file_preview", "save_markdown",
         "get_preview_asset", "answer_question", "get_goal", "set_goal", "clear_goal",
     })
     # These commands address a session through ``session_id`` instead.
@@ -904,6 +916,8 @@ class WrapperMachine:
             await self._handle_get_diff(cmd)
         elif t == "get_file_preview":
             return await self._handle_get_file_preview(cmd)
+        elif t == "save_markdown":
+            return await self._handle_save_markdown(cmd)
         elif t == "get_preview_asset":
             return await self._handle_get_preview_asset(cmd)
         elif t == "get_history":
@@ -3245,7 +3259,7 @@ class WrapperMachine:
             return response
 
         try:
-            path, content, size, truncated, mtime_ns, file_format = (
+            path, content, size, truncated, mtime_ns, file_format, revision = (
                 await asyncio.to_thread(
                     self._read_text_preview, ctx.cwd, cmd.path))
             response = FilePreview(
@@ -3255,7 +3269,8 @@ class WrapperMachine:
                 content=content,
                 size=size,
                 truncated=truncated,
-                mtime_ns=mtime_ns,
+                mtime_ns=str(mtime_ns),
+                revision=revision,
                 to=client_id,
             )
         except (UnicodeDecodeError, ValueError) as exc:
@@ -3273,6 +3288,71 @@ class WrapperMachine:
                 request_id=cmd.request_id,
                 format=self._preview_format(cmd.path),
                 error="读取文件失败",
+                to=client_id,
+            )
+        await self._emit(ctx, response)
+        return response
+
+    async def _handle_save_markdown(self, cmd):
+        sid = getattr(cmd, "sid", None)
+        client_id = getattr(cmd, "client_id", None)
+        ctx = self._ctx_for(sid)
+        if ctx is None:
+            response = FileSaveResult(
+                path=cmd.path,
+                request_id=cmd.request_id,
+                status="error",
+                error="该会话未启动，无法保存文件",
+                to=client_id,
+            )
+            await self._emit_to_sid(sid, response)
+            return response
+
+        try:
+            path, size, mtime_ns, revision = await asyncio.to_thread(
+                self._write_markdown_file,
+                ctx.cwd,
+                cmd.path,
+                cmd.content,
+                cmd.expected_size,
+                int(cmd.expected_mtime_ns),
+                cmd.expected_revision,
+            )
+            response = FileSaveResult(
+                path=path,
+                request_id=cmd.request_id,
+                status="saved",
+                size=size,
+                mtime_ns=str(mtime_ns),
+                revision=revision,
+                to=client_id,
+            )
+        except _FileRevisionConflict as exc:
+            response = FileSaveResult(
+                path=cmd.path,
+                request_id=cmd.request_id,
+                status="conflict",
+                size=exc.size,
+                mtime_ns=str(exc.mtime_ns),
+                revision=exc.revision,
+                error=str(exc),
+                to=client_id,
+            )
+        except (UnicodeDecodeError, ValueError) as exc:
+            response = FileSaveResult(
+                path=cmd.path,
+                request_id=cmd.request_id,
+                status="error",
+                error=str(exc),
+                to=client_id,
+            )
+        except Exception as exc:
+            log.exception("Markdown save failed", error_type=type(exc).__name__)
+            response = FileSaveResult(
+                path=cmd.path,
+                request_id=cmd.request_id,
+                status="error",
+                error="保存文件失败",
                 to=client_id,
             )
         await self._emit(ctx, response)
@@ -3645,7 +3725,7 @@ class WrapperMachine:
     @classmethod
     def _read_text_preview(
         cls, cwd: str, path: str,
-    ) -> tuple[str, str, int, bool, int, str]:
+    ) -> tuple[str, str, int, bool, int, str, Optional[str]]:
         relative, data, file_stat, truncated = cls._read_session_file(
             cwd,
             path,
@@ -3667,7 +3747,175 @@ class WrapperMachine:
             truncated,
             file_stat.st_mtime_ns,
             cls._preview_format(relative),
+            None if truncated else hashlib.sha256(data).hexdigest(),
         )
+
+    @classmethod
+    def _write_markdown_file(
+        cls,
+        cwd: str,
+        path: str,
+        content: str,
+        expected_size: int,
+        expected_mtime_ns: int,
+        expected_revision: str,
+    ) -> tuple[str, int, int, str]:
+        """CAS-style atomic save for one existing Markdown regular file.
+
+        Every path component is opened relative to an already-open cwd with
+        ``O_NOFOLLOW``. The replacement is written and fsynced in the same
+        directory, then renamed over the file only after a second revision
+        check. Existing UTF-8 BOM, dominant LF/CRLF style, and mode bits are
+        preserved.
+        """
+        if path.startswith("~"):
+            raise ValueError("保存路径必须位于当前工作目录")
+
+        root = os.path.realpath(cwd)
+        candidate = os.path.abspath(
+            path if os.path.isabs(path) else os.path.join(root, path))
+        try:
+            if os.path.commonpath((root, candidate)) != root:
+                raise ValueError("保存路径超出当前工作目录")
+        except ValueError as exc:
+            raise ValueError("保存路径超出当前工作目录") from exc
+
+        if os.path.splitext(candidate)[1].lower() not in cls.MARKDOWN_PREVIEW_SUFFIXES:
+            raise ValueError("只允许保存 Markdown 文件")
+        relative = os.path.relpath(candidate, root)
+        parts = relative.split(os.sep)
+        if relative in ("", ".") or any(part in ("", ".", "..") for part in parts):
+            raise ValueError("保存路径无效")
+
+        dir_flags = os.O_RDONLY
+        dir_flags |= getattr(os, "O_CLOEXEC", 0)
+        dir_flags |= getattr(os, "O_DIRECTORY", 0)
+        dir_flags |= getattr(os, "O_NOFOLLOW", 0)
+        file_flags = os.O_RDONLY
+        file_flags |= getattr(os, "O_CLOEXEC", 0)
+        file_flags |= getattr(os, "O_NONBLOCK", 0)
+        file_flags |= getattr(os, "O_NOFOLLOW", 0)
+        dir_fd: Optional[int] = None
+        temp_name: Optional[str] = None
+
+        def read_current() -> tuple[bytes, os.stat_result, str]:
+            try:
+                fd = os.open(parts[-1], file_flags, dir_fd=dir_fd)
+            except FileNotFoundError as exc:
+                raise ValueError("文件不存在") from exc
+            except PermissionError as exc:
+                raise ValueError("没有权限保存该文件") from exc
+            except OSError as exc:
+                raise ValueError("保存目标不能是符号链接或特殊文件") from exc
+            try:
+                file_stat = os.fstat(fd)
+                if not stat.S_ISREG(file_stat.st_mode):
+                    raise ValueError("保存目标必须是普通文件")
+                if file_stat.st_size > FILE_PREVIEW_MAX_BYTES:
+                    raise ValueError("超过 512 KiB 的 Markdown 文件不可编辑")
+                chunks = []
+                remaining = FILE_PREVIEW_MAX_BYTES + 1
+                while remaining > 0:
+                    chunk = os.read(fd, min(64 * 1024, remaining))
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+                    remaining -= len(chunk)
+                data = b"".join(chunks)
+                final_stat = os.fstat(fd)
+                if (final_stat.st_size != file_stat.st_size
+                        or final_stat.st_mtime_ns != file_stat.st_mtime_ns):
+                    revision = hashlib.sha256(data).hexdigest()
+                    raise _FileRevisionConflict(
+                        "文件正在被其他程序修改，请重新读取后再保存",
+                        size=final_stat.st_size,
+                        mtime_ns=final_stat.st_mtime_ns,
+                        revision=revision,
+                    )
+                return data, final_stat, hashlib.sha256(data).hexdigest()
+            finally:
+                os.close(fd)
+
+        def require_expected(file_stat: os.stat_result, revision: str) -> None:
+            if (file_stat.st_size != expected_size
+                    or file_stat.st_mtime_ns != expected_mtime_ns
+                    or revision != expected_revision):
+                raise _FileRevisionConflict(
+                    "文件已在别处修改，请重新读取并合并后再保存",
+                    size=file_stat.st_size,
+                    mtime_ns=file_stat.st_mtime_ns,
+                    revision=revision,
+                )
+
+        try:
+            dir_fd = os.open(root, dir_flags)
+            for part in parts[:-1]:
+                try:
+                    next_fd = os.open(part, dir_flags, dir_fd=dir_fd)
+                except OSError as exc:
+                    raise ValueError("保存路径不能包含符号链接") from exc
+                os.close(dir_fd)
+                dir_fd = next_fd
+
+            original, original_stat, original_revision = read_current()
+            require_expected(original_stat, original_revision)
+            if b"\0" in original:
+                raise ValueError("Markdown 文件不是有效的 UTF-8 文本")
+            try:
+                original.decode("utf-8-sig")
+            except UnicodeDecodeError as exc:
+                raise ValueError("Markdown 文件不是有效的 UTF-8 文本") from exc
+
+            normalized = content.replace("\r\n", "\n").replace("\r", "\n")
+            crlf_count = original.count(b"\r\n")
+            lf_only_count = original.count(b"\n") - crlf_count
+            newline = "\r\n" if crlf_count > lf_only_count else "\n"
+            payload = normalized.replace("\n", newline).encode("utf-8")
+            if original.startswith(codecs.BOM_UTF8):
+                payload = codecs.BOM_UTF8 + payload
+            if len(payload) > FILE_PREVIEW_MAX_BYTES:
+                raise ValueError("保存内容超过 512 KiB 限制")
+
+            temp_name = f".cc-remote-{uuid4().hex}.tmp"
+            temp_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            temp_flags |= getattr(os, "O_CLOEXEC", 0)
+            temp_flags |= getattr(os, "O_NOFOLLOW", 0)
+            temp_fd = os.open(temp_name, temp_flags, 0o600, dir_fd=dir_fd)
+            try:
+                view = memoryview(payload)
+                written = 0
+                while written < len(view):
+                    written += os.write(temp_fd, view[written:])
+                os.fchmod(temp_fd, stat.S_IMODE(original_stat.st_mode))
+                os.fsync(temp_fd)
+            finally:
+                os.close(temp_fd)
+
+            _, latest_stat, latest_revision = read_current()
+            require_expected(latest_stat, latest_revision)
+            os.replace(
+                temp_name,
+                parts[-1],
+                src_dir_fd=dir_fd,
+                dst_dir_fd=dir_fd,
+            )
+            temp_name = None
+            os.fsync(dir_fd)
+            saved_stat = os.stat(parts[-1], dir_fd=dir_fd, follow_symlinks=False)
+            return (
+                relative.replace(os.sep, "/"),
+                saved_stat.st_size,
+                saved_stat.st_mtime_ns,
+                hashlib.sha256(payload).hexdigest(),
+            )
+        finally:
+            if temp_name is not None and dir_fd is not None:
+                try:
+                    os.unlink(temp_name, dir_fd=dir_fd)
+                except FileNotFoundError:
+                    pass
+            if dir_fd is not None:
+                os.close(dir_fd)
 
     @classmethod
     def _read_markdown_preview(

--- a/cc_remote/wrapper/machine.py
+++ b/cc_remote/wrapper/machine.py
@@ -38,6 +38,8 @@ Multi-session model:
 from __future__ import annotations
 
 import asyncio
+import base64
+import codecs
 import json
 import os
 import re
@@ -64,7 +66,12 @@ from cc_remote.attachments import decode_attachment, validate_attachments
 from cc_remote.config import WrapperConfig
 from cc_remote.log import logger
 from cc_remote.protocol import (
-    ASK_OPTION_MAX_COUNT, Error, Hello, Query, Interrupt, CommandAck, Model, Models, Effort, Fast, CollaborationMode, Perm, BtwOpened, ContextReport, StatusReport, Notice, RateLimitUpdate, DiffReport, History, AskUser, GoalState, Pong, Snapshot, StateEvent, State, TakeoverState, UserMsg, TurnEnd, TurnResult, is_downstream, is_reliable_command,
+    ASK_OPTION_MAX_COUNT, FILE_PREVIEW_MAX_BYTES, PREVIEW_ASSET_MAX_BYTES,
+    Error, Hello, Query, Interrupt, CommandAck, Model, Models, Effort, Fast,
+    CollaborationMode, Perm, BtwOpened, ContextReport, StatusReport, Notice,
+    RateLimitUpdate, DiffReport, FilePreview, PreviewAsset, History, AskUser,
+    GoalState, Pong, Snapshot, StateEvent, State, TakeoverState, UserMsg,
+    TurnEnd, TurnResult, is_downstream, is_reliable_command,
     SessionInfo, SessionList, SessionFocus, SessionRekey, SessionForked, DirList,
     ERR_BUSY, ERR_NOT_RUNNING, ERR_BAD_PROMPT, ERR_DRAIN_TIMEOUT,
     ERR_CC_CRASH, ERR_INTERNAL, ERR_AUTH, ERR_PROTOCOL,
@@ -188,9 +195,19 @@ class WrapperMachine:
     FORK_RECONCILE_DELAY = 0.1
     FORK_BACKGROUND_ATTEMPTS = 100
     UNCERTAIN_FORK_CAP = 4096
+    MARKDOWN_PREVIEW_SUFFIXES = frozenset({".md", ".markdown"})
+    PREVIEW_ASSET_MEDIA_TYPES = {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+        ".avif": "image/avif",
+    }
     SAFE_RETRY_COMMANDS = frozenset({
         "list_sessions", "get_history", "get_models",
-        "get_context", "get_status", "get_diff", "get_goal", "list_dir",
+        "get_context", "get_status", "get_diff", "get_file_preview",
+        "get_preview_asset", "get_goal", "list_dir",
     })
     # Commands whose target is a runtime ``sid``.  A /btw runtime is private to
     # the client that created it, so every operation against that sid must pass
@@ -198,7 +215,8 @@ class WrapperMachine:
     BTW_SID_COMMANDS = frozenset({
         "query", "interrupt", "takeover", "set_model", "set_effort",
         "set_service_tier", "set_collaboration_mode", "open_btw", "close_btw", "set_perm",
-        "get_context", "get_status", "get_diff", "answer_question", "get_goal", "set_goal", "clear_goal",
+        "get_context", "get_status", "get_diff", "get_file_preview",
+        "get_preview_asset", "answer_question", "get_goal", "set_goal", "clear_goal",
     })
     # These commands address a session through ``session_id`` instead.
     BTW_SESSION_COMMANDS = frozenset({
@@ -835,12 +853,19 @@ class WrapperMachine:
         result = await self._handle(cmd)
 
         if reliable:
-            candidates = result if isinstance(result, (tuple, list)) else (result,)
-            responses = tuple(
-                response.model_copy(deep=True)
-                for response in candidates
-                if getattr(response, "type", None)
-            )
+            # Safe reads are recreated on retry, so retaining their potentially
+            # large History/file/image payloads in the command-id LRU buys
+            # nothing and can multiply memory by clients × commands.
+            if cmd.type in self.SAFE_RETRY_COMMANDS:
+                responses = ()
+            else:
+                candidates = (
+                    result if isinstance(result, (tuple, list)) else (result,))
+                responses = tuple(
+                    response.model_copy(deep=True)
+                    for response in candidates
+                    if getattr(response, "type", None)
+                )
             self._remember_command(client_id, cmd_id, responses)
             await self._send_command_ack(client_id, cmd_id)
 
@@ -877,6 +902,10 @@ class WrapperMachine:
             return await self._handle_get_status(cmd)
         elif t == "get_diff":
             await self._handle_get_diff(cmd)
+        elif t == "get_file_preview":
+            return await self._handle_get_file_preview(cmd)
+        elif t == "get_preview_asset":
+            return await self._handle_get_preview_asset(cmd)
         elif t == "get_history":
             await self._handle_get_history(cmd)
         elif t == "get_models":
@@ -3200,6 +3229,101 @@ class WrapperMachine:
             log.exception("get_diff failed", error=str(e))
             await self._emit(ctx, Error(code=ERR_INTERNAL, message=f"get_diff failed: {e}"))
 
+    async def _handle_get_file_preview(self, cmd):
+        sid = getattr(cmd, "sid", None)
+        client_id = getattr(cmd, "client_id", None)
+        ctx = self._ctx_for(sid)
+        if ctx is None:
+            response = FilePreview(
+                path=cmd.path,
+                request_id=cmd.request_id,
+                format=self._preview_format(cmd.path),
+                error="该会话未启动，无法读取文件",
+                to=client_id,
+            )
+            await self._emit_to_sid(sid, response)
+            return response
+
+        try:
+            path, content, size, truncated, mtime_ns, file_format = (
+                await asyncio.to_thread(
+                    self._read_text_preview, ctx.cwd, cmd.path))
+            response = FilePreview(
+                path=path,
+                request_id=cmd.request_id,
+                format=file_format,
+                content=content,
+                size=size,
+                truncated=truncated,
+                mtime_ns=mtime_ns,
+                to=client_id,
+            )
+        except (UnicodeDecodeError, ValueError) as exc:
+            response = FilePreview(
+                path=cmd.path,
+                request_id=cmd.request_id,
+                format=self._preview_format(cmd.path),
+                error=str(exc),
+                to=client_id,
+            )
+        except Exception as exc:
+            log.exception("file preview failed", error_type=type(exc).__name__)
+            response = FilePreview(
+                path=cmd.path,
+                request_id=cmd.request_id,
+                format=self._preview_format(cmd.path),
+                error="读取文件失败",
+                to=client_id,
+            )
+        await self._emit(ctx, response)
+        return response
+
+    async def _handle_get_preview_asset(self, cmd):
+        sid = getattr(cmd, "sid", None)
+        client_id = getattr(cmd, "client_id", None)
+        ctx = self._ctx_for(sid)
+        if ctx is None:
+            response = PreviewAsset(
+                path=cmd.path,
+                preview_id=cmd.preview_id,
+                request_id=cmd.request_id,
+                error="该会话未启动，无法读取预览图片",
+                to=client_id,
+            )
+            await self._emit_to_sid(sid, response)
+            return response
+
+        try:
+            _, media_type, data = await asyncio.to_thread(
+                self._read_preview_asset, ctx.cwd, cmd.path)
+            response = PreviewAsset(
+                path=cmd.path,
+                preview_id=cmd.preview_id,
+                request_id=cmd.request_id,
+                media_type=media_type,
+                data=base64.b64encode(data).decode("ascii"),
+                to=client_id,
+            )
+        except ValueError as exc:
+            response = PreviewAsset(
+                path=cmd.path,
+                preview_id=cmd.preview_id,
+                request_id=cmd.request_id,
+                error=str(exc),
+                to=client_id,
+            )
+        except Exception as exc:
+            log.exception("preview asset failed", error_type=type(exc).__name__)
+            response = PreviewAsset(
+                path=cmd.path,
+                preview_id=cmd.preview_id,
+                request_id=cmd.request_id,
+                error="读取预览图片失败",
+                to=client_id,
+            )
+        await self._emit(ctx, response)
+        return response
+
     # ---- ask_user MCP tool (agent asks the user a multiple-choice question) ----
 
     async def _on_ask(self, ctx: SessionContext, question: str,
@@ -3438,6 +3562,161 @@ class WrapperMachine:
             log.info("ask_user answered", ask_id=cmd.ask_id)
         else:
             log.warning("answer for already-done ask_id", ask_id=cmd.ask_id)
+
+    @staticmethod
+    def _read_session_file(
+        cwd: str,
+        path: str,
+        *,
+        allowed_suffixes: Optional[frozenset[str]],
+        max_bytes: int,
+        allow_truncate: bool,
+    ) -> tuple[str, bytes, os.stat_result, bool]:
+        """Read a bounded regular file below cwd without following an escape.
+
+        ``realpath`` contains relative or tool-reported absolute paths inside
+        the session root while rejecting symlinks that escape it. ``O_NONBLOCK``
+        prevents a malicious FIFO from hanging the wrapper before ``fstat`` can
+        reject the special file.
+        """
+        if path.startswith("~"):
+            raise ValueError("预览路径必须位于当前工作目录")
+
+        root = os.path.realpath(cwd)
+        candidate = os.path.realpath(
+            path if os.path.isabs(path) else os.path.join(root, path))
+        try:
+            if os.path.commonpath((root, candidate)) != root:
+                raise ValueError("预览路径超出当前工作目录")
+        except ValueError as exc:
+            raise ValueError("预览路径超出当前工作目录") from exc
+
+        suffix = os.path.splitext(candidate)[1].lower()
+        if allowed_suffixes is not None and suffix not in allowed_suffixes:
+            raise ValueError("不支持预览该文件类型")
+
+        relative = os.path.relpath(candidate, root)
+        parts = relative.split(os.sep)
+        file_flags = os.O_RDONLY
+        file_flags |= getattr(os, "O_CLOEXEC", 0)
+        file_flags |= getattr(os, "O_NONBLOCK", 0)
+        file_flags |= getattr(os, "O_NOFOLLOW", 0)
+        dir_flags = os.O_RDONLY
+        dir_flags |= getattr(os, "O_CLOEXEC", 0)
+        dir_flags |= getattr(os, "O_DIRECTORY", 0)
+        dir_flags |= getattr(os, "O_NOFOLLOW", 0)
+        dir_fd: Optional[int] = None
+        try:
+            # Walk from an already-open cwd and refuse symlinks at every hop.
+            # This closes the realpath/open race where a parent directory could
+            # otherwise be replaced by an escaping symlink between both calls.
+            dir_fd = os.open(root, dir_flags)
+            for part in parts[:-1]:
+                next_fd = os.open(part, dir_flags, dir_fd=dir_fd)
+                os.close(dir_fd)
+                dir_fd = next_fd
+            fd = os.open(parts[-1], file_flags, dir_fd=dir_fd)
+        except FileNotFoundError as exc:
+            raise ValueError("文件不存在") from exc
+        except PermissionError as exc:
+            raise ValueError("没有权限读取该文件") from exc
+        except OSError as exc:
+            raise ValueError("无法打开该文件") from exc
+        finally:
+            if dir_fd is not None:
+                os.close(dir_fd)
+
+        try:
+            file_stat = os.fstat(fd)
+            if not stat.S_ISREG(file_stat.st_mode):
+                raise ValueError("预览目标必须是普通文件")
+            if not allow_truncate and file_stat.st_size > max_bytes:
+                raise ValueError("预览图片超过 4 MiB 限制")
+            with os.fdopen(fd, "rb", closefd=False) as handle:
+                data = handle.read(max_bytes + 1)
+        finally:
+            os.close(fd)
+
+        truncated = len(data) > max_bytes or file_stat.st_size > max_bytes
+        if truncated and not allow_truncate:
+            raise ValueError("预览图片超过 4 MiB 限制")
+        return relative.replace(os.sep, "/"), data[:max_bytes], file_stat, truncated
+
+    @classmethod
+    def _read_text_preview(
+        cls, cwd: str, path: str,
+    ) -> tuple[str, str, int, bool, int, str]:
+        relative, data, file_stat, truncated = cls._read_session_file(
+            cwd,
+            path,
+            allowed_suffixes=None,
+            max_bytes=FILE_PREVIEW_MAX_BYTES,
+            allow_truncate=True,
+        )
+        if b"\0" in data:
+            raise ValueError("文件不是可预览的 UTF-8 文本")
+        decoder = codecs.getincrementaldecoder("utf-8-sig")("strict")
+        try:
+            content = decoder.decode(data, final=not truncated)
+        except UnicodeDecodeError as exc:
+            raise ValueError("文件不是有效的 UTF-8 文本") from exc
+        return (
+            relative,
+            content,
+            file_stat.st_size,
+            truncated,
+            file_stat.st_mtime_ns,
+            cls._preview_format(relative),
+        )
+
+    @classmethod
+    def _read_markdown_preview(
+        cls, cwd: str, path: str,
+    ) -> tuple[str, str, int, bool, int]:
+        relative, data, file_stat, truncated = cls._read_session_file(
+            cwd,
+            path,
+            allowed_suffixes=cls.MARKDOWN_PREVIEW_SUFFIXES,
+            max_bytes=FILE_PREVIEW_MAX_BYTES,
+            allow_truncate=True,
+        )
+        decoder = codecs.getincrementaldecoder("utf-8-sig")("strict")
+        try:
+            content = decoder.decode(data, final=not truncated)
+        except UnicodeDecodeError as exc:
+            raise UnicodeDecodeError(
+                exc.encoding,
+                exc.object,
+                exc.start,
+                exc.end,
+                "Markdown 文件不是有效的 UTF-8",
+            ) from exc
+        return relative, content, file_stat.st_size, truncated, file_stat.st_mtime_ns
+
+    @classmethod
+    def _preview_format(cls, path: str) -> str:
+        return (
+            "markdown"
+            if os.path.splitext(path)[1].lower() in cls.MARKDOWN_PREVIEW_SUFFIXES
+            else "text"
+        )
+
+    @classmethod
+    def _read_preview_asset(
+        cls, cwd: str, path: str,
+    ) -> tuple[str, str, bytes]:
+        suffix = os.path.splitext(path)[1].lower()
+        media_type = cls.PREVIEW_ASSET_MEDIA_TYPES.get(suffix)
+        if media_type is None:
+            raise ValueError("Markdown 预览只加载 PNG、JPEG、GIF、WebP 或 AVIF 图片")
+        relative, data, _, _ = cls._read_session_file(
+            cwd,
+            path,
+            allowed_suffixes=frozenset(cls.PREVIEW_ASSET_MEDIA_TYPES),
+            max_bytes=PREVIEW_ASSET_MAX_BYTES,
+            allow_truncate=False,
+        )
+        return relative, media_type, data
 
     async def _git_diff(self, cwd: str, file: str) -> str:
         """Raw `git diff` (vs HEAD) text for a cwd. Empty file => all files; a

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -29,12 +29,12 @@ machine). The **full step-by-step guide is in the main [README](../README.md#生
 - `env.relay.example` / `env.wrapper.example` — environment templates for each
   side. Install the wrapper template as root:root mode 0600 at the path above.
 
-Protocol v8 is a coordinated upgrade: publish the Python package and freshly
+Protocol v9 is a coordinated upgrade: publish the Python package and freshly
 built `web/dist` together in the documented stop window, then restart relay and
 wrapper. The strict protocol gate is intentional and mixed protocol versions will
 not communicate. `setup-vps.sh` also rejects a missing/old web build manifest.
-For a manual upgrade, stop the wrapper before stopping the relay; start the v8
-relay first and the v8 wrapper last.
+For a manual upgrade, stop the wrapper before stopping the relay; start the v9
+relay first and the v9 wrapper last.
 
 ## Security (short version)
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -29,12 +29,12 @@ machine). The **full step-by-step guide is in the main [README](../README.md#生
 - `env.relay.example` / `env.wrapper.example` — environment templates for each
   side. Install the wrapper template as root:root mode 0600 at the path above.
 
-Protocol v9 is a coordinated upgrade: publish the Python package and freshly
+Protocol v10 is a coordinated upgrade: publish the Python package and freshly
 built `web/dist` together in the documented stop window, then restart relay and
 wrapper. The strict protocol gate is intentional and mixed protocol versions will
 not communicate. `setup-vps.sh` also rejects a missing/old web build manifest.
-For a manual upgrade, stop the wrapper before stopping the relay; start the v9
-relay first and the v9 wrapper last.
+For a manual upgrade, stop the wrapper before stopping the relay; start the v10
+relay first and the v10 wrapper last.
 
 ## Security (short version)
 

--- a/deploy/setup-vps.sh
+++ b/deploy/setup-vps.sh
@@ -107,8 +107,8 @@ python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1
 [ -d "$APPDIR/web/dist" ] || die "$APPDIR/web/dist missing (run 'npm --prefix web run build' on your dev machine, then rsync web/dist here)"
 [ -s "$APPDIR/web/dist/index.html" ] || die "$APPDIR/web/dist/index.html missing or empty"
 [ -s "$APPDIR/web/dist/cc-remote-build.json" ] || die "$APPDIR/web/dist/cc-remote-build.json missing"
-grep -Eq '"protocol"[[:space:]]*:[[:space:]]*8' \
-  "$APPDIR/web/dist/cc-remote-build.json" || die "web build protocol is not v8"
+grep -Eq '"protocol"[[:space:]]*:[[:space:]]*9' \
+  "$APPDIR/web/dist/cc-remote-build.json" || die "web build protocol is not v9"
 [ -f "$APPDIR/requirements.lock" ] || die "$APPDIR/requirements.lock missing"
 [ -f "$APPDIR/deploy/Caddyfile" ] || die "$APPDIR/deploy/Caddyfile missing"
 [ -f "$APPDIR/deploy/caddy_managed_block.py" ] || die "$APPDIR/deploy/caddy_managed_block.py missing"

--- a/deploy/setup-vps.sh
+++ b/deploy/setup-vps.sh
@@ -107,8 +107,8 @@ python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1
 [ -d "$APPDIR/web/dist" ] || die "$APPDIR/web/dist missing (run 'npm --prefix web run build' on your dev machine, then rsync web/dist here)"
 [ -s "$APPDIR/web/dist/index.html" ] || die "$APPDIR/web/dist/index.html missing or empty"
 [ -s "$APPDIR/web/dist/cc-remote-build.json" ] || die "$APPDIR/web/dist/cc-remote-build.json missing"
-grep -Eq '"protocol"[[:space:]]*:[[:space:]]*9' \
-  "$APPDIR/web/dist/cc-remote-build.json" || die "web build protocol is not v9"
+grep -Eq '"protocol"[[:space:]]*:[[:space:]]*10' \
+  "$APPDIR/web/dist/cc-remote-build.json" || die "web build protocol is not v10"
 [ -f "$APPDIR/requirements.lock" ] || die "$APPDIR/requirements.lock missing"
 [ -f "$APPDIR/deploy/Caddyfile" ] || die "$APPDIR/deploy/Caddyfile missing"
 [ -f "$APPDIR/deploy/caddy_managed_block.py" ] || die "$APPDIR/deploy/caddy_managed_block.py missing"

--- a/tests/test_atomic_new_session.py
+++ b/tests/test_atomic_new_session.py
@@ -19,8 +19,8 @@ from tests.test_multisession import _mk_ctx, _mk_machine
 _PNG_1X1 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
 
 
-def test_protocol_v9_new_session_query_roundtrip_and_validation():
-    assert PROTOCOL_VERSION == 9
+def test_protocol_v10_new_session_query_roundtrip_and_validation():
+    assert PROTOCOL_VERSION == 10
     msg = NewSession(
         request_id="req-1",
         cwd="/tmp/project",

--- a/tests/test_atomic_new_session.py
+++ b/tests/test_atomic_new_session.py
@@ -19,8 +19,8 @@ from tests.test_multisession import _mk_ctx, _mk_machine
 _PNG_1X1 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
 
 
-def test_protocol_v8_new_session_query_roundtrip_and_validation():
-    assert PROTOCOL_VERSION == 8
+def test_protocol_v9_new_session_query_roundtrip_and_validation():
+    assert PROTOCOL_VERSION == 9
     msg = NewSession(
         request_id="req-1",
         cwd="/tmp/project",

--- a/tests/test_markdown_preview.py
+++ b/tests/test_markdown_preview.py
@@ -1,0 +1,213 @@
+"""Bounded, cwd-confined Markdown preview regressions."""
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from cc_remote.protocol import (
+    FilePreview,
+    GetFilePreview,
+    GetPreviewAsset,
+    FILE_PREVIEW_MAX_BYTES,
+    PREVIEW_ASSET_MAX_BYTES,
+    PreviewAsset,
+)
+from tests.test_multisession import _mk_ctx, _mk_machine
+
+
+def test_markdown_preview_reads_utf8_and_normalizes_paths(tmp_path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    readme = docs / "README.md"
+    readme.write_text("\ufeff# 标题\n\n正文", encoding="utf-8")
+    machine, _ = _mk_machine()
+
+    relative = machine._read_markdown_preview(str(tmp_path), "docs/README.md")
+    absolute = machine._read_markdown_preview(str(tmp_path), str(readme))
+
+    assert relative[0] == absolute[0] == "docs/README.md"
+    assert relative[1] == absolute[1] == "# 标题\n\n正文"
+    assert relative[2] == readme.stat().st_size
+    assert relative[3] is False
+    assert relative[4] == readme.stat().st_mtime_ns
+
+
+def test_source_preview_reads_utf8_and_reports_text_format(tmp_path):
+    source = tmp_path / "module.py"
+    source.write_text("def answer():\n    return 42\n", encoding="utf-8")
+    machine, _ = _mk_machine()
+
+    result = machine._read_text_preview(str(tmp_path), "module.py")
+
+    assert result[0] == "module.py"
+    assert result[1] == "def answer():\n    return 42\n"
+    assert result[5] == "text"
+
+
+def test_source_preview_rejects_binary_content(tmp_path):
+    (tmp_path / "binary.dat").write_bytes(b"text\0binary")
+    machine, _ = _mk_machine()
+
+    with pytest.raises(ValueError, match="UTF-8 文本"):
+        machine._read_text_preview(str(tmp_path), "binary.dat")
+
+
+def test_markdown_preview_truncates_without_breaking_split_utf8(tmp_path):
+    path = tmp_path / "large.md"
+    path.write_bytes(b"a" * (FILE_PREVIEW_MAX_BYTES - 1) + "界".encode() + b"tail")
+    machine, _ = _mk_machine()
+
+    relative, content, size, truncated, _ = machine._read_markdown_preview(
+        str(tmp_path), "large.md")
+
+    assert relative == "large.md"
+    assert content == "a" * (FILE_PREVIEW_MAX_BYTES - 1)
+    assert size > FILE_PREVIEW_MAX_BYTES
+    assert truncated is True
+
+
+@pytest.mark.parametrize("path", ["../outside.md", "~/.secret.md"])
+def test_markdown_preview_rejects_paths_outside_cwd(tmp_path, path):
+    machine, _ = _mk_machine()
+    with pytest.raises(ValueError, match="当前工作目录|超出"):
+        machine._read_markdown_preview(str(tmp_path), path)
+
+
+def test_markdown_preview_rejects_absolute_and_symlink_escape(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside.md"
+    outside.write_text("secret", encoding="utf-8")
+    (root / "escape.md").symlink_to(outside)
+    machine, _ = _mk_machine()
+
+    with pytest.raises(ValueError, match="超出"):
+        machine._read_markdown_preview(str(root), str(outside))
+    with pytest.raises(ValueError, match="超出"):
+        machine._read_markdown_preview(str(root), "escape.md")
+
+
+def test_markdown_preview_rejects_special_files_without_blocking(tmp_path):
+    fifo = tmp_path / "pipe.md"
+    os.mkfifo(fifo)
+    machine, _ = _mk_machine()
+
+    async def run():
+        with pytest.raises(ValueError, match="普通文件"):
+            await asyncio.wait_for(asyncio.to_thread(
+                machine._read_markdown_preview, str(tmp_path), "pipe.md"), 1)
+
+    asyncio.run(run())
+
+
+def test_markdown_preview_rejects_invalid_utf8(tmp_path):
+    (tmp_path / "invalid.md").write_bytes(b"\xff\xfe")
+    machine, _ = _mk_machine()
+
+    with pytest.raises(UnicodeDecodeError, match="UTF-8"):
+        machine._read_markdown_preview(str(tmp_path), "invalid.md")
+
+
+def test_preview_asset_is_type_limited_and_bounded(tmp_path):
+    (tmp_path / "image.png").write_bytes(b"png")
+    (tmp_path / "vector.svg").write_text("<svg/>", encoding="utf-8")
+    (tmp_path / "large.webp").write_bytes(b"x" * (PREVIEW_ASSET_MAX_BYTES + 1))
+    machine, _ = _mk_machine()
+
+    path, media_type, data = machine._read_preview_asset(
+        str(tmp_path), "image.png")
+    assert (path, media_type, data) == ("image.png", "image/png", b"png")
+    with pytest.raises(ValueError, match="PNG"):
+        machine._read_preview_asset(str(tmp_path), "vector.svg")
+    with pytest.raises(ValueError, match="4 MiB"):
+        machine._read_preview_asset(str(tmp_path), "large.webp")
+
+
+def test_preview_responses_are_requester_routed_and_correlated(tmp_path):
+    (tmp_path / "README.md").write_text("# hello", encoding="utf-8")
+    (tmp_path / "image.png").write_bytes(b"png")
+
+    async def run():
+        machine, transport = _mk_machine()
+        ctx = _mk_ctx("session-1", session_id="session-1")
+        ctx.cwd = str(tmp_path)
+        machine.sessions[ctx.key] = ctx
+        machine.focused_sid = ctx.key
+
+        preview = await machine._handle_get_file_preview(GetFilePreview(
+            sid=ctx.key,
+            client_id="client-1",
+            path="README.md",
+            request_id="preview-1",
+        ))
+        asset = await machine._handle_get_preview_asset(GetPreviewAsset(
+            sid=ctx.key,
+            client_id="client-1",
+            path="image.png",
+            preview_id="preview-1",
+            request_id="asset-1",
+        ))
+
+        assert isinstance(preview, FilePreview)
+        assert preview.to == "client-1" and preview.sid == "session-1"
+        assert preview.request_id == "preview-1" and preview.content == "# hello"
+        assert preview.format == "markdown"
+        assert isinstance(asset, PreviewAsset)
+        assert asset.to == "client-1" and asset.sid == "session-1"
+        assert asset.preview_id == "preview-1" and asset.request_id == "asset-1"
+        assert transport.sent[-2:] == [preview, asset]
+
+    asyncio.run(run())
+
+
+def test_preview_unknown_sid_never_reads_focused_session(tmp_path):
+    (tmp_path / "README.md").write_text("focused secret", encoding="utf-8")
+
+    async def run():
+        machine, transport = _mk_machine()
+        focused = _mk_ctx("focused", session_id="focused")
+        focused.cwd = str(tmp_path)
+        machine.sessions[focused.key] = focused
+        machine.focused_sid = focused.key
+
+        response = await machine._handle_get_file_preview(GetFilePreview(
+            sid="missing-session",
+            client_id="client-1",
+            path="README.md",
+            request_id="preview-1",
+        ))
+
+        assert response.error and not response.content
+        assert response.sid == "missing-session" and response.to == "client-1"
+        assert transport.sent[-1] == response
+
+    asyncio.run(run())
+
+
+def test_preview_payload_is_not_retained_in_command_dedupe_cache(tmp_path):
+    (tmp_path / "README.md").write_text("# hello", encoding="utf-8")
+
+    async def run():
+        machine, transport = _mk_machine()
+        ctx = _mk_ctx("session-1", session_id="session-1")
+        ctx.cwd = str(tmp_path)
+        machine.sessions[ctx.key] = ctx
+        machine.focused_sid = ctx.key
+        command = GetFilePreview(
+            sid=ctx.key,
+            client_id="client-1",
+            cmd_id="command-1",
+            path="README.md",
+            request_id="preview-1",
+        )
+
+        await machine._process_command(command)
+
+        assert machine._processed_commands["client-1"]["command-1"] == ()
+        assert [message.type for message in transport.sent[-2:]] == [
+            "file_preview", "command_ack",
+        ]
+
+    asyncio.run(run())

--- a/tests/test_markdown_preview.py
+++ b/tests/test_markdown_preview.py
@@ -2,17 +2,21 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import os
+import stat
 
 import pytest
 
 from cc_remote.protocol import (
+    FileSaveResult,
     FilePreview,
     GetFilePreview,
     GetPreviewAsset,
     FILE_PREVIEW_MAX_BYTES,
     PREVIEW_ASSET_MAX_BYTES,
     PreviewAsset,
+    SaveMarkdown,
 )
 from tests.test_multisession import _mk_ctx, _mk_machine
 
@@ -44,6 +48,68 @@ def test_source_preview_reads_utf8_and_reports_text_format(tmp_path):
     assert result[0] == "module.py"
     assert result[1] == "def answer():\n    return 42\n"
     assert result[5] == "text"
+    assert result[6] == hashlib.sha256(source.read_bytes()).hexdigest()
+
+
+def test_markdown_save_is_atomic_and_preserves_bom_crlf_and_mode(tmp_path):
+    path = tmp_path / "README.md"
+    path.write_bytes(b"\xef\xbb\xbf# old\r\nline\r\n")
+    path.chmod(0o640)
+    before = path.stat()
+    revision = hashlib.sha256(path.read_bytes()).hexdigest()
+    machine, _ = _mk_machine()
+
+    result = machine._write_markdown_file(
+        str(tmp_path), "README.md", "# new\nline\n",
+        before.st_size, before.st_mtime_ns, revision,
+    )
+
+    assert result[0] == "README.md"
+    assert path.read_bytes() == b"\xef\xbb\xbf# new\r\nline\r\n"
+    assert stat.S_IMODE(path.stat().st_mode) == 0o640
+    assert result[1] == path.stat().st_size
+    assert result[2] == path.stat().st_mtime_ns
+    assert result[3] == hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_markdown_save_conflict_never_overwrites_newer_content(tmp_path):
+    path = tmp_path / "README.md"
+    path.write_text("old", encoding="utf-8")
+    before = path.stat()
+    revision = hashlib.sha256(path.read_bytes()).hexdigest()
+    path.write_text("newer external content", encoding="utf-8")
+    machine, _ = _mk_machine()
+
+    with pytest.raises(RuntimeError, match="修改"):
+        machine._write_markdown_file(
+            str(tmp_path), "README.md", "editor draft",
+            before.st_size, before.st_mtime_ns, revision,
+        )
+
+    assert path.read_text(encoding="utf-8") == "newer external content"
+
+
+def test_markdown_save_rejects_non_markdown_and_symlink(tmp_path):
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside", encoding="utf-8")
+    root = tmp_path / "root"
+    root.mkdir()
+    source = root / "note.txt"
+    source.write_text("text", encoding="utf-8")
+    link = root / "link.md"
+    link.symlink_to(outside)
+    machine, _ = _mk_machine()
+    source_stat = source.stat()
+    link_stat = outside.stat()
+
+    with pytest.raises(ValueError, match="Markdown"):
+        machine._write_markdown_file(
+            str(root), "note.txt", "draft", source_stat.st_size,
+            source_stat.st_mtime_ns, hashlib.sha256(source.read_bytes()).hexdigest())
+    with pytest.raises(ValueError, match="符号链接"):
+        machine._write_markdown_file(
+            str(root), "link.md", "draft", link_stat.st_size,
+            link_stat.st_mtime_ns, hashlib.sha256(outside.read_bytes()).hexdigest())
 
 
 def test_source_preview_rejects_binary_content(tmp_path):
@@ -154,10 +220,52 @@ def test_preview_responses_are_requester_routed_and_correlated(tmp_path):
         assert preview.to == "client-1" and preview.sid == "session-1"
         assert preview.request_id == "preview-1" and preview.content == "# hello"
         assert preview.format == "markdown"
+        assert preview.revision == hashlib.sha256(b"# hello").hexdigest()
         assert isinstance(asset, PreviewAsset)
         assert asset.to == "client-1" and asset.sid == "session-1"
         assert asset.preview_id == "preview-1" and asset.request_id == "asset-1"
         assert transport.sent[-2:] == [preview, asset]
+
+    asyncio.run(run())
+
+
+def test_markdown_save_response_is_correlated_and_duplicate_is_not_reexecuted(tmp_path):
+    path = tmp_path / "README.md"
+    path.write_text("# old", encoding="utf-8")
+
+    async def run():
+        machine, transport = _mk_machine()
+        ctx = _mk_ctx("session-1", session_id="session-1")
+        ctx.cwd = str(tmp_path)
+        machine.sessions[ctx.key] = ctx
+        machine.focused_sid = ctx.key
+        before = path.stat()
+        command = SaveMarkdown(
+            sid=ctx.key,
+            client_id="client-1",
+            cmd_id="save-command-1",
+            path="README.md",
+            request_id="save-1",
+            content="# saved",
+            expected_size=before.st_size,
+            expected_mtime_ns=str(before.st_mtime_ns),
+            expected_revision=hashlib.sha256(path.read_bytes()).hexdigest(),
+        )
+
+        await machine._process_command(command)
+        saved_stat = path.stat()
+        await machine._process_command(command)
+
+        results = [message for message in transport.sent
+                   if isinstance(message, FileSaveResult)]
+        assert len(results) == 2
+        assert all(result.status == "saved" for result in results)
+        assert all(result.to == "client-1" for result in results)
+        assert path.read_text(encoding="utf-8") == "# saved"
+        assert path.stat().st_mtime_ns == saved_stat.st_mtime_ns
+        assert [message.type for message in transport.sent[-2:]] == [
+            "file_save_result", "command_ack",
+        ]
 
     asyncio.run(run())
 

--- a/tests/test_protocol_input_bounds.py
+++ b/tests/test_protocol_input_bounds.py
@@ -15,7 +15,9 @@ from cc_remote.protocol import (
     CollaborationMode,
     ForkSessionWorktree,
     GetDiff,
+    GetFilePreview,
     GetModels,
+    GetPreviewAsset,
     NewSession,
     PROTOCOL_VERSION,
     ProtocolError,
@@ -107,6 +109,9 @@ def test_surrogate_filename_is_a_clean_validation_error():
         lambda: SwitchSession(session_id="sid-1", engine="bogus"),
         lambda: GetModels(engine="bogus"),
         lambda: GetDiff(file="x", theme="bogus"),
+        lambda: GetFilePreview(path="x" * 4097, request_id="preview-1"),
+        lambda: GetPreviewAsset(
+            path="image.png", preview_id="preview-1", request_id="x" * 129),
         lambda: AnswerQuestion(
             ask_id="ask-1", answer="x" * (ASK_ANSWER_MAX_CHARS + 1)),
         lambda: ForkSessionWorktree(

--- a/tests/test_protocol_input_bounds.py
+++ b/tests/test_protocol_input_bounds.py
@@ -18,10 +18,12 @@ from cc_remote.protocol import (
     GetFilePreview,
     GetModels,
     GetPreviewAsset,
+    FILE_PREVIEW_MAX_BYTES,
     NewSession,
     PROTOCOL_VERSION,
     ProtocolError,
     Query,
+    SaveMarkdown,
     SetEffort,
     SetCollaborationMode,
     SetModel,
@@ -133,6 +135,19 @@ def test_known_dynamic_control_values_remain_supported():
     assert ForkSessionWorktree(
         session_id="sid-1", request_id="request-1", name="feature",
     ).name == "feature"
+
+
+def test_markdown_save_content_is_bounded_by_utf8_bytes():
+    common = {
+        "path": "README.md",
+        "request_id": "save-1",
+        "expected_size": 0,
+        "expected_mtime_ns": "0",
+        "expected_revision": "0" * 64,
+    }
+    assert SaveMarkdown(content="界" * (FILE_PREVIEW_MAX_BYTES // 3), **common)
+    with pytest.raises(ValidationError, match="UTF-8 bytes"):
+        SaveMarkdown(content="界" * (FILE_PREVIEW_MAX_BYTES // 3 + 1), **common)
 
 
 def test_collaboration_mode_state_roundtrips_as_downstream():

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,8 @@
     "test:outbox": "npm run test:compile --silent && node node_modules/.tmp/cc-remote-tests/tests/outbox.test.js",
     "test:scroll": "npm run test:compile --silent && node node_modules/.tmp/cc-remote-tests/tests/scroll-follow.test.js",
     "test:diff": "npm run test:compile --silent && node --expose-gc node_modules/.tmp/cc-remote-tests/tests/diff-performance.test.js",
-    "test:reliability": "npm run test:compile --silent && node node_modules/.tmp/cc-remote-tests/tests/outbox.test.js && node node_modules/.tmp/cc-remote-tests/tests/reliability.test.js && node --expose-gc node_modules/.tmp/cc-remote-tests/tests/diff-performance.test.js && node node_modules/.tmp/cc-remote-tests/tests/goal-command.test.js && node node_modules/.tmp/cc-remote-tests/tests/status-capabilities.test.js && node node_modules/.tmp/cc-remote-tests/tests/notices-rate-limits.test.js && node node_modules/.tmp/cc-remote-tests/tests/session-worktree.test.js && node node_modules/.tmp/cc-remote-tests/tests/scroll-follow.test.js",
+    "test:preview": "npm run test:compile --silent && node node_modules/.tmp/cc-remote-tests/tests/markdown-preview.test.js",
+    "test:reliability": "npm run test:compile --silent && node node_modules/.tmp/cc-remote-tests/tests/outbox.test.js && node node_modules/.tmp/cc-remote-tests/tests/reliability.test.js && node --expose-gc node_modules/.tmp/cc-remote-tests/tests/diff-performance.test.js && node node_modules/.tmp/cc-remote-tests/tests/goal-command.test.js && node node_modules/.tmp/cc-remote-tests/tests/status-capabilities.test.js && node node_modules/.tmp/cc-remote-tests/tests/notices-rate-limits.test.js && node node_modules/.tmp/cc-remote-tests/tests/session-worktree.test.js && node node_modules/.tmp/cc-remote-tests/tests/scroll-follow.test.js && node node_modules/.tmp/cc-remote-tests/tests/markdown-preview.test.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/public/cc-remote-build.json
+++ b/web/public/cc-remote-build.json
@@ -1,1 +1,1 @@
-{"protocol":9}
+{"protocol":10}

--- a/web/public/cc-remote-build.json
+++ b/web/public/cc-remote-build.json
@@ -1,1 +1,1 @@
-{"protocol":8}
+{"protocol":9}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useRef, useState, type TouchEvent } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState, type TouchEvent } from "react";
 import { RelayWs } from "./ws";
 import { reduce, initialState, createRuntime, type Turn } from "./reducer";
 import { uuid } from "./util";
@@ -85,6 +85,16 @@ export default function App() {
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
   const touchSwipeLocked = useRef(false);
+  const artifactDirtyRef = useRef(false);
+  const setArtifactDirty = useCallback((dirty: boolean) => {
+    artifactDirtyRef.current = dirty;
+  }, []);
+  const confirmArtifactDiscard = useCallback(() => {
+    if (!artifactDirtyRef.current) return true;
+    if (!window.confirm("Markdown 有未保存的修改，确定放弃吗？")) return false;
+    artifactDirtyRef.current = false;
+    return true;
+  }, []);
   // guards the once-per-connection "land on the latest session" auto-focus below
   const didInitFocusRef = useRef(false);
   const shortcutRef = useRef<{
@@ -701,12 +711,14 @@ export default function App() {
     setForkWorktreeError(null);
   };
   const getDiff = (file: string) => {
+    if (!confirmArtifactDiscard()) return;
     setRightView("diff");
     dispatch({ type: "open_artifact_loading", file, sid: focusedSid });
     wsRef.current?.sendGetDiff(file, theme);
   };
   const previewFile = (file: string, line?: number) => {
     if (!focusedSid) return;
+    if (!confirmArtifactDiscard()) return;
     const requestId = wsRef.current?.sendGetFilePreview(file) ?? null;
     if (!requestId) return;
     setRightView("diff");
@@ -722,9 +734,17 @@ export default function App() {
   const previewMarkdown = (file: string) => previewFile(file);
   const loadPreviewAsset = (file: string, previewId: string): boolean =>
     !!wsRef.current?.sendGetPreviewAsset(file, previewId);
+  const saveMarkdown = (file: string, content: string, expectedSize: number,
+                        expectedMtimeNs: string, expectedRevision: string): string | null => {
+    const requestId = wsRef.current?.sendSaveMarkdown(
+      file, content, expectedSize, expectedMtimeNs, expectedRevision) ?? null;
+    if (requestId) dispatch({ type: "start_file_save", requestId, content });
+    return requestId;
+  };
   // /btw: fork the focused session into an ephemeral side panel (wrapper replies
   // BtwOpened → reducer opens the panel). Send/close target the fork by its sid.
   const openBtw = () => {
+    if (!confirmArtifactDiscard()) return;
     setRightView("btw");
     if (!focusedSid || state.btwSid || pendingBtwRef.current) return;
     const requestId = wsRef.current?.sendOpenBtw(focusedSid) ?? null;
@@ -794,9 +814,9 @@ export default function App() {
         sessions={state.sessions}
         liveStates={Object.fromEntries(Object.entries(state.runtimes).map(([sid, r]) => [sid, r.state]))}
         activeSessionId={focusedSid}
-        onSelect={(id) => { pendingCreateRef.current = null; setCreateError(null); dispatch({ type: "exit_new_chat" }); dispatch({ type: "focus_session", sid: id }); wsRef.current?.setFocusedSid(id); wsRef.current?.sendSwitchSession(id, (state.sessions.find((s) => s.session_id === id)?.engine as "claude" | "codex") || engine); if (isMobile()) setSidebarOpen(false); }}
-        onNew={() => { pendingCreateRef.current = null; setCreateError(null); dispatch({ type: "enter_new_chat", cwd: "~" }); if (isMobile()) setSidebarOpen(false); }}
-        onNewInDir={(cwd) => { pendingCreateRef.current = null; setCreateError(null); dispatch({ type: "enter_new_chat", cwd }); if (isMobile()) setSidebarOpen(false); }}
+        onSelect={(id) => { if (!confirmArtifactDiscard()) return; pendingCreateRef.current = null; setCreateError(null); dispatch({ type: "exit_new_chat" }); dispatch({ type: "focus_session", sid: id }); wsRef.current?.setFocusedSid(id); wsRef.current?.sendSwitchSession(id, (state.sessions.find((s) => s.session_id === id)?.engine as "claude" | "codex") || engine); if (isMobile()) setSidebarOpen(false); }}
+        onNew={() => { if (!confirmArtifactDiscard()) return; pendingCreateRef.current = null; setCreateError(null); dispatch({ type: "enter_new_chat", cwd: "~" }); if (isMobile()) setSidebarOpen(false); }}
+        onNewInDir={(cwd) => { if (!confirmArtifactDiscard()) return; pendingCreateRef.current = null; setCreateError(null); dispatch({ type: "enter_new_chat", cwd }); if (isMobile()) setSidebarOpen(false); }}
         onClose={() => setSidebarOpen(false)}
         onRename={(id, title) => wsRef.current?.sendRenameSession(id, title)}
         onArchive={(id, archived) => { wsRef.current?.sendArchiveSession(id, archived); }}
@@ -929,6 +949,7 @@ export default function App() {
           return <ArtifactPanel artifact={state.artifact} active="diff" hasBtw={!!state.btwSid}
             onTab={switchRight} onRefresh={previewFile}
             onOpenFile={previewFile} onLoadPreviewAsset={loadPreviewAsset}
+            onSaveMarkdown={saveMarkdown} onDirtyChange={setArtifactDirty}
             onClose={() => dispatch({ type: "clear_artifact" })} />;
         return null;
       })()}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,6 +32,7 @@ import { classifyBtwOpened, consumeDiscardedBtwSnapshot, matchesBtwRequest,
   type CodexServiceTier, type CollaborationModeName,
   type DiffTheme, type Engine } from "./protocol";
 import { isMarkdownPath } from "./preview-path";
+import { resolveSidebarSwipe } from "./responsive-layout";
 
 const THEME_KEY = "cc_remote_theme";
 const ENGINE_KEY = "cc_remote_engine";  // which backend the NEXT new session uses
@@ -82,6 +83,8 @@ export default function App() {
   const btwRequestIdsRef = useRef<Set<string>>(new Set());
   const discardedBtwSidsRef = useRef<Set<string>>(new Set());
   const touchStartX = useRef(0);
+  const touchStartY = useRef(0);
+  const touchSwipeLocked = useRef(false);
   // guards the once-per-connection "land on the latest session" auto-focus below
   const didInitFocusRef = useRef(false);
   const shortcutRef = useRef<{
@@ -141,12 +144,27 @@ export default function App() {
     };
   }, []);
 
-  // swipe right -> open sidebar, swipe left -> close (mobile)
-  const onTouchStart = (e: TouchEvent) => { touchStartX.current = e.touches[0].clientX; };
+  // Swipe right -> open sidebar, swipe left -> close (mobile). Interactive
+  // vertical scrollers opt out so a diagonal scroll never becomes navigation.
+  const onTouchStart = (e: TouchEvent) => {
+    const touch = e.touches[0];
+    touchStartX.current = touch.clientX;
+    touchStartY.current = touch.clientY;
+    touchSwipeLocked.current = e.target instanceof Element
+      && !!e.target.closest("[data-lock-horizontal-swipe]");
+  };
   const onTouchEnd = (e: TouchEvent) => {
-    const dx = e.changedTouches[0].clientX - touchStartX.current;
-    if (dx > 50 && touchStartX.current < window.innerWidth / 3) setSidebarOpen(true);
-    else if (dx < -50) setSidebarOpen(false);
+    const touch = e.changedTouches[0];
+    const action = resolveSidebarSwipe(
+      touchStartX.current,
+      touchStartY.current,
+      touch.clientX,
+      touch.clientY,
+      window.innerWidth,
+      touchSwipeLocked.current,
+    );
+    if (action === "open") setSidebarOpen(true);
+    else if (action === "close") setSidebarOpen(false);
   };
 
   useEffect(() => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,7 @@ import { classifyBtwOpened, consumeDiscardedBtwSnapshot, matchesBtwRequest,
   type QueryFile, type SessionInfo, type CodexPermissionMode,
   type CodexServiceTier, type CollaborationModeName,
   type DiffTheme, type Engine } from "./protocol";
+import { isMarkdownPath } from "./preview-path";
 
 const THEME_KEY = "cc_remote_theme";
 const ENGINE_KEY = "cc_remote_engine";  // which backend the NEXT new session uses
@@ -497,7 +498,7 @@ export default function App() {
       if (k === "b" && e.shiftKey) {           // diff (shared right slot)
         e.preventDefault();
         const latest = shortcutRef.current;
-        if (latest.artifact && latest.rightView === "diff") dispatch({ type: "clear_artifact" });
+        if (latest.artifact?.kind === "gitdiff" && latest.rightView === "diff") dispatch({ type: "clear_artifact" });
         else latest.getDiff("");
       } else if (k === "b") {                    // toggle sidebar
         e.preventDefault();
@@ -686,6 +687,23 @@ export default function App() {
     dispatch({ type: "open_artifact_loading", file, sid: focusedSid });
     wsRef.current?.sendGetDiff(file, theme);
   };
+  const previewFile = (file: string, line?: number) => {
+    if (!focusedSid) return;
+    const requestId = wsRef.current?.sendGetFilePreview(file) ?? null;
+    if (!requestId) return;
+    setRightView("diff");
+    dispatch({
+      type: "open_file_loading",
+      file,
+      sid: focusedSid,
+      requestId,
+      kind: isMarkdownPath(file) ? "md" : "file",
+      line,
+    });
+  };
+  const previewMarkdown = (file: string) => previewFile(file);
+  const loadPreviewAsset = (file: string, previewId: string): boolean =>
+    !!wsRef.current?.sendGetPreviewAsset(file, previewId);
   // /btw: fork the focused session into an ephemeral side panel (wrapper replies
   // BtwOpened → reducer opens the panel). Send/close target the fork by its sid.
   const openBtw = () => {
@@ -714,7 +732,12 @@ export default function App() {
     }
   };
   // Header tab switch between the two right-slot views (opening the target lazily).
-  const switchRight = (v: "diff" | "btw") => { if (v === "diff") getDiff(""); else openBtw(); };
+  const switchRight = (v: "diff" | "btw") => {
+    if (v === "diff") {
+      setRightView("diff");
+      if (!state.artifact) getDiff("");
+    } else openBtw();
+  };
   shortcutRef.current = {
     artifact: state.artifact, btwSid: state.btwSid, rightView,
     getDiff, openBtw, closeBtw,
@@ -809,6 +832,8 @@ export default function App() {
               hasMore={!!rt.hasMore}
               onLoadMore={() => { if (focusedSid) wsRef.current?.sendGetHistory(focusedSid, rt.oldestId, HISTORY_PAGE); }}
               onEdit={(prompt) => setEditPrompt(prompt)} onGetDiff={getDiff}
+              onPreviewMarkdown={previewMarkdown}
+              onOpenFile={previewFile}
               onFork={forkFromTurn} />
 
             <GoalPanel engine={engine} goal={rt.goal}
@@ -860,6 +885,7 @@ export default function App() {
           onClear={() => dispatch({ type: "enter_new_chat", cwd: state.currentCwd })}
           onContext={() => wsRef.current?.sendGetContext()}
           onOpenBtw={openBtw}
+          onPreview={previewMarkdown}
           onGoal={runGoal}
           onStatus={openStatus}
           contextReport={rt.contextReport}
@@ -876,14 +902,16 @@ export default function App() {
         if (view === "btw")
           return <BtwPanel sid={state.btwSid ?? undefined} rt={state.btwSid ? state.runtimes[state.btwSid] : undefined}
             engine={state.btwEngine} opening={btwOpening && !state.btwSid}
-            active="btw" hasDiff={!!state.artifact} onTab={switchRight}
-            onSend={sendBtw} onClose={closeBtw}
+            active="btw" hasArtifact={!!state.artifact} artifactKind={state.artifact?.kind} onTab={switchRight}
+            onSend={sendBtw} onOpenFile={previewFile} onClose={closeBtw}
             onDismissNotice={(noticeId) => {
               if (state.btwSid) dispatch({ type: "dismiss_notice", sid: state.btwSid, noticeId });
             }} />;
         if (view === "diff" && state.artifact)
           return <ArtifactPanel artifact={state.artifact} active="diff" hasBtw={!!state.btwSid}
-            onTab={switchRight} onClose={() => dispatch({ type: "clear_artifact" })} />;
+            onTab={switchRight} onRefresh={previewFile}
+            onOpenFile={previewFile} onLoadPreviewAsset={loadPreviewAsset}
+            onClose={() => dispatch({ type: "clear_artifact" })} />;
         return null;
       })()}
       {rt.pendingQuestion && (

--- a/web/src/components/ArtifactPanel.tsx
+++ b/web/src/components/ArtifactPanel.tsx
@@ -101,7 +101,7 @@ function PreviewImage({ markdownPath, src, alt, title, asset, requestAsset }: {
 }
 
 export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
-  onRefresh, onOpenFile, onLoadPreviewAsset }: {
+  onRefresh, onOpenFile, onLoadPreviewAsset, onSaveMarkdown, onDirtyChange }: {
   artifact: Artifact;
   active: "diff" | "btw";
   hasBtw: boolean;
@@ -110,8 +110,12 @@ export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
   onRefresh?: (path: string, line?: number) => void;
   onOpenFile?: (path: string, line?: number) => void;
   onLoadPreviewAsset?: (path: string, previewId: string) => boolean;
+  onSaveMarkdown?: (path: string, content: string, expectedSize: number,
+    expectedMtimeNs: string, expectedRevision: string) => string | null;
+  onDirtyChange?: (dirty: boolean) => void;
 }) {
   const panelRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<HTMLTextAreaElement>(null);
   const resizeRef = useRef<{
     pointerId: number;
     startX: number;
@@ -121,6 +125,11 @@ export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
   const [pageState, setPageState] = useState({ key: artifactKey, page: 0 });
   const [modeState, setModeState] = useState<{ key: string; mode: "preview" | "source" }>({
     key: artifactKey, mode: "preview",
+  });
+  const [editorState, setEditorState] = useState({
+    key: artifactKey,
+    draft: artifact.content || "",
+    baseline: artifact.content || "",
   });
   const requestedAssets = useRef<{
     key: string;
@@ -138,12 +147,92 @@ export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
 
   const requestedPage = pageState.key === artifactKey ? pageState.page : 0;
   const mode = modeState.key === artifactKey ? modeState.mode : "preview";
+  const editor = editorState.key === artifactKey ? editorState : {
+    key: artifactKey,
+    draft: artifact.content || "",
+    baseline: artifact.content || "",
+  };
+  const dirty = artifact.kind === "md" && editor.draft !== editor.baseline;
   const sections = artifact.kind === "gitdiff"
     ? (artifact.sections || EMPTY_GIT_DIFF_SECTIONS) : EMPTY_GIT_DIFF_SECTIONS;
   const page = useMemo(() => pageGitDiff(sections, requestedPage), [sections, requestedPage]);
   const showPage = (nextPage: number) => setPageState({ key: artifactKey, page: nextPage });
   const loading = !!artifact.loading;
   const empty = artifact.kind === "gitdiff" && !loading && sections.length === 0;
+
+  useEffect(() => {
+    const incoming = artifact.content || "";
+    setEditorState((current) => {
+      if (current.key !== artifactKey) {
+        return { key: artifactKey, draft: incoming, baseline: incoming };
+      }
+      if (artifact.saveStatus === "saved" || current.draft === current.baseline) {
+        if (current.draft === incoming && current.baseline === incoming) return current;
+        return { key: artifactKey, draft: incoming, baseline: incoming };
+      }
+      return current;
+    });
+  }, [artifact.content, artifact.saveStatus, artifactKey]);
+
+  useEffect(() => {
+    onDirtyChange?.(dirty);
+    return () => onDirtyChange?.(false);
+  }, [dirty, onDirtyChange]);
+
+  useEffect(() => {
+    if (!dirty) return;
+    const warn = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", warn);
+    return () => window.removeEventListener("beforeunload", warn);
+  }, [dirty]);
+
+  useEffect(() => {
+    if (artifact.kind !== "md" || mode !== "source" || loading) return;
+    const frame = window.requestAnimationFrame(() => editorRef.current?.focus());
+    return () => window.cancelAnimationFrame(frame);
+  }, [artifact.kind, loading, mode]);
+
+  const canSave = artifact.kind === "md" && !loading && !artifact.error
+    && !artifact.truncated && typeof artifact.size === "number"
+    && typeof artifact.mtimeNs === "string" && !!artifact.revision
+    && !!onSaveMarkdown;
+  const saveDraft = useCallback(() => {
+    if (!canSave || !dirty || artifact.saving || !artifact.revision) return;
+    onSaveMarkdown?.(
+      artifact.file,
+      editor.draft,
+      artifact.size!,
+      artifact.mtimeNs!,
+      artifact.revision,
+    );
+  }, [artifact.file, artifact.mtimeNs, artifact.revision, artifact.size,
+    artifact.saving, canSave, dirty, editor.draft, onSaveMarkdown]);
+
+  const confirmDiscard = useCallback(() => (
+    !dirty || window.confirm("Markdown 有未保存的修改，确定放弃吗？")
+  ), [dirty]);
+
+  const leavePanel = useCallback(() => {
+    if (!confirmDiscard()) return;
+    onDirtyChange?.(false);
+    onClose();
+  }, [confirmDiscard, onClose, onDirtyChange]);
+
+  const switchPanelTab = useCallback((next: "diff" | "btw") => {
+    if (next !== active && !confirmDiscard()) return;
+    if (next !== active) onDirtyChange?.(false);
+    onTab(next);
+  }, [active, confirmDiscard, onDirtyChange, onTab]);
+
+  const handlePanelKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (artifact.kind !== "md" || !(event.metaKey || event.ctrlKey)
+        || event.key.toLowerCase() !== "s") return;
+    event.preventDefault();
+    saveDraft();
+  };
 
   const applyPanelWidth = useCallback((requestedWidth: number, persist = false) => {
     const width = clampPanelWidth(requestedWidth, window.innerWidth);
@@ -268,14 +357,15 @@ export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
     || (["md", "file"].includes(artifact.kind) ? "文件预览" : "改动");
 
   return (
-    <div className="artifact-panel" ref={panelRef} data-lock-horizontal-swipe="true">
+    <div className="artifact-panel" ref={panelRef} data-lock-horizontal-swipe="true"
+      onKeyDown={handlePanelKeyDown}>
       <button type="button" className="panel-resizer"
         aria-label="调整文件面板宽度" title="左右拖动调整面板宽度"
         onPointerDown={startResize} onPointerMove={moveResize}
         onPointerUp={finishResize} onPointerCancel={finishResize}
         onKeyDown={resizeWithKeyboard} />
       <div className="artifact-head">
-        {hasBtw ? <PanelTabs active={active} artifactKind={artifact.kind} onTab={onTab} />
+        {hasBtw ? <PanelTabs active={active} artifactKind={artifact.kind} onTab={switchPanelTab} />
           : <span className="artifact-title">{title}</span>}
         <span className="artifact-path" title={artifact.file}>{artifact.file || "所有改动"}</span>
         {artifact.kind === "md" && !loading && !artifact.error && <div className="preview-modes" role="group" aria-label="Markdown 显示模式">
@@ -284,10 +374,20 @@ export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
           <button className={mode === "source" ? "on" : ""}
             onClick={() => setModeState({ key: artifactKey, mode: "source" })}>源码</button>
         </div>}
+        {artifact.kind === "md" && !loading && !artifact.error && <button
+          type="button" className="markdown-save"
+          disabled={!dirty || artifact.saving || !canSave}
+          onClick={saveDraft}
+          title={artifact.truncated ? "截断的文件不可编辑" : "保存 Markdown（Ctrl/⌘+S）"}>
+          <Icon name={artifact.saving ? "refresh" : "check"} size={15} />
+          {artifact.saving ? "保存中" : "保存"}
+        </button>}
+        {artifact.kind === "md" && artifact.saveStatus === "saved" && !dirty
+          && <span className="markdown-save-state ok">已保存</span>}
         {["md", "file"].includes(artifact.kind) && <button className="iconbtn"
           onClick={() => onRefresh?.(artifact.file, artifact.line)}
           aria-label="刷新文件" title="重新读取文件"><Icon name="refresh" size={17} /></button>}
-        <button className="iconbtn" onClick={onClose} aria-label="收起"><Icon name="chevrons-right" /></button>
+        <button className="iconbtn" onClick={leavePanel} aria-label="收起"><Icon name="chevrons-right" /></button>
       </div>
       <div className="artifact-body">
         {loading ? (
@@ -347,10 +447,21 @@ export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
         ) : artifact.kind === "md" ? (
           <>
             {artifact.truncated && <div className="preview-truncated">文件共 {artifact.size?.toLocaleString()} 字节，仅预览前 512 KiB。</div>}
+            {artifact.saveError && <div className={"markdown-save-error " + (artifact.saveStatus || "error")}>
+              {artifact.saveError}
+            </div>}
             {mode === "source"
-              ? <pre className="markdown-source">{artifact.content || ""}</pre>
+              ? <textarea ref={editorRef} className="markdown-editor"
+                  aria-label="Markdown 源码编辑器" value={editor.draft}
+                  readOnly={!canSave}
+                  spellCheck={false}
+                  onChange={(event) => setEditorState({
+                    key: artifactKey,
+                    draft: event.currentTarget.value,
+                    baseline: editor.baseline,
+                  })} />
               : <div className="prose markdown-preview"><ReactMarkdown
-                  remarkPlugins={[remarkGfm]} components={markdownComponents}>{artifact.content || ""}</ReactMarkdown></div>}
+                  remarkPlugins={[remarkGfm]} components={markdownComponents}>{editor.draft}</ReactMarkdown></div>}
           </>
         ) : null}
       </div>

--- a/web/src/components/ArtifactPanel.tsx
+++ b/web/src/components/ArtifactPanel.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Artifact, PreviewAssetState } from "../reducer";
@@ -7,10 +9,12 @@ import { PanelTabs } from "./PanelTabs";
 import { GIT_DIFF_PAGE_LINES, pageGitDiff, type GitDiffSection } from "../diff";
 import { classifyPreviewTarget } from "../preview-path";
 import { parseLocalFileTarget } from "../file-link";
+import { clampPanelWidth } from "../responsive-layout";
 
 const EMPTY_GIT_DIFF_SECTIONS: GitDiffSection[] = [];
 const MAX_PREVIEW_ASSETS = 12;
 const SOURCE_PAGE_LINES = 500;
+const PANEL_WIDTH_KEY = "cc_remote_artifact_panel_width";
 
 function SourceFile({ content, targetLine, artifactKey }: {
   content: string;
@@ -107,6 +111,12 @@ export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
   onOpenFile?: (path: string, line?: number) => void;
   onLoadPreviewAsset?: (path: string, previewId: string) => boolean;
 }) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const resizeRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startWidth: number;
+  } | null>(null);
   const artifactKey = `${artifact.sid || ""}:${artifact.file}:${artifact.requestId || ""}`;
   const [pageState, setPageState] = useState({ key: artifactKey, page: 0 });
   const [modeState, setModeState] = useState<{ key: string; mode: "preview" | "source" }>({
@@ -134,6 +144,64 @@ export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
   const showPage = (nextPage: number) => setPageState({ key: artifactKey, page: nextPage });
   const loading = !!artifact.loading;
   const empty = artifact.kind === "gitdiff" && !loading && sections.length === 0;
+
+  const applyPanelWidth = useCallback((requestedWidth: number, persist = false) => {
+    const width = clampPanelWidth(requestedWidth, window.innerWidth);
+    document.documentElement.style.setProperty("--panel-w", `${width}px`);
+    if (persist) localStorage.setItem(PANEL_WIDTH_KEY, String(width));
+    return width;
+  }, []);
+
+  useEffect(() => {
+    if (!window.matchMedia("(min-width: 981px)").matches) return;
+    const saved = Number.parseFloat(localStorage.getItem(PANEL_WIDTH_KEY) || "");
+    if (Number.isFinite(saved)) applyPanelWidth(saved);
+    const fitPanel = () => {
+      if (!window.matchMedia("(min-width: 981px)").matches) return;
+      const current = panelRef.current?.getBoundingClientRect().width;
+      if (current) applyPanelWidth(current);
+    };
+    window.addEventListener("resize", fitPanel);
+    return () => {
+      window.removeEventListener("resize", fitPanel);
+      document.documentElement.classList.remove("panel-resizing");
+    };
+  }, [applyPanelWidth]);
+
+  const startResize = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (!window.matchMedia("(min-width: 981px)").matches || !panelRef.current) return;
+    resizeRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startWidth: panelRef.current.getBoundingClientRect().width,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    document.documentElement.classList.add("panel-resizing");
+    event.preventDefault();
+  };
+  const moveResize = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    const resize = resizeRef.current;
+    if (!resize || resize.pointerId !== event.pointerId) return;
+    applyPanelWidth(resize.startWidth + resize.startX - event.clientX);
+  };
+  const finishResize = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    const resize = resizeRef.current;
+    if (!resize || resize.pointerId !== event.pointerId) return;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    resizeRef.current = null;
+    document.documentElement.classList.remove("panel-resizing");
+    const width = panelRef.current?.getBoundingClientRect().width;
+    if (width) applyPanelWidth(width, true);
+  };
+  const resizeWithKeyboard = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    const width = panelRef.current?.getBoundingClientRect().width;
+    if (!width) return;
+    applyPanelWidth(width + (event.key === "ArrowLeft" ? 24 : -24), true);
+    event.preventDefault();
+  };
 
   const sendNextAsset = useCallback(() => {
     const current = requestedAssets.current;
@@ -200,7 +268,12 @@ export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
     || (["md", "file"].includes(artifact.kind) ? "文件预览" : "改动");
 
   return (
-    <div className="artifact-panel">
+    <div className="artifact-panel" ref={panelRef} data-lock-horizontal-swipe="true">
+      <button type="button" className="panel-resizer"
+        aria-label="调整文件面板宽度" title="左右拖动调整面板宽度"
+        onPointerDown={startResize} onPointerMove={moveResize}
+        onPointerUp={finishResize} onPointerCancel={finishResize}
+        onKeyDown={resizeWithKeyboard} />
       <div className="artifact-head">
         {hasBtw ? <PanelTabs active={active} artifactKind={artifact.kind} onTab={onTab} />
           : <span className="artifact-title">{title}</span>}

--- a/web/src/components/ArtifactPanel.tsx
+++ b/web/src/components/ArtifactPanel.tsx
@@ -1,38 +1,226 @@
-import { useMemo, useState } from "react";
-import ReactMarkdown from "react-markdown";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import type { Artifact } from "../reducer";
+import type { Artifact, PreviewAssetState } from "../reducer";
 import { Icon } from "../icons";
 import { PanelTabs } from "./PanelTabs";
 import { GIT_DIFF_PAGE_LINES, pageGitDiff, type GitDiffSection } from "../diff";
+import { classifyPreviewTarget } from "../preview-path";
+import { parseLocalFileTarget } from "../file-link";
 
 const EMPTY_GIT_DIFF_SECTIONS: GitDiffSection[] = [];
+const MAX_PREVIEW_ASSETS = 12;
+const SOURCE_PAGE_LINES = 500;
 
-export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose }: {
-  artifact: Artifact; active: "diff" | "btw"; hasBtw: boolean;
-  onTab: (v: "diff" | "btw") => void; onClose: () => void;
+function SourceFile({ content, targetLine, artifactKey }: {
+  content: string;
+  targetLine?: number;
+  artifactKey: string;
 }) {
-  const artifactKey = `${artifact.sid || ""}:${artifact.file}`;
+  const lines = useMemo(() => content.split("\n"), [content]);
+  const focusLine = targetLine && targetLine <= lines.length ? targetLine : undefined;
+  const initialPage = Math.min(
+    Math.max(0, Math.floor(((targetLine || 1) - 1) / SOURCE_PAGE_LINES)),
+    Math.max(0, Math.ceil(lines.length / SOURCE_PAGE_LINES) - 1),
+  );
+  const [pageState, setPageState] = useState({ key: artifactKey, page: initialPage });
+  const page = pageState.key === artifactKey ? pageState.page : initialPage;
+  const pageCount = Math.max(1, Math.ceil(lines.length / SOURCE_PAGE_LINES));
+  const start = page * SOURCE_PAGE_LINES;
+  const visible = lines.slice(start, start + SOURCE_PAGE_LINES);
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!focusLine || Math.floor((focusLine - 1) / SOURCE_PAGE_LINES) !== page) return;
+    const frame = window.requestAnimationFrame(() => {
+      targetRef.current?.scrollIntoView({ block: "center" });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [artifactKey, focusLine, page]);
+
+  return <>
+    {pageCount > 1 && <nav className="source-page-nav" aria-label="源文件分页">
+      <button type="button" disabled={page === 0}
+        onClick={() => setPageState({ key: artifactKey, page: page - 1 })}>上一页</button>
+      <span>{start + 1}–{Math.min(lines.length, start + SOURCE_PAGE_LINES)} / {lines.length} 行</span>
+      <button type="button" disabled={page + 1 >= pageCount}
+        onClick={() => setPageState({ key: artifactKey, page: page + 1 })}>下一页</button>
+    </nav>}
+    <div className="source-file">
+      {visible.map((text, index) => {
+        const line = start + index + 1;
+        const focused = line === focusLine;
+        return <div key={line} ref={focused ? targetRef : undefined}
+          className={"source-line" + (focused ? " focused" : "")}>
+          <span className="source-line-no">{line}</span>
+          <code>{text || " "}</code>
+        </div>;
+      })}
+    </div>
+  </>;
+}
+
+function PreviewImage({ markdownPath, src, alt, title, asset, requestAsset }: {
+  markdownPath: string;
+  src: string;
+  alt?: string;
+  title?: string;
+  asset?: PreviewAssetState;
+  requestAsset: (path: string) => boolean;
+}) {
+  const target = classifyPreviewTarget(markdownPath, src);
+  const [blocked, setBlocked] = useState(false);
+
+  useEffect(() => {
+    if (target.kind !== "local" || asset?.data || asset?.error) return;
+    setBlocked(!requestAsset(target.value));
+  }, [asset?.data, asset?.error, requestAsset, target.kind, target.value]);
+
+  if (target.kind === "external") {
+    return <img src={target.value} alt={alt || ""} title={title}
+      loading="lazy" referrerPolicy="no-referrer" />;
+  }
+  if (target.kind !== "local") {
+    return <span className="preview-image-error" title={src}>图片路径不可用：{alt || src}</span>;
+  }
+  if (asset?.data && asset.mediaType) {
+    return <img src={`data:${asset.mediaType};base64,${asset.data}`}
+      alt={alt || ""} title={title} loading="lazy" />;
+  }
+  if (asset?.error) {
+    return <span className="preview-image-error" title={asset.error}>图片不可用：{alt || src}</span>;
+  }
+  if (blocked) {
+    return <span className="preview-image-error">本页本地图片超过 {MAX_PREVIEW_ASSETS} 张，已停止加载</span>;
+  }
+  return <span className="preview-image-loading"><span className="thinking"><span/><span/><span/></span> {alt || "正在加载图片"}</span>;
+}
+
+export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
+  onRefresh, onOpenFile, onLoadPreviewAsset }: {
+  artifact: Artifact;
+  active: "diff" | "btw";
+  hasBtw: boolean;
+  onTab: (v: "diff" | "btw") => void;
+  onClose: () => void;
+  onRefresh?: (path: string, line?: number) => void;
+  onOpenFile?: (path: string, line?: number) => void;
+  onLoadPreviewAsset?: (path: string, previewId: string) => boolean;
+}) {
+  const artifactKey = `${artifact.sid || ""}:${artifact.file}:${artifact.requestId || ""}`;
   const [pageState, setPageState] = useState({ key: artifactKey, page: 0 });
+  const [modeState, setModeState] = useState<{ key: string; mode: "preview" | "source" }>({
+    key: artifactKey, mode: "preview",
+  });
+  const requestedAssets = useRef<{
+    key: string;
+    paths: Set<string>;
+    queued: string[];
+    active?: string;
+  }>({
+    key: artifactKey, paths: new Set(), queued: [],
+  });
+  if (requestedAssets.current.key !== artifactKey) {
+    requestedAssets.current = {
+      key: artifactKey, paths: new Set(), queued: [],
+    };
+  }
+
   const requestedPage = pageState.key === artifactKey ? pageState.page : 0;
+  const mode = modeState.key === artifactKey ? modeState.mode : "preview";
   const sections = artifact.kind === "gitdiff"
     ? (artifact.sections || EMPTY_GIT_DIFF_SECTIONS) : EMPTY_GIT_DIFF_SECTIONS;
   const page = useMemo(() => pageGitDiff(sections, requestedPage), [sections, requestedPage]);
   const showPage = (nextPage: number) => setPageState({ key: artifactKey, page: nextPage });
-  const loading = !!artifact.loading && sections.length === 0;
+  const loading = !!artifact.loading;
   const empty = artifact.kind === "gitdiff" && !loading && sections.length === 0;
+
+  const sendNextAsset = useCallback(() => {
+    const current = requestedAssets.current;
+    if (current.key !== artifactKey || current.active
+        || !artifact.requestId || !onLoadPreviewAsset) return;
+    while (current.queued.length) {
+      const path = current.queued.shift()!;
+      if (onLoadPreviewAsset(path, artifact.requestId)) {
+        current.active = path;
+        return;
+      }
+      current.paths.delete(path);
+    }
+  }, [artifact.requestId, artifactKey, onLoadPreviewAsset]);
+
+  useEffect(() => {
+    const current = requestedAssets.current;
+    if (current.key !== artifactKey) return;
+    if (current.active && artifact.assets?.[current.active]) {
+      current.active = undefined;
+    }
+    sendNextAsset();
+  }, [artifact.assets, artifactKey, sendNextAsset]);
+
+  const requestAsset = useCallback((path: string): boolean => {
+    const current = requestedAssets.current;
+    if (current.key !== artifactKey || !artifact.requestId
+        || !onLoadPreviewAsset) return false;
+    if (current.paths.has(path)) return true;
+    if (current.paths.size >= MAX_PREVIEW_ASSETS) return false;
+    current.paths.add(path);
+    current.queued.push(path);
+    sendNextAsset();
+    return current.paths.has(path);
+  }, [artifact.requestId, artifactKey, onLoadPreviewAsset, sendNextAsset]);
+
+  const markdownComponents = useMemo<Components>(() => ({
+    img: ({ src, alt, title }) => {
+      const source = typeof src === "string" ? src : "";
+      const target = classifyPreviewTarget(artifact.file, source);
+      const asset = target.kind === "local" ? artifact.assets?.[target.value] : undefined;
+      return <PreviewImage markdownPath={artifact.file} src={source} alt={alt}
+        title={title} asset={asset} requestAsset={requestAsset} />;
+    },
+    a: ({ href, children, title }) => {
+      const target = classifyPreviewTarget(artifact.file, href || "");
+      if (target.kind === "external") {
+        return <a href={target.value} target="_blank" rel="noopener noreferrer"
+          title={title}>{children}</a>;
+      }
+      if (target.kind === "anchor") return <a href={target.value} title={title}>{children}</a>;
+      if (target.kind === "local" && onOpenFile) {
+        const source = parseLocalFileTarget(href || "");
+        return <a href="#" title={target.value} onClick={(event) => {
+          event.preventDefault();
+          onOpenFile(target.value, source?.line);
+        }}>{children}</a>;
+      }
+      return <span className="preview-link-disabled" title="该相对链接不会离开当前工作目录">{children}</span>;
+    },
+  }), [artifact.assets, artifact.file, onOpenFile, requestAsset]);
+
+  const title = artifact.file.split("/").pop()
+    || (["md", "file"].includes(artifact.kind) ? "文件预览" : "改动");
 
   return (
     <div className="artifact-panel">
       <div className="artifact-head">
-        {hasBtw ? <PanelTabs active={active} onTab={onTab} />
-          : <span className="artifact-title">{artifact.file.split("/").pop() || "改动"}</span>}
+        {hasBtw ? <PanelTabs active={active} artifactKind={artifact.kind} onTab={onTab} />
+          : <span className="artifact-title">{title}</span>}
         <span className="artifact-path" title={artifact.file}>{artifact.file || "所有改动"}</span>
+        {artifact.kind === "md" && !loading && !artifact.error && <div className="preview-modes" role="group" aria-label="Markdown 显示模式">
+          <button className={mode === "preview" ? "on" : ""}
+            onClick={() => setModeState({ key: artifactKey, mode: "preview" })}>预览</button>
+          <button className={mode === "source" ? "on" : ""}
+            onClick={() => setModeState({ key: artifactKey, mode: "source" })}>源码</button>
+        </div>}
+        {["md", "file"].includes(artifact.kind) && <button className="iconbtn"
+          onClick={() => onRefresh?.(artifact.file, artifact.line)}
+          aria-label="刷新文件" title="重新读取文件"><Icon name="refresh" size={17} /></button>}
         <button className="iconbtn" onClick={onClose} aria-label="收起"><Icon name="chevrons-right" /></button>
       </div>
       <div className="artifact-body">
         {loading ? (
-          <div className="diff-empty"><span className="thinking"><span/><span/><span/></span> 正在读取 diff…</div>
+          <div className="diff-empty"><span className="thinking"><span/><span/><span/></span> {["md", "file"].includes(artifact.kind) ? "正在读取文件…" : "正在读取 diff…"}</div>
+        ) : artifact.error ? (
+          <div className="preview-error"><Icon name="read" size={18} />{artifact.error}</div>
         ) : artifact.kind === "gitdiff" ? (
           empty ? (
             <div className="diff-empty">没有未提交的改动。</div>
@@ -77,9 +265,21 @@ export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose }: {
               <span key={i} className={"diff-" + l.type}>{(l.type === "add" ? "+" : l.type === "del" ? "−" : " ") + " " + l.text + "\n"}</span>
             ))}
           </pre>
-        ) : (
-          <div className="prose"><ReactMarkdown remarkPlugins={[remarkGfm]}>{artifact.content || ""}</ReactMarkdown></div>
-        )}
+        ) : artifact.kind === "file" ? (
+          <>
+            {artifact.truncated && <div className="preview-truncated">文件共 {artifact.size?.toLocaleString()} 字节，仅预览前 512 KiB。</div>}
+            <SourceFile content={artifact.content || ""} targetLine={artifact.line}
+              artifactKey={artifactKey} />
+          </>
+        ) : artifact.kind === "md" ? (
+          <>
+            {artifact.truncated && <div className="preview-truncated">文件共 {artifact.size?.toLocaleString()} 字节，仅预览前 512 KiB。</div>}
+            {mode === "source"
+              ? <pre className="markdown-source">{artifact.content || ""}</pre>
+              : <div className="prose markdown-preview"><ReactMarkdown
+                  remarkPlugins={[remarkGfm]} components={markdownComponents}>{artifact.content || ""}</ReactMarkdown></div>}
+          </>
+        ) : null}
       </div>
     </div>
   );

--- a/web/src/components/BtwPanel.tsx
+++ b/web/src/components/BtwPanel.tsx
@@ -3,21 +3,24 @@ import { ChatView } from "./ChatView";
 import { Icon } from "../icons";
 import { PanelTabs } from "./PanelTabs";
 import { NoticeStack } from "./NoticeStack";
-import type { SessionRuntime } from "../reducer";
+import type { Artifact, SessionRuntime } from "../reducer";
 import { ImeSubmitGuard } from "../ime-submit";
 
 /** /btw side panel: a mini chat over an ephemeral fork of the current session.
  * Reuses ChatView for the transcript; a minimal textarea for input. Closing
  * discards the fork (the main thread never sees any of this). */
-export function BtwPanel({ sid, rt, engine, opening, active, hasDiff, onTab, onSend, onClose, onDismissNotice }: {
+export function BtwPanel({ sid, rt, engine, opening, active, hasArtifact,
+  artifactKind, onTab, onSend, onOpenFile, onClose, onDismissNotice }: {
   sid?: string;
   rt: SessionRuntime | undefined;
   engine?: string;
   opening?: boolean;   // fork still spawning (no sid yet) — show a spinner
   active: "diff" | "btw";
-  hasDiff: boolean;
+  hasArtifact: boolean;
+  artifactKind?: Artifact["kind"];
   onTab: (v: "diff" | "btw") => void;
   onSend: (prompt: string) => void;
+  onOpenFile?: (path: string, line?: number) => void;
   onClose: () => void;
   onDismissNotice: (noticeId: string) => void;
 }) {
@@ -53,8 +56,8 @@ export function BtwPanel({ sid, rt, engine, opening, active, hasDiff, onTab, onS
   return (
     <div className="btw-panel">
       <div className="btw-head">
-        {hasDiff
-          ? <PanelTabs active={active} onTab={onTab} />
+        {hasArtifact
+          ? <PanelTabs active={active} artifactKind={artifactKind} onTab={onTab} />
           : <div className="btw-titles">
               <span className="btw-title">btw · 侧边对话{engine === "codex" ? " · Codex" : ""}</span>
               <span className="btw-sub">基于当前会话上下文,不写回主线</span>
@@ -69,7 +72,8 @@ export function BtwPanel({ sid, rt, engine, opening, active, hasDiff, onTab, onS
           ? <div className="btw-empty"><span className="thinking"><span/><span/><span/></span> 正在打开侧边对话…</div>
           : turns.length === 0
             ? <div className="btw-empty">问一个基于当前会话的侧边问题 —— 回答不会写进主线,关闭即丢弃。</div>
-            : <ChatView sid={sid ?? null} turns={turns} onEdit={() => {}} onGetDiff={() => {}} />}
+            : <ChatView sid={sid ?? null} turns={turns} onEdit={() => {}}
+                onGetDiff={() => {}} onOpenFile={onOpenFile} />}
       </div>
       <div className="btw-input">
         <textarea

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -13,6 +13,7 @@ import { Icon, ClaudeMark, ClaudeWorking, ClaudeSpark } from "../icons";
 import { canForkTurn } from "../session-worktree";
 import { ProcessTimeline } from "./ProcessTimeline";
 import { finalTextBlocks, processBlocks } from "../process-blocks";
+import { isMarkdownPath } from "../preview-path";
 import {
   anchoredScrollTop,
   createFrameCoalescer,
@@ -44,7 +45,8 @@ function formatTime(ts: number): string {
 }
 
 export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
-  onLoadMore, onEdit, onGetDiff, onFork, forkingPointId }: {
+  onLoadMore, onEdit, onGetDiff, onPreviewMarkdown, onOpenFile,
+  onFork, forkingPointId }: {
   sid: string | null;
   turns: Turn[];
   engine?: "claude" | "codex";
@@ -53,6 +55,8 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
   onLoadMore?: () => void;
   onEdit: (prompt: string) => void;
   onGetDiff: (file: string) => void;
+  onPreviewMarkdown?: (file: string) => void;
+  onOpenFile?: (file: string, line?: number) => void;
   onFork?: (forkPointId: string) => void;
   forkingPointId?: string | null;
 }) {
@@ -238,11 +242,16 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
           <Icon name="edit" size={13} />改动 {arr.length} 个文件
         </button>
         <div className="turn-files-list">
-          {arr.map((f) => (
-            <button key={f} className="turn-file-chip" onClick={() => onGetDiff(f)} title={f}>
+          {arr.map((f) => {
+            const markdown = isMarkdownPath(f) && !!onPreviewMarkdown;
+            return <button key={f} className={"turn-file-chip" + (markdown ? " markdown" : "")}
+              onClick={() => markdown ? onPreviewMarkdown(f) : onGetDiff(f)}
+              title={markdown ? `预览 ${f}` : f}>
+              <Icon name={markdown ? "read" : "edit"} size={12} />
               {f.split("/").pop()}
-            </button>
-          ))}
+              {markdown && <span className="turn-file-action">预览</span>}
+            </button>;
+          })}
         </div>
       </div>
     );
@@ -308,9 +317,11 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
             {t.blocks.length > 0 ? (
               <>
                 <ProcessTimeline blocks={t.blocks} done={t.done}
-                  durationMs={t.durationMs} startTs={t.ts} />
+                  durationMs={t.durationMs} startTs={t.ts}
+                  onOpenFile={onOpenFile} />
                 {finalTextBlocks(t.blocks).map((block) => (
-                  <MessageBlock key={block.message_id} text={block.text} done={block.done} />
+                  <MessageBlock key={block.message_id} text={block.text}
+                    done={block.done} onOpenFile={onOpenFile} />
                 ))}
                 {!t.done && processBlocks(t.blocks).length === 0
                   && finalTextBlocks(t.blocks).length === 0 && (

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -47,6 +47,7 @@ interface Props {
   onClear: () => void;
   onContext: () => void;
   onOpenBtw?: () => void;
+  onPreview?: (path: string) => void;
   onGoal?: (args: string) => void;
   onStatus?: () => void;
   contextReport: ContextReport | null;
@@ -243,6 +244,14 @@ export function Composer(p: Props) {
       case "goal": p.onGoal?.(args); break;
       // /btw: open an ephemeral side-fork panel (both engines).
       case "btw": p.onOpenBtw?.(); break;
+      case "preview":
+        if (!args) {
+          setInput("/preview ");
+          focusTa();
+          return;
+        }
+        p.onPreview?.(args);
+        break;
       // Codex /fast flips only this thread's persisted service tier. The UI
       // waits for the wrapper's authoritative Fast event before changing state.
       case "fast": {

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -349,7 +349,8 @@ export function Composer(p: Props) {
     <div className="composer">
       <div className="composer-in">
         {cmdOpen && (
-          <div className="cmd-pop" role="listbox" aria-label="命令">
+          <div className="cmd-pop" role="listbox" aria-label="命令"
+            data-lock-horizontal-swipe="true">
             {cmdMatches.map((c) => (
               <button key={c.slash} type="button" className="cmd" onClick={() => pickCommand(c.slash)}>
                 <span className="cmd-ic"><Icon name={c.ic} size={17} /></span>

--- a/web/src/components/MessageBlock.tsx
+++ b/web/src/components/MessageBlock.tsx
@@ -1,11 +1,16 @@
-import { useEffect, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
+import { useEffect, useMemo, useRef, useState } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { parseLocalFileTarget } from "../file-link";
 
 // Streams markdown with a ~50ms throttle: re-parsing react-markdown on every
 // token delta is wasteful, so we hold a "shown" buffer that catches up on a
 // timer while streaming, and snaps to the full text when the block is done.
-export function MessageBlock({ text, done }: { text: string; done: boolean }) {
+export function MessageBlock({ text, done, onOpenFile }: {
+  text: string;
+  done: boolean;
+  onOpenFile?: (path: string, line?: number) => void;
+}) {
   const [shown, setShown] = useState(text);
   const latest = useRef(text);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -28,10 +33,29 @@ export function MessageBlock({ text, done }: { text: string; done: boolean }) {
     if (timer.current) clearTimeout(timer.current);
   }, []);
 
+  const components = useMemo<Components>(() => ({
+    a: ({ href = "", children, title }) => {
+      const file = parseLocalFileTarget(href);
+      if (file && onOpenFile) {
+        const location = file.line ? `${file.path}:${file.line}` : file.path;
+        return <button type="button" className="message-file-link"
+          title={`在 Remote 中打开 ${location}`}
+          onClick={() => onOpenFile(file.path, file.line)}>{children}</button>;
+      }
+      if (/^https?:\/\//i.test(href) || /^mailto:/i.test(href)) {
+        return <a href={href} target="_blank" rel="noopener noreferrer"
+          title={title}>{children}</a>;
+      }
+      if (href.startsWith("#")) return <a href={href} title={title}>{children}</a>;
+      return <span className="message-link-disabled"
+        title="该链接无法在当前会话中打开">{children}</span>;
+    },
+  }), [onOpenFile]);
+
   if (!shown) return null;
   return (
     <div className="prose">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{shown}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>{shown}</ReactMarkdown>
       {!done && <span className="cursor" />}
     </div>
   );

--- a/web/src/components/PanelTabs.tsx
+++ b/web/src/components/PanelTabs.tsx
@@ -1,11 +1,18 @@
 import { Icon } from "../icons";
+import type { Artifact } from "../reducer";
 
-/** Segmented tabs shared by the diff and /btw views (they reuse the right slot). */
-export function PanelTabs({ active, onTab }: { active: "diff" | "btw"; onTab: (v: "diff" | "btw") => void }) {
+/** Segmented tabs shared by the artifact and /btw views (they reuse the right slot). */
+export function PanelTabs({ active, artifactKind = "gitdiff", onTab }: {
+  active: "diff" | "btw";
+  artifactKind?: Artifact["kind"];
+  onTab: (v: "diff" | "btw") => void;
+}) {
+  const markdown = artifactKind === "md";
+  const file = artifactKind === "file";
   return (
     <div className="panel-tabs" role="tablist">
       <button className={"ptab" + (active === "diff" ? " on" : "")} role="tab" aria-selected={active === "diff"}
-        onClick={() => onTab("diff")}><Icon name="edit" size={13} /> 改动</button>
+        onClick={() => onTab("diff")}><Icon name={markdown || file ? "read" : "edit"} size={13} /> {markdown ? "预览" : file ? "文件" : "改动"}</button>
       <button className={"ptab" + (active === "btw" ? " on" : "")} role="tab" aria-selected={active === "btw"}
         onClick={() => onTab("btw")}><Icon name="spark" size={13} /> btw</button>
     </div>

--- a/web/src/components/ProcessTimeline.tsx
+++ b/web/src/components/ProcessTimeline.tsx
@@ -102,18 +102,23 @@ function ProcessActivity({ block }: { block: ProcessBlock }) {
   );
 }
 
-function TimelineItem({ block }: { block: Block }) {
+function TimelineItem({ block, onOpenFile }: {
+  block: Block;
+  onOpenFile?: (path: string, line?: number) => void;
+}) {
   if (block.kind === "process") return <ProcessActivity block={block as ProcessBlock} />;
   const text = block as TextBlock;
   if (text.channel === "thinking") {
     return (
       <details className="process-reasoning">
         <summary><Icon name="spark" size={14} /><span>思考</span><Icon name="chev" size={13} /></summary>
-        <div className="process-reasoning-body"><MessageBlock text={text.text} done={text.done} /></div>
+        <div className="process-reasoning-body"><MessageBlock text={text.text}
+          done={text.done} onOpenFile={onOpenFile} /></div>
       </details>
     );
   }
-  return <div className="process-commentary"><MessageBlock text={text.text} done={text.done} /></div>;
+  return <div className="process-commentary"><MessageBlock text={text.text}
+    done={text.done} onOpenFile={onOpenFile} /></div>;
 }
 
 type TimelineRow =
@@ -134,11 +139,12 @@ function groupTimelineRows(items: Block[]): TimelineRow[] {
   return rows;
 }
 
-export function ProcessTimeline({ blocks, done, durationMs, startTs }: {
+export function ProcessTimeline({ blocks, done, durationMs, startTs, onOpenFile }: {
   blocks: Block[];
   done: boolean;
   durationMs?: number;
   startTs?: number;
+  onOpenFile?: (path: string, line?: number) => void;
 }) {
   const items = processBlocks(blocks);
   const complete = done && !hasActiveProcess(items);
@@ -174,7 +180,7 @@ export function ProcessTimeline({ blocks, done, durationMs, startTs }: {
           ? <ToolGroup key={`tools-${row.tools[0].tool_use_id}`} tools={row.tools} />
           : <TimelineItem key={row.block.kind === "text"
               ? `text-${row.block.message_id}` : `process-${row.block.item_id}`}
-              block={row.block} />
+              block={row.block} onOpenFile={onOpenFile} />
       ))}</div>}
     </section>
   );

--- a/web/src/components/SessionsSidebar.tsx
+++ b/web/src/components/SessionsSidebar.tsx
@@ -250,8 +250,8 @@ export function SessionsSidebar({ open, sessions, liveStates, activeSessionId, o
     <>
       <div className={"scrim-side" + (open ? " show" : "")} onClick={onClose} />
       <aside className={"sessions" + (open ? " show" : "")}>
-        {/* fixed-width inner so the desktop column can animate its width (0→352)
-            as a slide-reveal without the content reflowing/squishing. */}
+        {/* Keep sidebar contents stable while the desktop shell and panel slide
+            in tandem; mobile uses the same panel transform as an overlay. */}
         <div className="s-inner">
           <div className="s-head">
             <div className="brand" onClick={onClose}>

--- a/web/src/data.ts
+++ b/web/src/data.ts
@@ -28,6 +28,7 @@ export const COMMANDS: Command[] = [
   { g: "会话" },
   { slash: "goal", name: "目标", ds: "/goal 查看 · /goal <目标> 设置 · /goal clear 清除", ic: "verify" },
   { slash: "btw", name: "侧边对话 (btw)", ds: "基于当前会话开一个临时 fork 侧聊,不影响主线", ic: "spark" },
+  { slash: "preview", name: "预览文件", ds: "/preview <路径> 打开 Markdown 或 UTF-8 源文件", ic: "read" },
   { slash: "clear", name: "清空会话", ds: "开新会话，清空上下文", ic: "close" },
   { slash: "context", name: "上下文用量", ds: "查看 token 占用", ic: "cpu" },
 ];
@@ -177,7 +178,7 @@ const CMD_LIST: Cmd[] = COMMANDS.filter(isCmd) as Cmd[];
 // Slashes handled locally by the web client (never forwarded to cc as a prompt).
 // Everything else (code-review, verify, run, deep-research, …) is a cc skill and
 // is forwarded verbatim so cc's own slash-command layer runs it.
-export const CLIENT_SLASHES = new Set(["model", "plan", "normal", "permissions", "clear", "context", "goal", "btw"]);
+export const CLIENT_SLASHES = new Set(["model", "plan", "normal", "permissions", "clear", "context", "goal", "btw", "preview"]);
 
 // Codex engine command palette — its REAL slash commands (verified against the
 // codex binary's own "get started" hint: /init /status /permissions /model /review).
@@ -202,12 +203,13 @@ export const CODEX_COMMANDS: Command[] = [
   { g: "会话" },
   { slash: "goal", name: "目标", ds: "/goal 查看 · /goal <目标> 设置 · /goal clear 清除", ic: "verify" },
   { slash: "btw", name: "侧边对话 (btw)", ds: "基于当前会话开一个临时 fork 侧聊,不影响主线", ic: "spark" },
+  { slash: "preview", name: "预览文件", ds: "/preview <路径> 打开 Markdown 或 UTF-8 源文件", ic: "read" },
   { slash: "status", name: "完整状态", ds: "线程 · 配置 · 账户 · 限额 · token", ic: "cpu" },
   { slash: "context", name: "上下文用量", ds: "查看 token 占用与容量", ic: "cpu" },
   { slash: "clear", name: "新会话", ds: "开新 codex 会话", ic: "close" },
 ];
 const CODEX_CMD_LIST: Cmd[] = CODEX_COMMANDS.filter(isCmd) as Cmd[];
-export const CODEX_CLIENT_SLASHES = new Set(["model", "plan", "normal", "clear", "context", "status", "permissions", "fast", "goal", "btw"]);
+export const CODEX_CLIENT_SLASHES = new Set(["model", "plan", "normal", "clear", "context", "status", "permissions", "fast", "goal", "btw", "preview"]);
 export const commandsFor = (engine?: string): Command[] => (engine === "codex" ? CODEX_COMMANDS : COMMANDS);
 export const clientSlashesFor = (engine?: string): Set<string> => (engine === "codex" ? CODEX_CLIENT_SLASHES : CLIENT_SLASHES);
 // codex slash -> the prompt actually sent to codex (agentic; no TUI slash layer).

--- a/web/src/file-link.ts
+++ b/web/src/file-link.ts
@@ -1,0 +1,65 @@
+export interface LocalFileTarget {
+  path: string;
+  line?: number;
+  column?: number;
+}
+
+const SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+const WINDOWS_PATH = /^[A-Za-z]:[\\/]/;
+const MAX_SOURCE_POSITION = 10_000_000;
+
+function sourcePosition(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0
+    && parsed <= MAX_SOURCE_POSITION ? parsed : undefined;
+}
+
+/** Parse links emitted by Claude/Codex such as `/cwd/file.py:731` or `#L731`.
+ * Network URLs and in-document anchors deliberately remain normal links. */
+export function parseLocalFileTarget(rawHref: string): LocalFileTarget | null {
+  let value = rawHref.trim();
+  if (!value || value.startsWith("#") || value.startsWith("//")) return null;
+
+  if (/^file:\/\//i.test(value)) {
+    try {
+      const url = new URL(value);
+      if (url.hostname && url.hostname !== "localhost") return null;
+      value = `${url.pathname}${url.hash}`;
+    } catch {
+      return null;
+    }
+  } else if (SCHEME.test(value) && !WINDOWS_PATH.test(value)) {
+    return null;
+  }
+
+  let line: number | undefined;
+  let column: number | undefined;
+  const hashAt = value.indexOf("#");
+  if (hashAt >= 0) {
+    const fragment = value.slice(hashAt + 1);
+    value = value.slice(0, hashAt);
+    const match = /^(?:L|line-)?(\d+)(?:[-:]?C?(\d+))?/i.exec(fragment);
+    line = sourcePosition(match?.[1]);
+    column = sourcePosition(match?.[2]);
+  }
+
+  value = value.split("?", 1)[0];
+  if (!line) {
+    const suffix = /:(\d+)(?::(\d+))?$/.exec(value);
+    const parsedLine = sourcePosition(suffix?.[1]);
+    if (suffix && parsedLine) {
+      value = value.slice(0, suffix.index);
+      line = parsedLine;
+      column = sourcePosition(suffix[2]);
+    }
+  }
+
+  try {
+    value = decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+  if (!value || value.includes("\0")) return null;
+  return { path: value, line, column };
+}

--- a/web/src/icons.tsx
+++ b/web/src/icons.tsx
@@ -38,6 +38,7 @@ const PATHS: Record<string, string> = {
   archive: '<rect x="3" y="4" width="18" height="4" rx="1.5"/><path d="M5 8v9a2 2 0 002 2h10a2 2 0 002-2V8"/><path d="M10 12h4"/>',
   branch: '<circle cx="6" cy="5" r="2"/><circle cx="18" cy="7" r="2"/><circle cx="6" cy="19" r="2"/><path d="M6 7v10M8 8.5c4.5 0 5.5-1.5 8-1.5"/>',
   copy: '<rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 012-2h10"/>',
+  refresh: '<path d="M20 7v5h-5"/><path d="M19 12a7.5 7.5 0 10.4 4.7"/>',
   // model-tier glyphs (one per model, so the picker rows are distinct)
   // reasoning-effort gauges: same dial, needle sweeps left(低)->right(最大)
   gauge1: '<path d="M4 16a8 8 0 0116 0"/><path d="M12 16L7.5 12.6"/><circle cx="12" cy="16" r="1.3"/>',

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -240,6 +240,9 @@ body{
 .prose pre code{ background:none; border:none; padding:0; font-size:13px; }
 .prose ul,.prose ol{ margin:8px 0; padding-left:22px; } .prose li{ margin:3px 0; }
 .prose a{ color:var(--accent-ink); text-decoration:none; border-bottom:1px solid var(--accent-line); }
+.message-file-link{ display:inline; padding:0; border:0; border-bottom:1px solid var(--accent-line); border-radius:0; background:none; color:var(--accent-ink); font:inherit; cursor:pointer; }
+.message-file-link:hover{ color:var(--accent); border-bottom-color:var(--accent); }
+.message-link-disabled{ color:var(--dim); border-bottom:1px dotted var(--faint); cursor:not-allowed; }
 .prose blockquote{ border-left:3px solid var(--accent-line); margin:8px 0; padding:2px 12px; color:var(--dim); }
 .prose img{ max-width:100%; height:auto; }
 .prose table{ display:table; width:100%; border-collapse:collapse; margin:10px 0; font-size:13.5px; }
@@ -388,6 +391,8 @@ body{
 .turn-file-chip{ display:inline-flex; align-items:center; gap:6px; background:var(--surface); border:1px solid var(--border); border-radius:8px; padding:5px 9px; font-family:var(--mono); font-size:11.5px; color:var(--dim); }
 .turn-file-chip:hover{ background:var(--accent-weak); color:var(--accent-ink); border-color:var(--accent-line); }
 .turn-file-chip svg{ width:13px; height:13px; }
+.turn-file-chip.markdown{ color:var(--accent-ink); border-color:var(--accent-line); }
+.turn-file-action{ font:10px/1 var(--sans); color:var(--faint); padding-left:2px; }
 /* floating rounded panel (was edge-docked + sharp), slides in from the right */
 .artifact-panel{ position:fixed; top:14px; right:14px; bottom:14px; width:var(--panel-w); z-index:35; background:var(--surface); border:1px solid var(--border-strong); border-radius:var(--r-panel); box-shadow:var(--shadow-lg); display:flex; flex-direction:column; overflow:hidden; animation:panel-in .24s var(--ease); }
 @keyframes panel-in{ from{ opacity:0; transform:translateX(18px) } to{ opacity:1; transform:none } }
@@ -398,7 +403,39 @@ body{
 .artifact-body{ flex:1; overflow-y:auto; -webkit-overflow-scrolling:touch; padding:14px 16px; }
 .artifact-body .diff-pre{ margin:0; }
 .artifact-body .prose{ font-size:14px; }
-@media (max-width:980px){ .artifact-panel{ top:auto; left:10px; right:10px; bottom:calc(10px + var(--keyboard-inset,0px)); width:auto; max-height:min(82vh,calc(var(--app-height,100dvh) - 20px)); animation:panel-in-m .24s var(--ease); } }
+.preview-modes{ display:flex; gap:2px; flex:none; padding:2px; border:1px solid var(--border); border-radius:8px; background:var(--raised); }
+.preview-modes button{ padding:4px 8px; border-radius:6px; color:var(--dim); font-size:11px; }
+.preview-modes button.on{ color:var(--accent-ink); background:var(--surface); box-shadow:var(--shadow-sm); }
+.preview-error,.preview-truncated{ display:flex; align-items:center; gap:8px; border-radius:9px; padding:10px 12px; font-size:12.5px; line-height:1.5; }
+.preview-error{ color:var(--danger); background:var(--danger-weak); border:1px solid color-mix(in srgb,var(--danger) 24%,transparent); }
+.preview-truncated{ margin-bottom:12px; color:var(--dim); background:var(--raised); border:1px solid var(--border); }
+.markdown-source{ margin:0; min-height:100%; white-space:pre-wrap; overflow-wrap:anywhere; font:12.5px/1.65 var(--mono); color:var(--text); tab-size:2; }
+.source-page-nav{ position:sticky; top:0; z-index:2; display:flex; align-items:center; justify-content:center; gap:10px; margin:0 0 8px; padding:7px 9px; border:1px solid var(--border); border-radius:9px; background:var(--surface); box-shadow:var(--shadow-sm); }
+.source-page-nav span{ color:var(--dim); font:11px/1.4 var(--mono); }
+.source-page-nav button{ padding:4px 8px; border-radius:7px; color:var(--accent-ink); background:var(--accent-weak); font-size:11px; }
+.source-page-nav button:disabled{ color:var(--faint); background:var(--raised); cursor:default; }
+.source-file{ min-width:100%; width:max-content; border:1px solid var(--border); border-radius:9px; overflow:hidden; background:var(--raised); font:12px/1.6 var(--mono); tab-size:2; }
+.source-line{ display:grid; grid-template-columns:5.5ch minmax(0,1fr); min-height:1.6em; }
+.source-line-no{ padding:0 9px 0 5px; color:var(--faint); text-align:right; user-select:none; border-right:1px solid var(--border); background:var(--bg); }
+.source-line code{ display:block; padding:0 11px; white-space:pre; color:var(--text); }
+.source-line.focused{ background:var(--accent-weak); box-shadow:inset 3px 0 var(--accent); }
+.source-line.focused .source-line-no{ color:var(--accent-ink); background:var(--accent-weak); }
+.markdown-preview{ max-width:780px; margin:0 auto; overflow-wrap:anywhere; }
+.markdown-preview img{ display:block; max-height:min(66vh,720px); margin:14px auto; border-radius:9px; object-fit:contain; }
+.markdown-preview pre{ overflow-x:auto; }
+.markdown-preview table{ display:block; max-width:100%; overflow-x:auto; }
+.preview-image-loading,.preview-image-error{ display:inline-flex; align-items:center; gap:7px; margin:5px 0; border-radius:8px; padding:7px 9px; font-size:12px; }
+.preview-image-loading{ color:var(--dim); background:var(--raised); border:1px solid var(--border); }
+.preview-image-error{ color:var(--danger); background:var(--danger-weak); }
+.preview-link-disabled{ color:var(--dim); border-bottom:1px dotted var(--faint); cursor:not-allowed; }
+@media (max-width:980px){
+  .artifact-panel{ top:auto; left:10px; right:10px; bottom:calc(10px + var(--keyboard-inset,0px)); width:auto; max-height:min(82vh,calc(var(--app-height,100dvh) - 20px)); animation:panel-in-m .24s var(--ease); }
+  .artifact-head{ gap:7px; padding-inline:10px; }
+  .artifact-path{ display:none; }
+  .preview-modes{ margin-left:auto; }
+  .artifact-body{ padding:13px 14px; }
+  .markdown-preview{ margin:0; }
+}
 
 /* /btw ephemeral side-fork panel (mini chat over a forked session) */
 .btw-panel{ position:fixed; top:14px; right:14px; bottom:14px; width:var(--panel-w); z-index:36; background:var(--surface); border:1px solid var(--border-strong); border-radius:var(--r-panel); box-shadow:var(--shadow-lg); display:flex; flex-direction:column; overflow:hidden; animation:panel-in .24s var(--ease); }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -404,16 +404,24 @@ html.panel-resizing,html.panel-resizing *{ cursor:col-resize !important; user-se
 .artifact-head{ display:flex; align-items:center; gap:10px; min-width:0; padding:12px 14px; border-bottom:1px solid var(--border); flex:none; padding-top:max(12px, env(safe-area-inset-top)); }
 .artifact-title{ min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-weight:600; font-size:14px; flex:0 1 auto; }
 .artifact-path{ font-family:var(--mono); font-size:11px; color:var(--dim); flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-.artifact-body{ flex:1; min-width:0; max-width:100%; overflow-y:auto; overflow-x:hidden; overscroll-behavior:contain; touch-action:pan-y; -webkit-overflow-scrolling:touch; padding:14px 16px; }
+.artifact-body{ flex:1; min-width:0; min-height:0; max-width:100%; overflow-y:auto; overflow-x:hidden; overscroll-behavior:contain; touch-action:pan-y; -webkit-overflow-scrolling:touch; padding:14px 16px; }
 .artifact-body .diff-pre{ margin:0; }
 .artifact-body .prose{ font-size:14px; }
 .preview-modes{ display:flex; gap:2px; flex:none; padding:2px; border:1px solid var(--border); border-radius:8px; background:var(--raised); }
 .preview-modes button{ padding:4px 8px; border-radius:6px; color:var(--dim); font-size:11px; }
 .preview-modes button.on{ color:var(--accent-ink); background:var(--surface); box-shadow:var(--shadow-sm); }
+.markdown-save{ display:inline-flex; align-items:center; gap:5px; flex:none; padding:6px 9px; border:1px solid var(--accent-line); border-radius:8px; color:var(--accent-ink); background:var(--accent-weak); font-size:11px; font-weight:650; }
+.markdown-save:disabled{ color:var(--faint); border-color:var(--border); background:var(--raised); cursor:default; }
+.markdown-save-state{ flex:none; font-size:11px; color:var(--dim); }
+.markdown-save-state.ok{ color:var(--success); }
+.markdown-save-error{ margin:0 0 12px; border:1px solid color-mix(in srgb,var(--danger) 24%,transparent); border-radius:9px; padding:9px 11px; color:var(--danger); background:var(--danger-weak); font-size:12px; line-height:1.5; }
+.markdown-save-error.conflict{ color:var(--warn); border-color:color-mix(in srgb,var(--warn) 30%,transparent); background:color-mix(in srgb,var(--warn) 10%,transparent); }
 .preview-error,.preview-truncated{ display:flex; align-items:center; gap:8px; border-radius:9px; padding:10px 12px; font-size:12.5px; line-height:1.5; }
 .preview-error{ color:var(--danger); background:var(--danger-weak); border:1px solid color-mix(in srgb,var(--danger) 24%,transparent); }
 .preview-truncated{ margin-bottom:12px; color:var(--dim); background:var(--raised); border:1px solid var(--border); }
-.markdown-source{ margin:0; min-height:100%; white-space:pre-wrap; overflow-wrap:anywhere; font:12.5px/1.65 var(--mono); color:var(--text); tab-size:2; }
+.markdown-editor{ display:block; box-sizing:border-box; width:100%; min-height:calc(100% - 2px); resize:none; border:1px solid var(--border); border-radius:9px; padding:12px 14px; background:var(--raised); color:var(--text); font:12.5px/1.65 var(--mono); tab-size:2; white-space:pre-wrap; overflow-wrap:anywhere; }
+.markdown-editor:focus{ outline:none; border-color:var(--accent-line); box-shadow:0 0 0 2px var(--accent-weak); }
+.markdown-editor:read-only{ color:var(--dim); cursor:not-allowed; }
 .source-page-nav{ position:sticky; top:0; z-index:2; display:flex; align-items:center; justify-content:center; gap:10px; margin:0 0 8px; padding:7px 9px; border:1px solid var(--border); border-radius:9px; background:var(--surface); box-shadow:var(--shadow-sm); }
 .source-page-nav span{ color:var(--dim); font:11px/1.4 var(--mono); }
 .source-page-nav button{ padding:4px 8px; border-radius:7px; color:var(--accent-ink); background:var(--accent-weak); font-size:11px; }
@@ -440,6 +448,8 @@ html.panel-resizing,html.panel-resizing *{ cursor:col-resize !important; user-se
   .preview-modes{ margin-left:auto; }
   .artifact-body{ padding:13px 14px; }
   .markdown-preview{ margin:0; }
+  .markdown-editor{ min-height:56vh; font-size:16px; }
+  .markdown-save-state{ display:none; }
 }
 @media (min-width:981px){ .panel-resizer{ display:block; } }
 
@@ -792,13 +802,15 @@ html.panel-resizing,html.panel-resizing *{ cursor:col-resize !important; user-se
 .sgroup-toggle .label{ font-size:11.5px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; color:var(--faint); flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .sgroup-toggle .count{ font-size:10.5px; color:var(--faint); font-weight:500; flex:none; }
 @media (min-width:980px){
-  /* Keep the desktop track switch discrete. Chromium can leave an interpolated
-     0px/1fr grid transition stuck at its first frame, making the visible
-     sidebar inaccessible even though React has applied sidebar-open. */
-  .shell{ display:grid; grid-template-columns:0px 1fr; height:var(--app-height,100dvh); }
-  .shell.sidebar-open{ grid-template-columns:352px 1fr; }
-  .sessions{ position:static; transform:none; width:auto; height:var(--app-height,100dvh); overflow:hidden; }
-  .s-inner{ width:352px; }
+  /* Animate two ordinary lengths instead of grid-template-columns. Chromium
+     can strand an interpolated 0px/1fr grid track; a fixed sidebar transform
+     plus a matching pane offset keeps the slide smooth without that failure. */
+  .shell{ display:block; height:var(--app-height,100dvh); }
+  .pane{ width:100%; margin-left:0;
+    transition:margin-left .3s var(--ease),width .3s var(--ease),padding-right .26s var(--ease); }
+  .shell.sidebar-open .pane{ width:calc(100% - 352px); margin-left:352px; }
+  .sessions{ position:fixed; width:352px; height:var(--app-height,100dvh); overflow:hidden; }
+  .s-inner{ width:100%; }
   .shell.sidebar-open .sessions{ border-right:1px solid var(--divider); }
   .scrim-side{ display:none; }
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -397,10 +397,14 @@ body{
 .artifact-panel{ position:fixed; top:14px; right:14px; bottom:14px; width:var(--panel-w); z-index:35; background:var(--surface); border:1px solid var(--border-strong); border-radius:var(--r-panel); box-shadow:var(--shadow-lg); display:flex; flex-direction:column; overflow:hidden; animation:panel-in .24s var(--ease); }
 @keyframes panel-in{ from{ opacity:0; transform:translateX(18px) } to{ opacity:1; transform:none } }
 @keyframes panel-in-m{ from{ opacity:0; transform:translateY(22px) } to{ opacity:1; transform:none } }
-.artifact-head{ display:flex; align-items:center; gap:10px; padding:12px 14px; border-bottom:1px solid var(--border); flex:none; padding-top:max(12px, env(safe-area-inset-top)); }
-.artifact-title{ font-weight:600; font-size:14px; flex:none; }
+.panel-resizer{ display:none; position:absolute; z-index:5; top:0; bottom:0; left:0; width:12px; padding:0; cursor:col-resize; touch-action:none; }
+.panel-resizer::after{ content:""; position:absolute; top:50%; left:3px; width:3px; height:48px; border-radius:3px; background:var(--border-strong); opacity:0; transform:translateY(-50%); transition:opacity .14s,background .14s; }
+.panel-resizer:hover::after,.panel-resizer:focus-visible::after{ opacity:1; background:var(--accent); }
+html.panel-resizing,html.panel-resizing *{ cursor:col-resize !important; user-select:none !important; }
+.artifact-head{ display:flex; align-items:center; gap:10px; min-width:0; padding:12px 14px; border-bottom:1px solid var(--border); flex:none; padding-top:max(12px, env(safe-area-inset-top)); }
+.artifact-title{ min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-weight:600; font-size:14px; flex:0 1 auto; }
 .artifact-path{ font-family:var(--mono); font-size:11px; color:var(--dim); flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-.artifact-body{ flex:1; overflow-y:auto; -webkit-overflow-scrolling:touch; padding:14px 16px; }
+.artifact-body{ flex:1; min-width:0; max-width:100%; overflow-y:auto; overflow-x:hidden; overscroll-behavior:contain; touch-action:pan-y; -webkit-overflow-scrolling:touch; padding:14px 16px; }
 .artifact-body .diff-pre{ margin:0; }
 .artifact-body .prose{ font-size:14px; }
 .preview-modes{ display:flex; gap:2px; flex:none; padding:2px; border:1px solid var(--border); border-radius:8px; background:var(--raised); }
@@ -414,28 +418,30 @@ body{
 .source-page-nav span{ color:var(--dim); font:11px/1.4 var(--mono); }
 .source-page-nav button{ padding:4px 8px; border-radius:7px; color:var(--accent-ink); background:var(--accent-weak); font-size:11px; }
 .source-page-nav button:disabled{ color:var(--faint); background:var(--raised); cursor:default; }
-.source-file{ min-width:100%; width:max-content; border:1px solid var(--border); border-radius:9px; overflow:hidden; background:var(--raised); font:12px/1.6 var(--mono); tab-size:2; }
+.source-file{ min-width:0; width:100%; border:1px solid var(--border); border-radius:9px; overflow:hidden; background:var(--raised); font:12px/1.6 var(--mono); tab-size:2; }
 .source-line{ display:grid; grid-template-columns:5.5ch minmax(0,1fr); min-height:1.6em; }
 .source-line-no{ padding:0 9px 0 5px; color:var(--faint); text-align:right; user-select:none; border-right:1px solid var(--border); background:var(--bg); }
-.source-line code{ display:block; padding:0 11px; white-space:pre; color:var(--text); }
+.source-line code{ display:block; min-width:0; padding:0 11px; white-space:pre-wrap; overflow-wrap:anywhere; word-break:break-word; color:var(--text); }
 .source-line.focused{ background:var(--accent-weak); box-shadow:inset 3px 0 var(--accent); }
 .source-line.focused .source-line-no{ color:var(--accent-ink); background:var(--accent-weak); }
 .markdown-preview{ max-width:780px; margin:0 auto; overflow-wrap:anywhere; }
 .markdown-preview img{ display:block; max-height:min(66vh,720px); margin:14px auto; border-radius:9px; object-fit:contain; }
-.markdown-preview pre{ overflow-x:auto; }
-.markdown-preview table{ display:block; max-width:100%; overflow-x:auto; }
+.markdown-preview pre{ white-space:pre-wrap; overflow-wrap:anywhere; word-break:break-word; overflow-x:hidden; }
+.markdown-preview table{ display:table; width:100%; max-width:100%; table-layout:fixed; }
+.markdown-preview th,.markdown-preview td{ overflow-wrap:anywhere; word-break:break-word; }
 .preview-image-loading,.preview-image-error{ display:inline-flex; align-items:center; gap:7px; margin:5px 0; border-radius:8px; padding:7px 9px; font-size:12px; }
 .preview-image-loading{ color:var(--dim); background:var(--raised); border:1px solid var(--border); }
 .preview-image-error{ color:var(--danger); background:var(--danger-weak); }
 .preview-link-disabled{ color:var(--dim); border-bottom:1px dotted var(--faint); cursor:not-allowed; }
 @media (max-width:980px){
-  .artifact-panel{ top:auto; left:10px; right:10px; bottom:calc(10px + var(--keyboard-inset,0px)); width:auto; max-height:min(82vh,calc(var(--app-height,100dvh) - 20px)); animation:panel-in-m .24s var(--ease); }
+  .artifact-panel{ top:auto; left:10px; right:10px; bottom:calc(10px + var(--keyboard-inset,0px)); width:auto; max-width:calc(100vw - 20px); max-height:min(82vh,calc(var(--app-height,100dvh) - 20px)); animation:panel-in-m .24s var(--ease); }
   .artifact-head{ gap:7px; padding-inline:10px; }
   .artifact-path{ display:none; }
   .preview-modes{ margin-left:auto; }
   .artifact-body{ padding:13px 14px; }
   .markdown-preview{ margin:0; }
 }
+@media (min-width:981px){ .panel-resizer{ display:block; } }
 
 /* /btw ephemeral side-fork panel (mini chat over a forked session) */
 .btw-panel{ position:fixed; top:14px; right:14px; bottom:14px; width:var(--panel-w); z-index:36; background:var(--surface); border:1px solid var(--border-strong); border-radius:var(--r-panel); box-shadow:var(--shadow-lg); display:flex; flex-direction:column; overflow:hidden; animation:panel-in .24s var(--ease); }
@@ -490,9 +496,9 @@ body{
 /* Inline "/" command palette: a popover ABOVE the composer (not a modal sheet),
    so the composer textarea stays visible + typeable while it filters live. */
 .cmd-pop{ position:absolute; left:0; right:0; bottom:calc(100% + 8px); z-index:20;
-  max-height:min(48vh,340px); overflow-y:auto; background:var(--surface);
+  max-height:min(48vh,340px); overflow-y:auto; overflow-x:hidden; background:var(--surface);
   border:1px solid var(--border); border-radius:18px; box-shadow:var(--shadow-lg); padding:6px;
-  animation:popin .16s var(--ease); }
+  animation:popin .16s var(--ease); overscroll-behavior:contain; touch-action:pan-y; }
 @keyframes popin{ from{ opacity:0; transform:translateY(6px) } to{ opacity:1; transform:none } }
 .composer-notice{ position:absolute; left:50%; transform:translateX(-50%); bottom:calc(100% + 10px);
   z-index:22; width:max-content; max-width:92%; background:var(--accent); color:#fff;
@@ -667,7 +673,7 @@ body{
 .qa-opt-ds{ font-size:12.5px; color:var(--dim); }
 .cmd-group{ font-size:11px; font-weight:600; letter-spacing:.06em; text-transform:uppercase;
   color:var(--faint); padding:12px 12px 5px; }
-.cmd{ display:flex; align-items:center; gap:12px; width:100%; text-align:left;
+.cmd{ display:flex; align-items:center; gap:12px; width:100%; min-width:0; overflow:hidden; text-align:left;
   padding:10px 12px; border-radius:12px; transition:.12s; }
 .cmd.sel{ background:var(--accent-weak); }
 @media (hover:hover){ .cmd:hover{ background:var(--accent-weak); } }

--- a/web/src/preview-path.ts
+++ b/web/src/preview-path.ts
@@ -1,0 +1,46 @@
+export type PreviewTarget =
+  | { kind: "local"; value: string }
+  | { kind: "external"; value: string }
+  | { kind: "anchor"; value: string }
+  | { kind: "blocked"; value: "" };
+
+const SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+
+/** Resolve a Markdown link/image without letting browser URL rules escape cwd. */
+export function classifyPreviewTarget(markdownPath: string, rawTarget: string): PreviewTarget {
+  const target = rawTarget.trim();
+  if (!target) return { kind: "blocked", value: "" };
+  if (target.startsWith("#")) return { kind: "anchor", value: target };
+  if (/^https?:/i.test(target)) return { kind: "external", value: target };
+  if (target.startsWith("//") || SCHEME.test(target) || target.startsWith("/")) {
+    return { kind: "blocked", value: "" };
+  }
+
+  const pathPart = target.split(/[?#]/, 1)[0];
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(pathPart);
+  } catch {
+    return { kind: "blocked", value: "" };
+  }
+  if (!decoded || decoded.includes("\0")) return { kind: "blocked", value: "" };
+
+  const base = markdownPath.split("/").slice(0, -1);
+  const resolved: string[] = [];
+  for (const part of [...base, ...decoded.replace(/\\/g, "/").split("/")]) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      if (!resolved.length) return { kind: "blocked", value: "" };
+      resolved.pop();
+      continue;
+    }
+    resolved.push(part);
+  }
+  return resolved.length
+    ? { kind: "local", value: resolved.join("/") }
+    : { kind: "blocked", value: "" };
+}
+
+export function isMarkdownPath(path: string): boolean {
+  return /\.(?:md|markdown)$/i.test(path.split(/[?#]/, 1)[0]);
+}

--- a/web/src/protocol.ts
+++ b/web/src/protocol.ts
@@ -217,6 +217,10 @@ export interface Perm extends Base { type: "perm"; mode: string }
 export interface GetContext extends Base { type: "get_context" }
 export interface GetDiff extends Base { type: "get_diff"; file: string; theme?: DiffTheme }
 export interface DiffReport extends Base { type: "diff_report"; file: string; diff: string }
+export interface GetFilePreview extends Base { type: "get_file_preview"; path: string; request_id: string }
+export interface FilePreview extends Base { type: "file_preview"; path: string; request_id: string; format: "markdown" | "text"; content: string; size: number; truncated: boolean; mtime_ns: number; error?: string | null }
+export interface GetPreviewAsset extends Base { type: "get_preview_asset"; path: string; preview_id: string; request_id: string }
+export interface PreviewAsset extends Base { type: "preview_asset"; path: string; preview_id: string; request_id: string; media_type?: "image/png" | "image/jpeg" | "image/gif" | "image/webp" | "image/avif" | null; data?: string | null; error?: string | null }
 // On-demand bulk history: fetched once when a session is opened (like a web
 // chat's GET /conversation) instead of replaying the ring buffer on every hello.
 export interface GetHistory extends Base { type: "get_history"; session_id: string; client_id?: string | null; cwd?: string | null; before?: string | null; limit?: number | null }
@@ -338,7 +342,7 @@ export interface ContextReport extends Base {
 }
 
 export type ServerEvent =
-  | Pong | CommandAck | ReplayStart | ReplayEnd | Snapshot | StateEvent | Model | Effort | Fast | CollaborationMode | BtwOpened | Perm | ContextReport | DiffReport | History | Models | TakeoverState
+  | Pong | CommandAck | ReplayStart | ReplayEnd | Snapshot | StateEvent | Model | Effort | Fast | CollaborationMode | BtwOpened | Perm | ContextReport | DiffReport | FilePreview | PreviewAsset | History | Models | TakeoverState
   | AskUser | GoalState | StatusReport | Notice | RateLimitUpdate
   | SessionList | SessionFocus | SessionRekey | SessionForked
   | DirList
@@ -346,7 +350,7 @@ export type ServerEvent =
   | ProcessEvent | TurnPlan | TurnDiff
   | TurnEnd | ErrorMsg | WrapperDisconnected | WrapperReconnected | Hello;
 
-export const PROTOCOL_VERSION = 8;
+export const PROTOCOL_VERSION = 9;
 
 /** Local storage is user-controlled and may contain stale values from older
  * builds. Normalize before a value reaches a strict Pydantic command frame. */

--- a/web/src/protocol.ts
+++ b/web/src/protocol.ts
@@ -218,7 +218,9 @@ export interface GetContext extends Base { type: "get_context" }
 export interface GetDiff extends Base { type: "get_diff"; file: string; theme?: DiffTheme }
 export interface DiffReport extends Base { type: "diff_report"; file: string; diff: string }
 export interface GetFilePreview extends Base { type: "get_file_preview"; path: string; request_id: string }
-export interface FilePreview extends Base { type: "file_preview"; path: string; request_id: string; format: "markdown" | "text"; content: string; size: number; truncated: boolean; mtime_ns: number; error?: string | null }
+export interface FilePreview extends Base { type: "file_preview"; path: string; request_id: string; format: "markdown" | "text"; content: string; size: number; truncated: boolean; mtime_ns: string; revision?: string | null; error?: string | null }
+export interface SaveMarkdown extends Base { type: "save_markdown"; path: string; request_id: string; content: string; expected_size: number; expected_mtime_ns: string; expected_revision: string }
+export interface FileSaveResult extends Base { type: "file_save_result"; path: string; request_id: string; status: "saved" | "conflict" | "error"; size: number; mtime_ns: string; revision?: string | null; error?: string | null }
 export interface GetPreviewAsset extends Base { type: "get_preview_asset"; path: string; preview_id: string; request_id: string }
 export interface PreviewAsset extends Base { type: "preview_asset"; path: string; preview_id: string; request_id: string; media_type?: "image/png" | "image/jpeg" | "image/gif" | "image/webp" | "image/avif" | null; data?: string | null; error?: string | null }
 // On-demand bulk history: fetched once when a session is opened (like a web
@@ -342,7 +344,7 @@ export interface ContextReport extends Base {
 }
 
 export type ServerEvent =
-  | Pong | CommandAck | ReplayStart | ReplayEnd | Snapshot | StateEvent | Model | Effort | Fast | CollaborationMode | BtwOpened | Perm | ContextReport | DiffReport | FilePreview | PreviewAsset | History | Models | TakeoverState
+  | Pong | CommandAck | ReplayStart | ReplayEnd | Snapshot | StateEvent | Model | Effort | Fast | CollaborationMode | BtwOpened | Perm | ContextReport | DiffReport | FilePreview | FileSaveResult | PreviewAsset | History | Models | TakeoverState
   | AskUser | GoalState | StatusReport | Notice | RateLimitUpdate
   | SessionList | SessionFocus | SessionRekey | SessionForked
   | DirList
@@ -350,7 +352,7 @@ export type ServerEvent =
   | ProcessEvent | TurnPlan | TurnDiff
   | TurnEnd | ErrorMsg | WrapperDisconnected | WrapperReconnected | Hello;
 
-export const PROTOCOL_VERSION = 9;
+export const PROTOCOL_VERSION = 10;
 
 /** Local storage is user-controlled and may contain stale values from older
  * builds. Normalize before a value reaches a strict Pydantic command frame. */

--- a/web/src/reducer.ts
+++ b/web/src/reducer.ts
@@ -123,7 +123,28 @@ export interface PendingQuery {
   files?: QueryFile[];
 }
 
-export interface Artifact { file: string; kind: "diff" | "md" | "gitdiff"; sid?: string | null; diff?: DiffLine[]; content?: string; sections?: GitDiffSection[]; loading?: boolean; }
+export interface PreviewAssetState {
+  mediaType?: string;
+  data?: string;
+  error?: string;
+}
+
+export interface Artifact {
+  file: string;
+  kind: "diff" | "md" | "file" | "gitdiff";
+  sid?: string | null;
+  requestId?: string;
+  diff?: DiffLine[];
+  content?: string;
+  sections?: GitDiffSection[];
+  loading?: boolean;
+  size?: number;
+  truncated?: boolean;
+  mtimeNs?: number;
+  line?: number;
+  error?: string;
+  assets?: Record<string, PreviewAssetState>;
+}
 
 export interface SessionRuntime {
   turns: Turn[];
@@ -229,6 +250,7 @@ export type Action =
   | { type: "set_turns"; sid: string; turns: Turn[] }
   | { type: "set_artifact"; artifact: Artifact }
   | { type: "open_artifact_loading"; file: string; sid: string | null }
+  | { type: "open_file_loading"; file: string; sid: string | null; requestId: string; kind: "md" | "file"; line?: number }
   | { type: "clear_artifact" }
   | { type: "clear_btw" }
   | { type: "focus_session"; sid: string }
@@ -685,6 +707,11 @@ export function reduce(state: AppState, action: Action): AppState {
       // optimistic: show the diff panel (with a spinner) instantly on click; the
       // diff_report event replaces it with the real sections when it arrives.
       return { ...state, artifact: { file: action.file, sid: action.sid, kind: "gitdiff", sections: [], loading: true } };
+    case "open_file_loading":
+      return { ...state, artifact: {
+        file: action.file, sid: action.sid, requestId: action.requestId,
+        kind: action.kind, line: action.line, content: "", assets: {}, loading: true,
+      } };
     case "clear_artifact":
       return { ...state, artifact: null };
     case "clear_btw": {
@@ -964,6 +991,38 @@ function reduceEvent(
           || state.artifact.sid !== (e.sid ?? state.focusedSid)) return state;
       return { ...state, artifact: {
         file: e.file, sid: state.artifact.sid, kind: "gitdiff", sections: parseGitDiff(e.diff),
+      } };
+    case "file_preview":
+      if (!state.artifact || !["md", "file"].includes(state.artifact.kind)
+          || state.artifact.requestId !== e.request_id
+          || state.artifact.sid !== (e.sid ?? state.focusedSid)) return state;
+      return { ...state, artifact: {
+        file: e.path,
+        sid: state.artifact.sid,
+        requestId: e.request_id,
+        kind: e.format === "markdown" ? "md" : "file",
+        content: e.content,
+        size: e.size,
+        truncated: e.truncated,
+        mtimeNs: e.mtime_ns,
+        line: state.artifact.line,
+        error: e.error ?? undefined,
+        assets: {},
+      } };
+    case "preview_asset":
+      if (!state.artifact || state.artifact.kind !== "md"
+          || state.artifact.requestId !== e.preview_id
+          || state.artifact.sid !== (e.sid ?? state.focusedSid)) return state;
+      return { ...state, artifact: {
+        ...state.artifact,
+        assets: {
+          ...state.artifact.assets,
+          [e.path]: {
+            mediaType: e.media_type ?? undefined,
+            data: e.data ?? undefined,
+            error: e.error ?? undefined,
+          },
+        },
       } };
     case "state":
       return patch(state, e.sid, (rt) => {

--- a/web/src/reducer.ts
+++ b/web/src/reducer.ts
@@ -140,7 +140,13 @@ export interface Artifact {
   loading?: boolean;
   size?: number;
   truncated?: boolean;
-  mtimeNs?: number;
+  mtimeNs?: string;
+  revision?: string;
+  saveRequestId?: string;
+  saving?: boolean;
+  saveStatus?: "saved" | "conflict" | "error";
+  saveError?: string;
+  pendingContent?: string;
   line?: number;
   error?: string;
   assets?: Record<string, PreviewAssetState>;
@@ -251,6 +257,7 @@ export type Action =
   | { type: "set_artifact"; artifact: Artifact }
   | { type: "open_artifact_loading"; file: string; sid: string | null }
   | { type: "open_file_loading"; file: string; sid: string | null; requestId: string; kind: "md" | "file"; line?: number }
+  | { type: "start_file_save"; requestId: string; content: string }
   | { type: "clear_artifact" }
   | { type: "clear_btw" }
   | { type: "focus_session"; sid: string }
@@ -712,6 +719,16 @@ export function reduce(state: AppState, action: Action): AppState {
         file: action.file, sid: action.sid, requestId: action.requestId,
         kind: action.kind, line: action.line, content: "", assets: {}, loading: true,
       } };
+    case "start_file_save":
+      if (!state.artifact || state.artifact.kind !== "md") return state;
+      return { ...state, artifact: {
+        ...state.artifact,
+        saveRequestId: action.requestId,
+        saving: true,
+        saveStatus: undefined,
+        saveError: undefined,
+        pendingContent: action.content,
+      } };
     case "clear_artifact":
       return { ...state, artifact: null };
     case "clear_btw": {
@@ -1005,9 +1022,35 @@ function reduceEvent(
         size: e.size,
         truncated: e.truncated,
         mtimeNs: e.mtime_ns,
+        revision: e.revision ?? undefined,
         line: state.artifact.line,
         error: e.error ?? undefined,
         assets: {},
+      } };
+    case "file_save_result":
+      if (!state.artifact || state.artifact.kind !== "md"
+          || state.artifact.saveRequestId !== e.request_id
+          || state.artifact.sid !== (e.sid ?? state.focusedSid)) return state;
+      if (e.status === "saved") {
+        return { ...state, artifact: {
+          ...state.artifact,
+          content: state.artifact.pendingContent ?? state.artifact.content,
+          size: e.size,
+          mtimeNs: e.mtime_ns,
+          revision: e.revision ?? state.artifact.revision,
+          saving: false,
+          saveStatus: "saved",
+          saveError: undefined,
+          pendingContent: undefined,
+        } };
+      }
+      return { ...state, artifact: {
+        ...state.artifact,
+        saving: false,
+        saveStatus: e.status,
+        saveError: e.error || (e.status === "conflict"
+          ? "文件已被其他程序修改，请重新读取后再保存。" : "保存失败。"),
+        pendingContent: undefined,
       } };
     case "preview_asset":
       if (!state.artifact || state.artifact.kind !== "md"

--- a/web/src/responsive-layout.ts
+++ b/web/src/responsive-layout.ts
@@ -1,0 +1,33 @@
+export type SidebarSwipeAction = "open" | "close" | null;
+
+const SWIPE_THRESHOLD_PX = 50;
+const HORIZONTAL_INTENT_RATIO = 1.25;
+
+export function resolveSidebarSwipe(
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
+  viewportWidth: number,
+  locked: boolean,
+): SidebarSwipeAction {
+  if (locked) return null;
+  const dx = endX - startX;
+  const dy = endY - startY;
+  if (Math.abs(dx) <= SWIPE_THRESHOLD_PX
+      || Math.abs(dx) <= Math.abs(dy) * HORIZONTAL_INTENT_RATIO) return null;
+  if (dx > 0 && startX < viewportWidth / 3) return "open";
+  return dx < 0 ? "close" : null;
+}
+
+const PANEL_MIN_WIDTH_PX = 360;
+const CHAT_MIN_WIDTH_PX = 420;
+const PANEL_MAX_VIEWPORT_RATIO = 0.72;
+
+export function clampPanelWidth(width: number, viewportWidth: number): number {
+  const maxWidth = Math.max(
+    PANEL_MIN_WIDTH_PX,
+    Math.min(viewportWidth - CHAT_MIN_WIDTH_PX, viewportWidth * PANEL_MAX_VIEWPORT_RATIO),
+  );
+  return Math.round(Math.min(Math.max(width, PANEL_MIN_WIDTH_PX), maxWidth));
+}

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -331,6 +331,24 @@ export class RelayWs {
     this.send({ v: PROTOCOL_VERSION, type: "get_diff", file, theme, ts: nowTs(), ...this.sidObj() });
   }
 
+  sendGetFilePreview(path: string, requestId = uuid()): string | null {
+    const queued = this.send({
+      v: PROTOCOL_VERSION, type: "get_file_preview", path, request_id: requestId,
+      ts: nowTs(), ...this.sidObj(),
+    });
+    return queued ? requestId : null;
+  }
+
+  sendGetPreviewAsset(path: string, previewId: string,
+                      requestId = uuid()): string | null {
+    const queued = this.send({
+      v: PROTOCOL_VERSION, type: "get_preview_asset", path,
+      preview_id: previewId, request_id: requestId,
+      ts: nowTs(), ...this.sidObj(),
+    });
+    return queued ? requestId : null;
+  }
+
   /** Fetch a session's history as ONE bulk frame, read on-demand from its
    *  transcript (like a web chat's GET /conversation). client_id lets the wrapper
    *  route the History reply to=this client. Replaces per-hello buffer replay. */

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -339,6 +339,24 @@ export class RelayWs {
     return queued ? requestId : null;
   }
 
+  sendSaveMarkdown(path: string, content: string, expectedSize: number,
+                   expectedMtimeNs: string, expectedRevision: string,
+                   requestId = uuid()): string | null {
+    const queued = this.send({
+      v: PROTOCOL_VERSION,
+      type: "save_markdown",
+      path,
+      content,
+      expected_size: expectedSize,
+      expected_mtime_ns: expectedMtimeNs,
+      expected_revision: expectedRevision,
+      request_id: requestId,
+      ts: nowTs(),
+      ...this.sidObj(),
+    });
+    return queued ? requestId : null;
+  }
+
   sendGetPreviewAsset(path: string, previewId: string,
                       requestId = uuid()): string | null {
     const queued = this.send({

--- a/web/tests/markdown-preview.test.ts
+++ b/web/tests/markdown-preview.test.ts
@@ -161,6 +161,8 @@ try {
     onClose: () => {},
   }));
   assert.match(markup, /markdown-preview/);
+  assert.match(markup, /panel-resizer/);
+  assert.match(markup, /data-lock-horizontal-swipe="true"/);
   assert.match(markup, />预览</);
   assert.match(markup, />源码</);
   assert.match(markup, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);

--- a/web/tests/markdown-preview.test.ts
+++ b/web/tests/markdown-preview.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createServer } from "vite";
+
+import { classifyPreviewTarget, isMarkdownPath } from "../src/preview-path.ts";
+import { parseLocalFileTarget } from "../src/file-link.ts";
+import type { ServerEvent } from "../src/protocol.ts";
+
+assert.deepEqual(classifyPreviewTarget("docs/README.md", "./img/a.png"), {
+  kind: "local", value: "docs/img/a.png",
+});
+assert.deepEqual(classifyPreviewTarget("docs/README.md", "../root.png?raw=1"), {
+  kind: "local", value: "root.png",
+});
+assert.equal(classifyPreviewTarget("README.md", "../secret.png").kind, "blocked");
+assert.equal(classifyPreviewTarget("README.md", "/etc/passwd").kind, "blocked");
+assert.equal(classifyPreviewTarget("README.md", "file:///etc/passwd").kind, "blocked");
+assert.equal(classifyPreviewTarget("README.md", "//example.com/a.png").kind, "blocked");
+assert.deepEqual(classifyPreviewTarget("README.md", "https://example.com/a.png"), {
+  kind: "external", value: "https://example.com/a.png",
+});
+assert.deepEqual(classifyPreviewTarget("README.md", "#section"), {
+  kind: "anchor", value: "#section",
+});
+assert.equal(isMarkdownPath("docs/guide.MD#intro"), true);
+assert.equal(isMarkdownPath("docs/image.png"), false);
+assert.deepEqual(parseLocalFileTarget(
+  "/home/nancy/project/codex_stream.py:731"), {
+  path: "/home/nancy/project/codex_stream.py", line: 731, column: undefined,
+});
+assert.deepEqual(parseLocalFileTarget("src/app.ts#L42C7"), {
+  path: "src/app.ts", line: 42, column: 7,
+});
+assert.deepEqual(parseLocalFileTarget("file:///tmp/a%20b.py:9"), {
+  path: "/tmp/a b.py", line: 9, column: undefined,
+});
+assert.equal(parseLocalFileTarget("https://example.com/a.py:9"), null);
+assert.equal(parseLocalFileTarget("#L9"), null);
+
+const harness = await createServer({
+  root: process.cwd(),
+  appType: "custom",
+  logLevel: "silent",
+  server: { middlewareMode: true, watch: null },
+});
+try {
+  const { initialState, reduce } = await harness.ssrLoadModule("/src/reducer.ts");
+  const { ArtifactPanel } = await harness.ssrLoadModule(
+    "/src/components/ArtifactPanel.tsx");
+  const { MessageBlock } = await harness.ssrLoadModule(
+    "/src/components/MessageBlock.tsx");
+  let state = reduce(initialState, {
+    type: "open_file_loading",
+    file: "README.md",
+    sid: "session-1",
+    requestId: "preview-new",
+    kind: "md",
+  });
+  const loading = state;
+
+  state = reduce(state, { type: "event", event: {
+    v: 9,
+    type: "file_preview",
+    ts: 1,
+    sid: "session-1",
+    path: "README.md",
+    request_id: "preview-old",
+    format: "markdown",
+    content: "stale",
+    size: 5,
+    truncated: false,
+    mtime_ns: 1,
+  } as ServerEvent });
+  assert.equal(state, loading,
+    "a stale preview response must not replace the open request");
+
+  state = reduce(state, { type: "event", event: {
+    v: 9,
+    type: "file_preview",
+    ts: 2,
+    sid: "session-1",
+    path: "docs/README.md",
+    request_id: "preview-new",
+    format: "markdown",
+    content: "# current",
+    size: 9,
+    truncated: false,
+    mtime_ns: 2,
+  } as ServerEvent });
+  assert.equal(state.artifact?.file, "docs/README.md");
+  assert.equal(state.artifact?.content, "# current");
+  assert.equal(state.artifact?.loading, undefined);
+
+  const rendered = state;
+  state = reduce(state, { type: "event", event: {
+    v: 9,
+    type: "preview_asset",
+    ts: 3,
+    sid: "other-session",
+    path: "docs/image.png",
+    preview_id: "preview-new",
+    request_id: "asset-wrong-session",
+    media_type: "image/png",
+    data: "cG5n",
+  } as ServerEvent });
+  assert.equal(state, rendered, "assets from another session must be ignored");
+
+  state = reduce(state, { type: "event", event: {
+    v: 9,
+    type: "preview_asset",
+    ts: 4,
+    sid: "session-1",
+    path: "docs/image.png",
+    preview_id: "preview-new",
+    request_id: "asset-1",
+    media_type: "image/png",
+    data: "cG5n",
+  } as ServerEvent });
+  assert.deepEqual(state.artifact?.assets?.["docs/image.png"], {
+    mediaType: "image/png", data: "cG5n", error: undefined,
+  });
+
+  state = reduce(state, {
+    type: "open_file_loading",
+    file: "/home/nancy/project/codex_stream.py",
+    sid: "session-1",
+    requestId: "source-1",
+    kind: "file",
+    line: 731,
+  });
+  state = reduce(state, { type: "event", event: {
+    v: 9,
+    type: "file_preview",
+    ts: 5,
+    sid: "session-1",
+    path: "cc_remote/wrapper/codex_stream.py",
+    request_id: "source-1",
+    format: "text",
+    content: "source",
+    size: 6,
+    truncated: false,
+    mtime_ns: 3,
+  } as ServerEvent });
+  assert.equal(state.artifact?.kind, "file");
+  assert.equal(state.artifact?.line, 731);
+  assert.equal(state.artifact?.file, "cc_remote/wrapper/codex_stream.py");
+
+  const markup = renderToStaticMarkup(createElement(ArtifactPanel, {
+    artifact: {
+      file: "docs/README.md",
+      sid: "session-1",
+      requestId: "preview-new",
+      kind: "md",
+      content: "# Preview\n\n<script>alert(1)</script>",
+      assets: {},
+    },
+    active: "diff",
+    hasBtw: false,
+    onTab: () => {},
+    onClose: () => {},
+  }));
+  assert.match(markup, /markdown-preview/);
+  assert.match(markup, />预览</);
+  assert.match(markup, />源码</);
+  assert.match(markup, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.doesNotMatch(markup, /<script>/);
+
+  const messageMarkup = renderToStaticMarkup(createElement(MessageBlock, {
+    text: "[codex_stream.py](/home/nancy/project/codex_stream.py:731)",
+    done: true,
+    onOpenFile: () => {},
+  }));
+  assert.match(messageMarkup, /message-file-link/);
+  assert.match(messageMarkup, /在 Remote 中打开/);
+  assert.doesNotMatch(messageMarkup, /href="\/home\/nancy/);
+
+  const source = Array.from({ length: 740 }, (_, index) => `line ${index + 1}`).join("\n");
+  const sourceMarkup = renderToStaticMarkup(createElement(ArtifactPanel, {
+    artifact: {
+      file: "cc_remote/wrapper/codex_stream.py",
+      sid: "session-1",
+      requestId: "source-1",
+      kind: "file",
+      content: source,
+      line: 731,
+      assets: {},
+    },
+    active: "diff",
+    hasBtw: false,
+    onTab: () => {},
+    onClose: () => {},
+  }));
+  assert.match(sourceMarkup, /source-line focused/);
+  assert.match(sourceMarkup, />731<\/span><code>line 731<\/code>/);
+  assert.match(sourceMarkup, /501–740 \/ 740 行/);
+} finally {
+  await harness.close();
+}
+
+console.log("markdown preview tests passed");

--- a/web/tests/markdown-preview.test.ts
+++ b/web/tests/markdown-preview.test.ts
@@ -60,7 +60,7 @@ try {
   const loading = state;
 
   state = reduce(state, { type: "event", event: {
-    v: 9,
+    v: 10,
     type: "file_preview",
     ts: 1,
     sid: "session-1",
@@ -70,13 +70,13 @@ try {
     content: "stale",
     size: 5,
     truncated: false,
-    mtime_ns: 1,
+    mtime_ns: "1",
   } as ServerEvent });
   assert.equal(state, loading,
     "a stale preview response must not replace the open request");
 
   state = reduce(state, { type: "event", event: {
-    v: 9,
+    v: 10,
     type: "file_preview",
     ts: 2,
     sid: "session-1",
@@ -86,15 +86,17 @@ try {
     content: "# current",
     size: 9,
     truncated: false,
-    mtime_ns: 2,
+    mtime_ns: "2",
+    revision: "a".repeat(64),
   } as ServerEvent });
   assert.equal(state.artifact?.file, "docs/README.md");
   assert.equal(state.artifact?.content, "# current");
+  assert.equal(state.artifact?.revision, "a".repeat(64));
   assert.equal(state.artifact?.loading, undefined);
 
   const rendered = state;
   state = reduce(state, { type: "event", event: {
-    v: 9,
+    v: 10,
     type: "preview_asset",
     ts: 3,
     sid: "other-session",
@@ -107,7 +109,7 @@ try {
   assert.equal(state, rendered, "assets from another session must be ignored");
 
   state = reduce(state, { type: "event", event: {
-    v: 9,
+    v: 10,
     type: "preview_asset",
     ts: 4,
     sid: "session-1",
@@ -122,6 +124,64 @@ try {
   });
 
   state = reduce(state, {
+    type: "start_file_save",
+    requestId: "save-1",
+    content: "# edited",
+  });
+  const saving = state;
+  state = reduce(state, { type: "event", event: {
+    v: 10,
+    type: "file_save_result",
+    ts: 5,
+    sid: "session-1",
+    path: "docs/README.md",
+    request_id: "stale-save",
+    status: "saved",
+    size: 8,
+    mtime_ns: "3",
+    revision: "b".repeat(64),
+  } as ServerEvent });
+  assert.equal(state, saving, "a stale save response must be ignored");
+
+  state = reduce(state, { type: "event", event: {
+    v: 10,
+    type: "file_save_result",
+    ts: 6,
+    sid: "session-1",
+    path: "docs/README.md",
+    request_id: "save-1",
+    status: "conflict",
+    size: 12,
+    mtime_ns: "4",
+    revision: "c".repeat(64),
+    error: "文件已修改",
+  } as ServerEvent });
+  assert.equal(state.artifact?.content, "# current");
+  assert.equal(state.artifact?.saveStatus, "conflict");
+  assert.equal(state.artifact?.saveError, "文件已修改");
+
+  state = reduce(state, {
+    type: "start_file_save",
+    requestId: "save-2",
+    content: "# edited",
+  });
+  state = reduce(state, { type: "event", event: {
+    v: 10,
+    type: "file_save_result",
+    ts: 7,
+    sid: "session-1",
+    path: "docs/README.md",
+    request_id: "save-2",
+    status: "saved",
+    size: 8,
+    mtime_ns: "5",
+    revision: "d".repeat(64),
+  } as ServerEvent });
+  assert.equal(state.artifact?.content, "# edited");
+  assert.equal(state.artifact?.saveStatus, "saved");
+  assert.equal(state.artifact?.revision, "d".repeat(64));
+
+  state = reduce(state, {
     type: "open_file_loading",
     file: "/home/nancy/project/codex_stream.py",
     sid: "session-1",
@@ -130,7 +190,7 @@ try {
     line: 731,
   });
   state = reduce(state, { type: "event", event: {
-    v: 9,
+    v: 10,
     type: "file_preview",
     ts: 5,
     sid: "session-1",
@@ -140,7 +200,7 @@ try {
     content: "source",
     size: 6,
     truncated: false,
-    mtime_ns: 3,
+    mtime_ns: "3",
   } as ServerEvent });
   assert.equal(state.artifact?.kind, "file");
   assert.equal(state.artifact?.line, 731);
@@ -153,6 +213,9 @@ try {
       requestId: "preview-new",
       kind: "md",
       content: "# Preview\n\n<script>alert(1)</script>",
+      size: 42,
+      mtimeNs: "2",
+      revision: "a".repeat(64),
       assets: {},
     },
     active: "diff",
@@ -165,6 +228,7 @@ try {
   assert.match(markup, /data-lock-horizontal-swipe="true"/);
   assert.match(markup, />预览</);
   assert.match(markup, />源码</);
+  assert.match(markup, />保存</);
   assert.match(markup, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
   assert.doesNotMatch(markup, /<script>/);
 

--- a/web/tests/notices-rate-limits.test.ts
+++ b/web/tests/notices-rate-limits.test.ts
@@ -22,7 +22,7 @@ try {
     "/src/components/NoticeStack.tsx");
   const sid = "notice-session";
   const event = (body: Record<string, unknown>): ServerEvent => ({
-    v: 9, ts: 10, sid, ...body,
+    v: 10, ts: 10, sid, ...body,
   } as ServerEvent);
   let state = {
     ...initialState,

--- a/web/tests/notices-rate-limits.test.ts
+++ b/web/tests/notices-rate-limits.test.ts
@@ -22,7 +22,7 @@ try {
     "/src/components/NoticeStack.tsx");
   const sid = "notice-session";
   const event = (body: Record<string, unknown>): ServerEvent => ({
-    v: 8, ts: 10, sid, ...body,
+    v: 9, ts: 10, sid, ...body,
   } as ServerEvent);
   let state = {
     ...initialState,

--- a/web/tests/outbox.test.ts
+++ b/web/tests/outbox.test.ts
@@ -5,9 +5,9 @@ import { shouldAcceptSessionList } from "../src/session-list.ts";
 
 const outbox = new CommandOutbox(2, 4096);
 const first = outbox.enqueue(
-  { v: 8, type: "query", prompt: "one", ts: 1 }, "client-1", "cmd-1");
+  { v: 9, type: "query", prompt: "one", ts: 1 }, "client-1", "cmd-1");
 const second = outbox.enqueue(
-  { v: 8, type: "interrupt", ts: 2 }, "client-1", "cmd-2");
+  { v: 9, type: "interrupt", ts: 2 }, "client-1", "cmd-2");
 assert.equal(first.ok, true);
 assert.equal(second.ok, true);
 assert.equal(outbox.size, 2);
@@ -17,7 +17,7 @@ assert.deepEqual(
 );
 
 const full = outbox.enqueue(
-  { v: 8, type: "set_model", model: "x", ts: 3 }, "client-1", "cmd-3");
+  { v: 9, type: "set_model", model: "x", ts: 3 }, "client-1", "cmd-3");
 assert.equal(full.ok, false);
 assert.equal(outbox.size, 2); // never evict an unacknowledged older command
 
@@ -33,16 +33,16 @@ assert.deepEqual(
 
 const byteBounded = new CommandOutbox(10, 8);
 assert.equal(byteBounded.enqueue(
-  { v: 8, type: "query", prompt: "too large", ts: 1 }, "c", "x").ok, false);
+  { v: 9, type: "query", prompt: "too large", ts: 1 }, "c", "x").ok, false);
 assert.equal(byteBounded.size, 0);
 assert.equal(byteBounded.byteSize, 0);
 
 const frameBounded = new CommandOutbox(10, 4096, 160);
 const smallFrame = frameBounded.enqueue(
-  { v: 8, type: "query", prompt: "small", ts: 1 }, "client", "small");
+  { v: 9, type: "query", prompt: "small", ts: 1 }, "client", "small");
 assert.equal(smallFrame.ok, true);
 const oversizedFrame = frameBounded.enqueue(
-  { v: 8, type: "query", prompt: "x".repeat(200), ts: 1 }, "client", "oversized");
+  { v: 9, type: "query", prompt: "x".repeat(200), ts: 1 }, "client", "oversized");
 assert.equal(oversizedFrame.ok, false);
 assert.match(oversizedFrame.ok ? "" : oversizedFrame.reason, /command too large/);
 assert.equal(frameBounded.size, 1); // reject before mutating aggregate accounting
@@ -50,7 +50,7 @@ assert.equal(frameBounded.byteSize, smallFrame.ok ? new TextEncoder().encode(sma
 
 const rekeyed = new CommandOutbox(10, 4096);
 assert.equal(rekeyed.enqueue(
-  { v: 8, type: "query", sid: "tmp-old", prompt: "x", msg_id: "m", ts: 1 },
+  { v: 9, type: "query", sid: "tmp-old", prompt: "x", msg_id: "m", ts: 1 },
   "c", "rekey-cmd").ok, true);
 assert.deepEqual(rekeyed.pendingSessionIds(), ["tmp-old"]);
 assert.deepEqual(rekeyed.pendingFramesWithSessionIds().map((item) => ({
@@ -64,10 +64,10 @@ assert.equal(JSON.parse(rekeyed.pendingFrames()[0]).sid, "real-id");
 
 const protectedTargets = new CommandOutbox(10, 4096);
 assert.equal(protectedTargets.enqueue(
-  { v: 8, type: "query", sid: "query-target", prompt: "x", msg_id: "m", ts: 1 },
+  { v: 9, type: "query", sid: "query-target", prompt: "x", msg_id: "m", ts: 1 },
   "c", "query-cmd").ok, true);
 assert.equal(protectedTargets.enqueue(
-  { v: 8, type: "switch_session", session_id: "switch-target", ts: 1 },
+  { v: 9, type: "switch_session", session_id: "switch-target", ts: 1 },
   "c", "switch-cmd").ok, true);
 assert.deepEqual(protectedTargets.pendingSessionIds(), ["query-target", "switch-target"]);
 
@@ -87,10 +87,10 @@ assert.deepEqual(planRecoveryReplay([
 ]);
 
 assert.equal(shouldAcceptSessionList("claude", {
-  v: 8, type: "session_list", ts: 1, engine: "claude", sessions: [],
+  v: 9, type: "session_list", ts: 1, engine: "claude", sessions: [],
 }), true);
 assert.equal(shouldAcceptSessionList("codex", {
-  v: 8, type: "session_list", ts: 1, engine: "claude", sessions: [],
+  v: 9, type: "session_list", ts: 1, engine: "claude", sessions: [],
 }), false);
 
 console.log("command outbox tests passed");

--- a/web/tests/outbox.test.ts
+++ b/web/tests/outbox.test.ts
@@ -5,9 +5,9 @@ import { shouldAcceptSessionList } from "../src/session-list.ts";
 
 const outbox = new CommandOutbox(2, 4096);
 const first = outbox.enqueue(
-  { v: 9, type: "query", prompt: "one", ts: 1 }, "client-1", "cmd-1");
+  { v: 10, type: "query", prompt: "one", ts: 1 }, "client-1", "cmd-1");
 const second = outbox.enqueue(
-  { v: 9, type: "interrupt", ts: 2 }, "client-1", "cmd-2");
+  { v: 10, type: "interrupt", ts: 2 }, "client-1", "cmd-2");
 assert.equal(first.ok, true);
 assert.equal(second.ok, true);
 assert.equal(outbox.size, 2);
@@ -17,7 +17,7 @@ assert.deepEqual(
 );
 
 const full = outbox.enqueue(
-  { v: 9, type: "set_model", model: "x", ts: 3 }, "client-1", "cmd-3");
+  { v: 10, type: "set_model", model: "x", ts: 3 }, "client-1", "cmd-3");
 assert.equal(full.ok, false);
 assert.equal(outbox.size, 2); // never evict an unacknowledged older command
 
@@ -33,16 +33,16 @@ assert.deepEqual(
 
 const byteBounded = new CommandOutbox(10, 8);
 assert.equal(byteBounded.enqueue(
-  { v: 9, type: "query", prompt: "too large", ts: 1 }, "c", "x").ok, false);
+  { v: 10, type: "query", prompt: "too large", ts: 1 }, "c", "x").ok, false);
 assert.equal(byteBounded.size, 0);
 assert.equal(byteBounded.byteSize, 0);
 
 const frameBounded = new CommandOutbox(10, 4096, 160);
 const smallFrame = frameBounded.enqueue(
-  { v: 9, type: "query", prompt: "small", ts: 1 }, "client", "small");
+  { v: 10, type: "query", prompt: "small", ts: 1 }, "client", "small");
 assert.equal(smallFrame.ok, true);
 const oversizedFrame = frameBounded.enqueue(
-  { v: 9, type: "query", prompt: "x".repeat(200), ts: 1 }, "client", "oversized");
+  { v: 10, type: "query", prompt: "x".repeat(200), ts: 1 }, "client", "oversized");
 assert.equal(oversizedFrame.ok, false);
 assert.match(oversizedFrame.ok ? "" : oversizedFrame.reason, /command too large/);
 assert.equal(frameBounded.size, 1); // reject before mutating aggregate accounting
@@ -50,7 +50,7 @@ assert.equal(frameBounded.byteSize, smallFrame.ok ? new TextEncoder().encode(sma
 
 const rekeyed = new CommandOutbox(10, 4096);
 assert.equal(rekeyed.enqueue(
-  { v: 9, type: "query", sid: "tmp-old", prompt: "x", msg_id: "m", ts: 1 },
+  { v: 10, type: "query", sid: "tmp-old", prompt: "x", msg_id: "m", ts: 1 },
   "c", "rekey-cmd").ok, true);
 assert.deepEqual(rekeyed.pendingSessionIds(), ["tmp-old"]);
 assert.deepEqual(rekeyed.pendingFramesWithSessionIds().map((item) => ({
@@ -64,10 +64,10 @@ assert.equal(JSON.parse(rekeyed.pendingFrames()[0]).sid, "real-id");
 
 const protectedTargets = new CommandOutbox(10, 4096);
 assert.equal(protectedTargets.enqueue(
-  { v: 9, type: "query", sid: "query-target", prompt: "x", msg_id: "m", ts: 1 },
+  { v: 10, type: "query", sid: "query-target", prompt: "x", msg_id: "m", ts: 1 },
   "c", "query-cmd").ok, true);
 assert.equal(protectedTargets.enqueue(
-  { v: 9, type: "switch_session", session_id: "switch-target", ts: 1 },
+  { v: 10, type: "switch_session", session_id: "switch-target", ts: 1 },
   "c", "switch-cmd").ok, true);
 assert.deepEqual(protectedTargets.pendingSessionIds(), ["query-target", "switch-target"]);
 
@@ -87,10 +87,10 @@ assert.deepEqual(planRecoveryReplay([
 ]);
 
 assert.equal(shouldAcceptSessionList("claude", {
-  v: 9, type: "session_list", ts: 1, engine: "claude", sessions: [],
+  v: 10, type: "session_list", ts: 1, engine: "claude", sessions: [],
 }), true);
 assert.equal(shouldAcceptSessionList("codex", {
-  v: 9, type: "session_list", ts: 1, engine: "claude", sessions: [],
+  v: 10, type: "session_list", ts: 1, engine: "claude", sessions: [],
 }), false);
 
 console.log("command outbox tests passed");

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -221,6 +221,15 @@ for (const filename of [
   assert.match(source, /nativeEvent\.keyCode/);
 }
 
+// Desktop sidebar motion must not regress to the old discrete grid-track swap.
+// Chromium could strand an animated 0px/1fr grid, so the safe implementation
+// slides the fixed sidebar and offsets the pane using ordinary CSS lengths.
+const layoutCss = readFileSync(resolve(process.cwd(), "src/index.css"), "utf8");
+assert.doesNotMatch(layoutCss, /transition\s*:\s*grid-template-columns/);
+assert.match(layoutCss, /\.shell\.sidebar-open \.pane\s*\{[^}]*margin-left\s*:\s*352px/s);
+assert.match(layoutCss, /\.pane\s*\{[^}]*transition\s*:[^}]*margin-left[^}]*width/s);
+assert.match(layoutCss, /\.sessions\s*\{[^}]*position\s*:\s*fixed[^}]*width\s*:\s*352px/s);
+
 let requested = "";
 const authenticated = await probeSession(async (input, init) => {
   requested = input;
@@ -502,7 +511,7 @@ try {
     OMITTED_PROCESS_ITEM_ID,
   } = await reducerHarness.ssrLoadModule("/src/reducer.ts");
   const event = (body: Record<string, unknown>): ServerEvent => ({
-    v: 9, ts: 10, ...body,
+    v: 10, ts: 10, ...body,
   } as ServerEvent);
   const unannounced = createRuntime();
   assert.equal(unannounced.model, "");
@@ -1279,7 +1288,7 @@ class FakeWebSocket {
   }
 
   receive(frame: Record<string, unknown>): void {
-    this.onmessage?.({ data: JSON.stringify({ v: 9, ts: 1, ...frame }) });
+    this.onmessage?.({ data: JSON.stringify({ v: 10, ts: 1, ...frame }) });
   }
 }
 

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -491,7 +491,7 @@ try {
     OMITTED_PROCESS_ITEM_ID,
   } = await reducerHarness.ssrLoadModule("/src/reducer.ts");
   const event = (body: Record<string, unknown>): ServerEvent => ({
-    v: 8, ts: 10, ...body,
+    v: 9, ts: 10, ...body,
   } as ServerEvent);
   const unannounced = createRuntime();
   assert.equal(unannounced.model, "");
@@ -1268,7 +1268,7 @@ class FakeWebSocket {
   }
 
   receive(frame: Record<string, unknown>): void {
-    this.onmessage?.({ data: JSON.stringify({ v: 8, ts: 1, ...frame }) });
+    this.onmessage?.({ data: JSON.stringify({ v: 9, ts: 1, ...frame }) });
   }
 }
 

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -44,6 +44,17 @@ import {
   type ViewportReading,
 } from "../src/use-mobile-viewport.ts";
 import type { ServerEvent } from "../src/protocol.ts";
+import { clampPanelWidth, resolveSidebarSwipe } from "../src/responsive-layout.ts";
+
+assert.equal(resolveSidebarSwipe(12, 200, 84, 205, 390, false), "open");
+assert.equal(resolveSidebarSwipe(300, 200, 230, 205, 390, false), "close");
+assert.equal(resolveSidebarSwipe(12, 100, 78, 240, 390, false), null,
+  "a mostly vertical gesture must not navigate");
+assert.equal(resolveSidebarSwipe(12, 200, 84, 205, 390, true), null,
+  "an interactive vertical scroller must own its gesture");
+assert.equal(clampPanelWidth(200, 1440), 360);
+assert.equal(clampPanelWidth(2_000, 1440), 1_020);
+assert.equal(clampPanelWidth(600, 1_000), 580);
 
 const viewportListeners = new Map<MobileViewportEvent, Set<() => void>>();
 const viewportCss = new Map<string, string>();
@@ -1353,6 +1364,7 @@ for (const optimisticAction of ["set_model", "set_effort", "set_perm", "set_coll
   assert.doesNotMatch(appSource, new RegExp(`dispatch\\(\\{ type: ["']${optimisticAction}["']`));
 }
 assert.match(appSource, /const \{ cwd, model, effort \} = state\.newChat/);
+assert.match(appSource, /data-lock-horizontal-swipe/);
 
 assert.equal(relay.sendTakeover("codex-model-session"), true);
 const takeoverFrame = JSON.parse(socket.sent.at(-1) ?? "{}");

--- a/web/tests/session-worktree.test.ts
+++ b/web/tests/session-worktree.test.ts
@@ -41,7 +41,7 @@ assert.equal(isWorktreeForkNameValid("x".repeat(WORKTREE_FORK_NAME_MAX + 1)), fa
 assert.deepEqual(
   makeForkSessionCommand("codex-parent", "turn-7", "request-message", 122),
   {
-    v: 9,
+    v: 10,
     type: "fork_session",
     session_id: "codex-parent",
     request_id: "request-message",
@@ -53,7 +53,7 @@ assert.deepEqual(
 assert.deepEqual(
   makeForkSessionWorktreeCommand("codex-parent", "fix-login", "request-1", 123),
   {
-    v: 9,
+    v: 10,
     type: "fork_session_worktree",
     session_id: "codex-parent",
     name: "fix-login",

--- a/web/tests/session-worktree.test.ts
+++ b/web/tests/session-worktree.test.ts
@@ -41,7 +41,7 @@ assert.equal(isWorktreeForkNameValid("x".repeat(WORKTREE_FORK_NAME_MAX + 1)), fa
 assert.deepEqual(
   makeForkSessionCommand("codex-parent", "turn-7", "request-message", 122),
   {
-    v: 8,
+    v: 9,
     type: "fork_session",
     session_id: "codex-parent",
     request_id: "request-message",
@@ -53,7 +53,7 @@ assert.deepEqual(
 assert.deepEqual(
   makeForkSessionWorktreeCommand("codex-parent", "fix-login", "request-1", 123),
   {
-    v: 8,
+    v: 9,
     type: "fork_session_worktree",
     session_id: "codex-parent",
     name: "fix-login",


### PR DESCRIPTION
## 变更

- 增加 Markdown 渲染、源码文件浏览与本地图片预览
- 识别消息中的本地文件及行号链接，在 Remote 侧栏内直接定位
- 支持 Markdown 源码编辑、草稿实时预览和保存按钮 / Ctrl/Cmd+S 显式保存
- 保存限制在当前会话工作目录内的现存 Markdown 普通文件，并加入版本冲突检测、原子替换、BOM/换行/权限保留
- 升级线协议至 v10，并以字符串无损传递纳秒时间戳
- 修复手机端命令面板横向手势误触，Diff、Markdown 和源码改为单页换行
- 桌面端文件面板支持拖动调宽，并恢复多会话侧栏开合动画

## 原因

消息中的本地文件链接此前会被浏览器当作站内路由打开，从而出现白屏；Markdown 只能查看，无法在 Remote 内安全修改。保存链路还需要避免越界路径、符号链接、并发外部修改和重复命令覆盖。

桌面会话侧栏此前为规避 Chromium 的 `grid-template-columns` 插值卡死改成离散切换，同时强制禁用了侧栏 transform，因此开关动画消失。本次改为固定侧栏位移，并让主内容区同步让位，不再依赖 grid 轨道动画。

## 影响

用户可以在 Remote 内安全查看和编辑 Markdown；只有明确保存才写盘，未保存内容在关闭、刷新或切换时提示。外部修改会返回冲突而不是覆盖。手机端保持纵向阅读，桌面端文件面板和会话侧栏具备平滑、可控的布局动画。

## 验证

- Python Markdown / 协议 / 部署专项：67 passed
- `npm run test:reliability`
- `npm run lint`
- `npm run build`
- `git diff --check`
- protocol v10 已协调部署，公共健康检查确认 relay 与 wrapper 在线
