### PR TITLE
feat: add ALLOW_INSECURE_HTTP escape hatch for plain http/ws

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,14 @@ RELAY_PORT=8765
 # Exact browser origin allowed for cookie-authenticated WebSockets. Plain HTTP
 # is accepted only on loopback; production must use https://.
 PUBLIC_ORIGIN=http://127.0.0.1:8765
+# Opt-in escape hatch: set to 1 to allow PUBLIC_ORIGIN/RELAY_URL to be a
+# non-loopback plain http://IP (or ws://IP) instead of requiring https/wss —
+# e.g. reaching the relay over a bare public IP with no TLS terminator in
+# front. Leave unset/0 unless you understand the tradeoff: the login
+# password, session cookie, and all traffic travel in cleartext, so anyone on
+# the network path can read or hijack the session. Prefer TLS (Caddy/nginx,
+# see deploy/) whenever possible.
+ALLOW_INSECURE_HTTP=0
 # Web login password (what you type in the browser). REQUIRED.
 LOGIN_PASSWORD=change-me-login
 # HMAC secret for signing web session tokens. REQUIRED.
@@ -34,6 +42,8 @@ WS_MAX_SIZE_BYTES=16777216
 
 # ---- Wrapper ----
 RELAY_URL=ws://127.0.0.1:8765/ws
+# Same ALLOW_INSECURE_HTTP switch as above; the wrapper reads it too so
+# RELAY_URL can stay ws:// against a non-loopback host.
 # Optional absolute Claude Code executable. Blank uses PATH discovery.
 CLAUDE_BIN=
 # Working directory of the claude session. MUST match for --resume to find the

--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ python -m cc_remote.wrapper
 - **域名**：A 记录指向 VPS 公网 IP（Caddy 自动签 + 续 Let's Encrypt 证书）。
 - **你的机器**：Linux（下面用 systemd 常驻 wrapper），出站 443 到公网放行。
 
+没有域名时也支持公网 IPv4 + 明文 HTTP/WS 的临时逃生路径：VPS 只需放行
+80，wrapper 需能出站访问 80。该模式仍由 Caddy 反代到 loopback relay，保留
+请求限制和服务加固，但**没有任何传输加密**；登录口令、cookie、wrapper token
+和全部会话内容都可能被链路上的人读取或篡改。
+
 ### 1）生成 token / 口令
 
 ```bash
@@ -258,6 +263,21 @@ sudoedit /opt/cc-remote/.env     # 填 LOGIN_PASSWORD / SESSION_SECRET / WRAPPER
 sudo bash /opt/cc-remote/deploy/setup-vps.sh your-domain.com
 ```
 
+若暂时只有公网 IPv4，则改成下面这一组严格匹配的配置和参数：
+
+```ini
+# /opt/cc-remote/.env
+PUBLIC_ORIGIN=http://your-public-ip
+ALLOW_INSECURE_HTTP=1
+```
+
+```bash
+sudo bash /opt/cc-remote/deploy/setup-vps.sh your-public-ip
+```
+
+脚本只会在开关明确开启、参数是公网 IPv4 且 `PUBLIC_ORIGIN` 精确匹配时选择
+明文 Caddy 配置；私网、loopback、保留地址和错误拼写都会拒绝启动。
+
 脚本会：装 `python3-venv` + Caddy、建 `ccremote` 系统用户、建 venv + `pip install`、把带标记的 cc-remote 站点块和全局 HTTP 超时/头大小上限合并进 Caddyfile（保留其他全局项和站点），再启动 `cc-remote-relay` + `caddy`。若新 relay 重启或健康检查失败，venv、Caddyfile、systemd unit 会作为一个事务全部恢复，并验证旧 relay 的 `/healthz`。
 
 验证：
@@ -266,6 +286,8 @@ sudo bash /opt/cc-remote/deploy/setup-vps.sh your-domain.com
 curl https://your-domain.com/healthz
 # 期望：{"ok":true,"wrapper_connected":false,"clients":0}
 ```
+
+明文模式改用 `curl http://your-public-ip/healthz`。
 
 ### 5）你的机器：配 root-only wrapper 环境 + systemd
 
@@ -286,11 +308,20 @@ sudo systemctl daemon-reload && sudo systemctl enable --now cc-remote-wrapper
 journalctl -u cc-remote-wrapper -f     # 期望：connected to relay / wrapper running
 ```
 
-回 VPS 再看 `curl https://your-domain.com/healthz` → 应 `wrapper_connected:true`。
+明文模式下 wrapper 侧还必须同时设置：
+
+```ini
+RELAY_URL=ws://your-public-ip/ws
+ALLOW_INSECURE_HTTP=1
+```
+
+回 VPS 再看对应模式的 `/healthz` → 应 `wrapper_connected:true`。
 
 ### 6）手机验证
 
-手机浏览器（任意网络）开 `https://your-domain.com/` → 用 `LOGIN_PASSWORD` 登录 → 发消息，应看到流式回复 + 可打断 + 多端同步。
+手机浏览器（任意网络）打开对应的 `https://your-domain.com/` 或
+`http://your-public-ip/` → 用 `LOGIN_PASSWORD` 登录 → 发消息，应看到流式回复 +
+可打断 + 多端同步。
 
 ### 公司/内网走 HTTP 代理出网？
 
@@ -315,7 +346,8 @@ HTTPS_PROXY=http://your-proxy:port      # SOCKS 用 ALL_PROXY=socks5://...
 | `SESSION_TTL_SECONDS` | `604800` | 会话 token 有效期（默认 7 天）。 |
 | `LOGIN_BODY_MAX_BYTES` / `LOGIN_READ_TIMEOUT` / `LOGIN_INFLIGHT_CAP` | `4096` / `10` / `32` | 登录请求体字节数、总读取秒数和并发读取数的硬上限。 |
 | `SESSION_REGISTRY_CAP` | `1024` | 进程内可撤销浏览器会话注册表的硬上限。 |
-| `PUBLIC_ORIGIN` | 空 | 浏览器允许连接 WS 的精确来源，如 `https://remote.example.com`；**必须设**，非 loopback 必须 HTTPS。 |
+| `PUBLIC_ORIGIN` | 空 | 浏览器允许连接 WS 的精确来源，如 `https://remote.example.com`；**必须设**，非 loopback 必须 HTTPS（除非开了 `ALLOW_INSECURE_HTTP`）。 |
+| `ALLOW_INSECURE_HTTP` | `0` | 逃生开关：设为 `1` 允许 `PUBLIC_ORIGIN` / `RELAY_URL` 在非 loopback 时仍用明文 `http://`/`ws://`（例如直接暴露一个没有 TLS 终端的公网 IP）。默认关闭；开启后登录口令、会话 cookie 和全部流量都走明文，链路上任何人都能窃取或劫持会话，务必优先用 TLS（见下文部署一节的 Caddy）。 |
 | `WRAPPER_TOKEN` | 占位值 | wrapper 连中继时的 Bearer token，两边必须一致；启动会拒绝占位值和短值。 |
 | `WEB_STATIC_DIR` | 空 | 指向 `web/dist` 则同源托管网页；留空则只做 API/WS。 |
 | `CLIENT_QUEUE_CAP` / `CLIENT_QUEUE_BYTES` | `4096` / `16777216` | 单客户端待发帧数/字节硬上限；超限断开慢客户端，不静默丢帧。 |
@@ -326,7 +358,8 @@ HTTPS_PROXY=http://your-proxy:port      # SOCKS 用 ALL_PROXY=socks5://...
 
 | 变量 | 默认 | 说明 |
 |---|---|---|
-| `RELAY_URL` | `ws://127.0.0.1:8765/ws` | 中继的 WebSocket 地址（公网用 `wss://域名/ws`）。 |
+| `RELAY_URL` | `ws://127.0.0.1:8765/ws` | 中继的 WebSocket 地址（公网用 `wss://域名/ws`，除非开了 `ALLOW_INSECURE_HTTP`）。 |
+| `ALLOW_INSECURE_HTTP` | `0` | 同中继的逃生开关；wrapper 也读这个变量，开启后 `RELAY_URL` 可以在非 loopback 时仍用 `ws://`。 |
 | `WRAPPER_TOKEN` | `change-me-wrapper` | 同中继。 |
 | `CLAUDE_BIN` | 空 | 可选的 Claude CLI 绝对路径；systemd/PATH 找不到 `claude` 时设置。 |
 | `CC_CWD` | 当前目录 | 新会话默认工作目录。Claude `--resume` 靠它定位 `~/.claude/projects/` 下的会话文件，**必须对**；Codex 恢复时会优先从 rollout 取原 cwd。 |
@@ -360,7 +393,7 @@ HTTPS_PROXY=http://your-proxy:port      # SOCKS 用 ALL_PROXY=socks5://...
 
 - Claude 会话默认使用 `permissionMode: bypassPermissions`；Codex 默认审批策略是 `never` 并继承本机 Codex sandbox 配置，也可切到 `on-request` / `untrusted`，审批请求会转到网页。无论当前界面显示什么策略，已登录客户端都能创建/切换会话和修改可用控制项。**能连到中继且通过登录的人，应等同于拿到了这台机器的远程 agent/shell 权限。**
 - `LOGIN_PASSWORD` / `WRAPPER_TOKEN` / `SESSION_SECRET` 是唯一的门：用强随机值、别提交 git、别贴到聊天里、定期轮换。仓库 `.env` 只适合本机开发；生产 wrapper 必须使用上述 root-only `/etc/cc-remote/wrapper.env`。systemd 模板会禁止服务及模型子进程读取这个源文件和遗留仓库 `.env`；Linux wrapper 还会关闭 dumpability，避免子进程从 `/proc/<pid>/environ` 或进程内存取回已经捕获的 token。
-- 公网必须上 TLS（`wss://`，本仓库用 Caddy 自动签证书）。别用明文 `ws://` 暴露公网。
+- 公网必须上 TLS（`wss://`，本仓库用 Caddy 自动签证书）。别用明文 `ws://` 暴露公网。只有明确需要临时用公网 IP + 明文 HTTP/WS（例如还没配好域名和 TLS）时才设 `ALLOW_INSECURE_HTTP=1`；开启后登录口令、会话 cookie 和全部流量都不加密，任何能看到这段网络流量的人都能窃取或劫持会话，条件允许应尽快切回 TLS。
 - 建议：给中继加 IP 白名单 / 只在需要时开、给登录加失败限速（已内置每 IP 每分钟 5 次）。
 
 ## 模型后端（可选）

--- a/README_en.md
+++ b/README_en.md
@@ -224,6 +224,13 @@ your machine wrapper ──wss:443──▶ Caddy(VPS, auto HTTPS) ──▶ rel
 - **Domain**: an A record pointing at the VPS IP (Caddy auto-provisions + renews the TLS cert).
 - **Your machine**: Linux (systemd runs the wrapper below), outbound 443 allowed.
 
+If you do not have a domain yet, a temporary public-IPv4 + plain-HTTP/WS
+escape hatch is also supported: open port 80 on the VPS and allow outbound 80
+from the wrapper machine. Caddy still proxies to the loopback-only relay, so
+request limits and service hardening remain in place, but there is **no
+transport encryption**: the login password, cookie, wrapper token, and all
+session content can be read or modified on the network path.
+
 ### 1) Generate tokens / password
 
 ```bash
@@ -281,6 +288,22 @@ sudoedit /opt/cc-remote/.env     # set LOGIN_PASSWORD / SESSION_SECRET / WRAPPER
 sudo bash /opt/cc-remote/deploy/setup-vps.sh your-domain.com
 ```
 
+For a public-IPv4-only deployment, use this matching configuration and target:
+
+```ini
+# /opt/cc-remote/.env
+PUBLIC_ORIGIN=http://your-public-ip
+ALLOW_INSECURE_HTTP=1
+```
+
+```bash
+sudo bash /opt/cc-remote/deploy/setup-vps.sh your-public-ip
+```
+
+The installer selects the plain-HTTP Caddy template only when the opt-in is
+enabled, the argument is a public IPv4 address, and `PUBLIC_ORIGIN` matches it
+exactly. Private, loopback, reserved, and malformed addresses fail closed.
+
 The script installs `python3-venv` + Caddy, creates a `ccremote` system user, builds a venv + `pip install`, merges both a marked cc-remote site and global HTTP timeout/header limits into the Caddyfile while preserving other global options and sites, then starts `cc-remote-relay` + `caddy`. If the new relay restart or readiness check fails, the venv, Caddyfile, and systemd unit are restored as one transaction and the previous relay's `/healthz` is verified.
 
 Verify:
@@ -289,6 +312,8 @@ Verify:
 curl https://your-domain.com/healthz
 # expect: {"ok":true,"wrapper_connected":false,"clients":0}
 ```
+
+In insecure mode, use `curl http://your-public-ip/healthz` instead.
 
 ### 5) Your machine: root-only wrapper environment + systemd
 
@@ -310,11 +335,20 @@ sudo systemctl daemon-reload && sudo systemctl enable --now cc-remote-wrapper
 journalctl -u cc-remote-wrapper -f     # expect: connected to relay / wrapper running
 ```
 
-Back on the VPS, `curl https://your-domain.com/healthz` should now show `wrapper_connected:true`.
+In insecure mode, also set both wrapper-side values:
+
+```ini
+RELAY_URL=ws://your-public-ip/ws
+ALLOW_INSECURE_HTTP=1
+```
+
+Back on the VPS, the matching mode's `/healthz` should now show `wrapper_connected:true`.
 
 ### 6) Verify from a phone
 
-Open `https://your-domain.com/` on your phone (any network) → log in with `LOGIN_PASSWORD` → send a message. You should get streaming replies, interrupt, and multi-device sync.
+Open the matching `https://your-domain.com/` or `http://your-public-ip/` on
+your phone (any network) → log in with `LOGIN_PASSWORD` → send a message. You
+should get streaming replies, interrupt, and multi-device sync.
 
 ### Behind a corporate HTTP proxy?
 
@@ -339,7 +373,8 @@ HTTPS_PROXY=http://your-proxy:port      # for SOCKS use ALL_PROXY=socks5://...
 | `SESSION_TTL_SECONDS` | `604800` | Session token lifetime (default 7 days). |
 | `LOGIN_BODY_MAX_BYTES` / `LOGIN_READ_TIMEOUT` / `LOGIN_INFLIGHT_CAP` | `4096` / `10` / `32` | Hard limits for login body bytes, total read seconds, and concurrent body reads. |
 | `SESSION_REGISTRY_CAP` | `1024` | Hard limit for process-local revocable browser sessions. |
-| `PUBLIC_ORIGIN` | empty | Exact browser origin allowed to connect, e.g. `https://remote.example.com`; **required**, and non-loopback origins must use HTTPS. |
+| `PUBLIC_ORIGIN` | empty | Exact browser origin allowed to connect, e.g. `https://remote.example.com`; **required**, and non-loopback origins must use HTTPS (unless `ALLOW_INSECURE_HTTP` is set). |
+| `ALLOW_INSECURE_HTTP` | `0` | Escape hatch: set to `1` to let a non-loopback `PUBLIC_ORIGIN`/`RELAY_URL` stay plain `http://`/`ws://` instead of requiring HTTPS/WSS — e.g. reaching the relay over a bare public IP with no TLS terminator in front. Off by default; enabling it sends the login password, session cookie, and all traffic in cleartext, so anyone on the network path can read or hijack the session. Prefer TLS (Caddy/nginx, see the deploy section) whenever possible. |
 | `WRAPPER_TOKEN` | placeholder | Bearer token the wrapper presents; must match on both sides. Startup rejects placeholders and short values. |
 | `WEB_STATIC_DIR` | empty | Point at `web/dist` to serve the web client same-origin; empty = API/WS only. |
 | `CLIENT_QUEUE_CAP` / `CLIENT_QUEUE_BYTES` | `4096` / `16777216` | Hard per-client pending-frame/byte limits; a slow client is disconnected instead of silently losing frames. |
@@ -350,7 +385,8 @@ HTTPS_PROXY=http://your-proxy:port      # for SOCKS use ALL_PROXY=socks5://...
 
 | Var | Default | Notes |
 |---|---|---|
-| `RELAY_URL` | `ws://127.0.0.1:8765/ws` | Relay WebSocket URL (`wss://domain/ws` in prod). |
+| `RELAY_URL` | `ws://127.0.0.1:8765/ws` | Relay WebSocket URL (`wss://domain/ws` in prod, unless `ALLOW_INSECURE_HTTP` is set). |
+| `ALLOW_INSECURE_HTTP` | `0` | Same escape hatch as the relay; the wrapper reads it too so `RELAY_URL` can stay `ws://` against a non-loopback host. |
 | `WRAPPER_TOKEN` | `change-me-wrapper` | Same as relay. |
 | `CLAUDE_BIN` | empty | Optional absolute Claude CLI path; set it when systemd/PATH cannot find `claude`. |
 | `CC_CWD` | cwd | Default working directory for new sessions. Claude `--resume` needs it to locate `~/.claude/projects/` — **it must be correct**; Codex resume first recovers the original cwd from its rollout. |
@@ -384,7 +420,7 @@ Each message accepts at most 8 attachments, at most 6 MiB each and 8 MiB decoded
 
 - Claude sessions default to `permissionMode: bypassPermissions`. Codex defaults to approval policy `never` while inheriting the machine's Codex sandbox configuration; it can also use `on-request` / `untrusted`, with approval requests bridged to the web client. Regardless of the policy currently displayed, authenticated clients can create/switch sessions and change available controls. **Treat anyone authenticated to the relay as holding remote agent/shell authority on the wrapper machine.**
 - `LOGIN_PASSWORD` / `WRAPPER_TOKEN` / `SESSION_SECRET` are the only gate: use strong random values, never commit or paste them into chats, and rotate them. A repository `.env` is for local development only; production wrappers must use the root-only `/etc/cc-remote/wrapper.env` above. The systemd template prevents the service and model descendants from reading that source file or a legacy repository `.env`; on Linux the wrapper also disables dumpability so children cannot recover the captured token through `/proc/<pid>/environ` or process memory.
-- Always use TLS (`wss://`) in production (this repo uses Caddy for automatic certs). Do not expose plain `ws://` publicly.
+- Always use TLS (`wss://`) in production (this repo uses Caddy for automatic certs). Do not expose plain `ws://` publicly. Only set `ALLOW_INSECURE_HTTP=1` when you genuinely need to run temporarily over a bare public IP with plain HTTP/WS (e.g. before a domain and TLS are set up); with it on, the login password, session cookie, and all traffic are unencrypted and can be read or hijacked by anyone on the network path — switch back to TLS as soon as you can.
 - Recommended: restrict the relay by IP / only run it when needed; login is rate-limited (5/min per IP) out of the box.
 
 ## Model backend (optional)

--- a/cc_remote/config.py
+++ b/cc_remote/config.py
@@ -36,6 +36,13 @@ def _float(key: str, default: float) -> float:
     return float(v) if v and v.strip() else default
 
 
+def _bool(key: str, default: bool = False) -> bool:
+    v = os.environ.get(key)
+    if v is None or not v.strip():
+        return default
+    return v.strip().lower() in {"1", "true", "yes", "on"}
+
+
 @dataclass
 class RelayConfig:
     host: str = field(default_factory=lambda: _env("RELAY_HOST", "127.0.0.1"))
@@ -74,6 +81,12 @@ class RelayConfig:
     # Exact browser Origin accepted for cookie-authenticated WebSockets, for
     # example https://remote.example.com (no path or trailing slash).
     public_origin: str = field(default_factory=lambda: _env("PUBLIC_ORIGIN", ""))
+    # Opt-in escape hatch: allow a non-loopback PUBLIC_ORIGIN/RELAY_URL to stay
+    # on plain http(s)/ws(s) instead of requiring TLS. Off by default; turning
+    # it on trades transport confidentiality (password, cookie, tokens, and all
+    # traffic travel in cleartext) for being reachable over a bare public IP
+    # without a TLS terminator in front.
+    allow_insecure_http: bool = field(default_factory=lambda: _bool("ALLOW_INSECURE_HTTP"))
 
 
 @dataclass
@@ -82,6 +95,10 @@ class WrapperConfig:
     # Token the wrapper presents to the relay at WS upgrade (must match the
     # relay's WRAPPER_TOKEN). Same env name as the relay for convenience.
     wrapper_token: str = field(default_factory=lambda: _env("WRAPPER_TOKEN", "change-me-wrapper"))
+    # Same opt-in escape hatch as the relay's ALLOW_INSECURE_HTTP: lets
+    # RELAY_URL stay ws:// against a non-loopback host instead of requiring
+    # wss://. Off by default.
+    allow_insecure_http: bool = field(default_factory=lambda: _bool("ALLOW_INSECURE_HTTP"))
     # Optional explicit Claude Code executable. Blank preserves the existing
     # SDK/PATH discovery behavior.
     claude_bin: str = field(default_factory=lambda: _env("CLAUDE_BIN", "").strip())
@@ -214,9 +231,11 @@ def validate_relay_config(cfg: RelayConfig) -> None:
             # Store exactly the serialization browsers use for Origin headers,
             # including lower-case host and omitted default port.
             cfg.public_origin = canonical_origin
-            if scheme != "https" and canonical_host not in {
-                "127.0.0.1", "::1", "localhost"
-            }:
+            if (
+                scheme != "https"
+                and canonical_host not in {"127.0.0.1", "::1", "localhost"}
+                and not cfg.allow_insecure_http
+            ):
                 errors.append("PUBLIC_ORIGIN must use https except on loopback")
 
     if errors:
@@ -245,7 +264,11 @@ def validate_wrapper_config(cfg: WrapperConfig) -> None:
         errors.append("RELAY_URL must be a ws(s) URL without credentials, query, or fragment")
     else:
         loopback = parsed.hostname in {"127.0.0.1", "::1", "localhost"}
-        if parsed.scheme != "wss" and not loopback:
+        if (
+            parsed.scheme != "wss"
+            and not loopback
+            and not cfg.allow_insecure_http
+        ):
             errors.append("RELAY_URL must use wss except on loopback")
     if parsed.path != "/ws":
         errors.append("RELAY_URL path must be /ws")

--- a/cc_remote/relay/server.py
+++ b/cc_remote/relay/server.py
@@ -181,12 +181,15 @@ class _BodyTooLarge(ValueError):
 
 
 def _cookie_secure(cfg: RelayConfig) -> bool:
-    """Allow an insecure cookie only for the explicit loopback quick-start."""
+    """Allow an insecure cookie for the loopback quick-start, or when the
+    operator has explicitly opted into ALLOW_INSECURE_HTTP for a plain-http
+    public origin."""
     origin = urlsplit(cfg.public_origin.strip().rstrip("/"))
-    return not (
-        origin.scheme == "http"
-        and origin.hostname in {"127.0.0.1", "::1", "localhost"}
-    )
+    if origin.scheme != "http":
+        return True
+    if origin.hostname in {"127.0.0.1", "::1", "localhost"}:
+        return False
+    return not cfg.allow_insecure_http
 
 
 def _rate_limited(ip: str) -> bool:

--- a/cc_remote/tui.py
+++ b/cc_remote/tui.py
@@ -15,6 +15,9 @@ Env:
   LOGIN_PASSWORD  optional; if omitted the TUI prompts without echo
   PUBLIC_ORIGIN   optional WebSocket Origin override (normally derived from URL)
   ENGINE          claude | codex   (which store to list / which backend for /new)
+  ALLOW_INSECURE_HTTP  1/true to allow a non-loopback RELAY_URL to stay ws://
+                        instead of requiring wss:// (default off; traffic
+                        including the login password travels in cleartext)
 
 Usage:
   python -m cc_remote.tui [session_id]     # attach to session_id, or pick from a list
@@ -66,6 +69,11 @@ RELAY_URL = os.environ.get("RELAY_URL", "ws://127.0.0.1:8765/ws")
 LOGIN_PASSWORD = os.environ.get("LOGIN_PASSWORD", "")
 PUBLIC_ORIGIN = os.environ.get("PUBLIC_ORIGIN", "")
 ENGINE = os.environ.get("ENGINE", "claude")
+# Same opt-in escape hatch as the relay/wrapper: lets RELAY_URL stay ws://
+# against a non-loopback host instead of requiring wss://. Off by default.
+ALLOW_INSECURE_HTTP = os.environ.get("ALLOW_INSECURE_HTTP", "").strip().lower() in {
+    "1", "true", "yes", "on",
+}
 TUI_OUTBOX_CAP = 256
 TUI_OUTBOX_BYTES = 32 * 1024 * 1024
 TUI_MAX_FRAME_BYTES = 16 * 1024 * 1024
@@ -163,7 +171,7 @@ def _validate_relay_url(ws_url: str) -> str:
         loopback = ipaddress.ip_address(host).is_loopback
     except ValueError:
         loopback = host.lower() == "localhost"
-    if parsed.scheme != "wss" and not loopback:
+    if parsed.scheme != "wss" and not loopback and not ALLOW_INSECURE_HTTP:
         raise ValueError("RELAY_URL must use wss:// outside loopback")
     return ws_url
 

--- a/deploy/Caddyfile.insecure
+++ b/deploy/Caddyfile.insecure
@@ -1,0 +1,24 @@
+# /etc/caddy/Caddyfile — explicit plain-HTTP public-IP escape hatch.
+#
+# setup-vps.sh selects this template only when ALLOW_INSECURE_HTTP=1 and its
+# argument is a public IPv4 address. The explicit http:// address prevents
+# Caddy from enabling automatic HTTPS. Relay traffic remains behind Caddy so
+# the normal request limits still apply.
+
+http://cc-remote.example.com {
+	@entry path / /index.html
+	@login path /api/login
+	request_body @login {
+		max_size 4KB
+	}
+	header @entry Cache-Control "no-store"
+	header {
+		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws://cc-remote.example.com; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "no-referrer"
+		Permissions-Policy "camera=(), microphone=(), geolocation=()"
+	}
+	reverse_proxy 127.0.0.1:8765
+	encode zstd gzip
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,7 +4,9 @@ Reference files for the production deploy (public VPS relay + wrapper on your
 machine). The **full step-by-step guide is in the main [README](../README.md#生产部署公网-vps-中继--你机器上的-wrapper)**
 ([English](../README_en.md#production-deploy-public-vps-relay--wrapper-on-your-machine)).
 
-- `setup-vps.sh` — idempotent VPS setup: validates required secrets, installs
+- `setup-vps.sh` — idempotent VPS setup for either the normal domain + TLS
+  path or the explicit `ALLOW_INSECURE_HTTP=1` public-IPv4 + plain-HTTP escape
+  hatch: validates required secrets, installs
   Caddy + a hardened `ccremote` systemd service, keeps the app/venv root-owned
   and read-only to that service account, updates a marked cc-remote
   site block without overwriting unrelated Caddy sites, manages bounded global
@@ -12,7 +14,11 @@ machine). The **full step-by-step guide is in the main [README](../README.md#生
   restarts both services. If the new relay fails to restart or become ready,
   the venv, Caddyfile, and relay unit are restored as one transaction and the
   previous relay is health-checked.
-  Run as `sudo bash deploy/setup-vps.sh your-domain.com` after following the
+  Run as `sudo bash deploy/setup-vps.sh your-domain.com` for TLS, or set
+  `PUBLIC_ORIGIN=http://your-public-ip` and `ALLOW_INSECURE_HTTP=1` before
+  running `sudo bash deploy/setup-vps.sh your-public-ip`. The insecure mode
+  still keeps the relay on loopback behind Caddy, but Caddy listens on port 80
+  without TLS. Run the script after following the
   main README's maintenance-window publish flow: upload to a user-owned staging
   directory, stop the relay, then `sudo rsync --delete` into the root-owned
   `/opt/cc-remote`. Keep the existing `.env` and `.venv` excluded from that
@@ -21,6 +27,8 @@ machine). The **full step-by-step guide is in the main [README](../README.md#生
 - `Caddyfile` — reverse proxy + auto Let's Encrypt TLS (`wss://domain/ws` →
   `127.0.0.1:8765`) plus an early 4 KiB login-body limit. Replace
   `cc-remote.example.com` with your domain.
+- `Caddyfile.insecure` — explicit plain-HTTP public-IP template selected only
+  when `ALLOW_INSECURE_HTTP=1`; it omits HSTS and permits `ws://` in CSP.
 - `cc-remote-relay.service` — systemd unit for the relay on the VPS.
 - `cc-remote-wrapper.service` — systemd unit for the wrapper on your machine
   (edit `User` + paths first). It reads root-only
@@ -44,7 +52,8 @@ The relay is exposed publicly; `LOGIN_PASSWORD`, `SESSION_SECRET`, and
 policy `never`. Treat every logged-in client as holding remote agent/shell
 authority on the wrapper machine. Use strong secrets, keep relay `.env` out of
 git, never store the production wrapper token in a model-readable repository
-file, and always terminate TLS at Caddy.
+file. Always prefer TLS at Caddy; the public-IP escape hatch sends the login
+password, browser cookie, wrapper token, and session traffic unencrypted.
 See the [security section](../README.md#安全须知务必读) of the main README.
 
 The relay itself limits unfinished login bodies to 32 concurrent reads and 10

--- a/deploy/env.relay.example
+++ b/deploy/env.relay.example
@@ -6,6 +6,11 @@ RELAY_HOST=127.0.0.1
 RELAY_PORT=8765
 # Exact browser origin allowed to open a cookie-authenticated WebSocket.
 PUBLIC_ORIGIN=https://cc-remote.example.com
+# Leave at 0 for the normal domain + TLS path. Set to 1 only for the supported
+# public-IPv4 escape hatch, change PUBLIC_ORIGIN to http://your-public-ip, and
+# pass the same IP to setup-vps.sh. Caddy will listen on plain port 80; the
+# login password, session cookie, and all traffic travel in cleartext.
+ALLOW_INSECURE_HTTP=0
 # Web login password (what you type in the browser to log in). REQUIRED.
 LOGIN_PASSWORD=REPLACE_WITH_A_STRONG_PASSWORD
 # HMAC secret for signing web session tokens. REQUIRED.

--- a/deploy/env.wrapper.example
+++ b/deploy/env.wrapper.example
@@ -5,6 +5,9 @@
 # Generate it with `openssl rand -hex 32`; setup-vps.sh rejects values shorter
 # than 32 characters on the relay.
 RELAY_URL=wss://your-domain.com/ws
+# Set to 1 only when RELAY_URL intentionally uses ws:// against a public IP.
+# The wrapper token and all session traffic will cross the network unencrypted.
+ALLOW_INSECURE_HTTP=0
 WRAPPER_TOKEN=REPLACE_WITH_STRONG_WRAPPER_TOKEN
 # Explicit executable avoids relying on systemd's minimal PATH. Leave blank to
 # use the existing PATH discovery behavior.

--- a/deploy/setup-vps.sh
+++ b/deploy/setup-vps.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # vps setup (Ubuntu/Debian). Run as root/sudo:
 #   sudo bash deploy/setup-vps.sh your-domain.com
+#   sudo bash deploy/setup-vps.sh your-public-ip  # ALLOW_INSECURE_HTTP=1
 #
 # Assumes /opt/cc-remote already contains: the code, web/dist (from
 # `npm --prefix web run build`), requirements.lock, and a filled-in .env (from
@@ -8,10 +9,10 @@
 # WRAPPER_TOKEN).
 set -euo pipefail
 
-DOMAIN_INPUT="${1:?usage: sudo bash setup-vps.sh your-domain.com}"
-# Browser Origin serialization lower-cases DNS hostnames.  Use that canonical
+TARGET_INPUT="${1:?usage: sudo bash setup-vps.sh domain-or-public-ip}"
+# Browser Origin serialization lower-cases DNS hostnames. Use that canonical
 # spelling in Caddy and require the same spelling in PUBLIC_ORIGIN.
-DOMAIN="${DOMAIN_INPUT,,}"
+TARGET="${TARGET_INPUT,,}"
 APPDIR=/opt/cc-remote
 ENV_FILE="$APPDIR/.env"
 VENV_STAGE=""
@@ -31,6 +32,9 @@ UNIT_CHANGED=0
 UNIT_HAD_FILE=0
 RELAY_SERVICE_TOUCHED=0
 ROLLBACK_DONE=0
+INSECURE_HTTP=0
+PUBLIC_SCHEME=https
+CADDY_TEMPLATE=""
 
 [ -r "$APPDIR/deploy/setup_transaction.sh" ] || {
   echo "ERROR: $APPDIR/deploy/setup_transaction.sh is missing" >&2
@@ -98,19 +102,44 @@ require_secret() {
 command -v python3 >/dev/null 2>&1 || die "python3 is required (3.10 or newer)"
 python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' || \
   die "Python 3.10 or newer is required (use Ubuntu 22.04+ or Debian 12+)"
-[[ "$DOMAIN" == *.* && "$DOMAIN" != *..* &&
-   "$DOMAIN" =~ ^[a-z0-9]([a-z0-9.-]*[a-z0-9])$ ]] ||
-  die "domain must be a hostname such as cc.example.com (without a scheme or path)"
 
 [ -f "$ENV_FILE" ] || die "$ENV_FILE missing (copy deploy/env.relay.example, fill tokens)"
 [ ! -L "$ENV_FILE" ] || die "$ENV_FILE must be a regular file, not a symlink"
+ALLOW_INSECURE_VALUE="$(read_env_value ALLOW_INSECURE_HTTP 2>/dev/null || printf '0')"
+case "${ALLOW_INSECURE_VALUE,,}" in
+  1|true|yes|on)
+    INSECURE_HTTP=1
+    PUBLIC_SCHEME=http
+    CADDY_TEMPLATE="$APPDIR/deploy/Caddyfile.insecure"
+    python3 - "$TARGET" <<'PY' || \
+      die "ALLOW_INSECURE_HTTP=1 requires a public IPv4 address as the setup target"
+import ipaddress
+import sys
+
+address = ipaddress.ip_address(sys.argv[1])
+raise SystemExit(not (
+    address.version == 4 and address.is_global and not address.is_multicast
+))
+PY
+    ;;
+  0|false|no|off|"")
+    [[ "$TARGET" == *.* && "$TARGET" != *..* &&
+       "$TARGET" =~ ^[a-z0-9]([a-z0-9.-]*[a-z0-9])$ &&
+       ! "$TARGET" =~ ^[0-9.]+$ ]] ||
+      die "TLS mode requires a hostname such as cc.example.com (without a scheme or path)"
+    CADDY_TEMPLATE="$APPDIR/deploy/Caddyfile"
+    ;;
+  *)
+    die "ALLOW_INSECURE_HTTP must be one of 1/true/yes/on or 0/false/no/off"
+    ;;
+esac
 [ -d "$APPDIR/web/dist" ] || die "$APPDIR/web/dist missing (run 'npm --prefix web run build' on your dev machine, then rsync web/dist here)"
 [ -s "$APPDIR/web/dist/index.html" ] || die "$APPDIR/web/dist/index.html missing or empty"
 [ -s "$APPDIR/web/dist/cc-remote-build.json" ] || die "$APPDIR/web/dist/cc-remote-build.json missing"
 grep -Eq '"protocol"[[:space:]]*:[[:space:]]*10' \
   "$APPDIR/web/dist/cc-remote-build.json" || die "web build protocol is not v10"
 [ -f "$APPDIR/requirements.lock" ] || die "$APPDIR/requirements.lock missing"
-[ -f "$APPDIR/deploy/Caddyfile" ] || die "$APPDIR/deploy/Caddyfile missing"
+[ -f "$CADDY_TEMPLATE" ] || die "$CADDY_TEMPLATE missing"
 [ -f "$APPDIR/deploy/caddy_managed_block.py" ] || die "$APPDIR/deploy/caddy_managed_block.py missing"
 [ -f "$APPDIR/deploy/setup_transaction.sh" ] || die "$APPDIR/deploy/setup_transaction.sh missing"
 [ -f "$APPDIR/deploy/cc-remote-relay.service" ] || die "$APPDIR/deploy/cc-remote-relay.service missing"
@@ -120,8 +149,8 @@ require_secret SESSION_SECRET 32
 require_secret WRAPPER_TOKEN 32
 CONFIGURED_ORIGIN="$(read_env_value PUBLIC_ORIGIN)" || \
   die "PUBLIC_ORIGIN is missing from $ENV_FILE"
-[[ "$CONFIGURED_ORIGIN" == "https://$DOMAIN" ]] || \
-  die "PUBLIC_ORIGIN must be exactly https://$DOMAIN"
+[[ "$CONFIGURED_ORIGIN" == "$PUBLIC_SCHEME://$TARGET" ]] || \
+  die "PUBLIC_ORIGIN must be exactly $PUBLIC_SCHEME://$TARGET"
 CONFIGURED_RELAY_HOST="$(read_env_value RELAY_HOST)" || \
   die "RELAY_HOST is missing from $ENV_FILE"
 CONFIGURED_RELAY_PORT="$(read_env_value RELAY_PORT)" || \
@@ -180,15 +209,15 @@ mv "$VENV_STAGE" "$APPDIR/.venv"
 VENV_STAGE=""
 VENV_SWAPPED=1
 
-echo "==> Caddy config (domain: $DOMAIN)"
+echo "==> Caddy config ($PUBLIC_SCHEME://$TARGET)"
 CADDY_SITE="$(mktemp /etc/caddy/cc-remote-site.XXXXXX)"
 CADDY_CANDIDATE="$(mktemp /etc/caddy/Caddyfile.cc-remote.XXXXXX)"
-sed "s/cc-remote\.example\.com/$DOMAIN/g" "$APPDIR/deploy/Caddyfile" > "$CADDY_SITE"
+sed "s/cc-remote\.example\.com/$TARGET/g" "$CADDY_TEMPLATE" > "$CADDY_SITE"
 python3 "$APPDIR/deploy/caddy_managed_block.py" \
   --current "$CADDYFILE" \
   --site "$CADDY_SITE" \
   --output "$CADDY_CANDIDATE" \
-  --domain "$DOMAIN"
+  --domain "$TARGET"
 chmod 0644 "$CADDY_CANDIDATE"
 caddy validate --config "$CADDY_CANDIDATE" --adapter caddyfile
 
@@ -248,7 +277,10 @@ rm -rf "$VENV_BACKUP"
 
 echo
 echo "Done. Check:"
-echo "  https://$DOMAIN/healthz   (should show {\"ok\":true,...})"
-echo "  https://$DOMAIN/          (web client)"
+echo "  $PUBLIC_SCHEME://$TARGET/healthz   (should show {\"ok\":true,...})"
+echo "  $PUBLIC_SCHEME://$TARGET/          (web client)"
+if (( INSECURE_HTTP )); then
+  echo "  WARNING: login credentials, cookies, and session traffic are unencrypted"
+fi
 echo "  journalctl -u cc-remote-relay -f"
 echo "  journalctl -u caddy -f"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -611,6 +611,32 @@ def test_relay_config_rejects_non_tls_public_origin():
         validate_relay_config(_cfg(public_origin="http://remote.example"))
 
 
+def test_allow_insecure_http_permits_a_plain_http_public_ip_origin():
+    # Explicit opt-in escape hatch: a bare public IP without a TLS terminator.
+    cfg = _cfg(public_origin="http://198.51.100.10:8765", allow_insecure_http=True)
+    validate_relay_config(cfg)  # must not raise
+    assert cfg.public_origin == "http://198.51.100.10:8765"
+
+
+def test_allow_insecure_http_off_still_rejects_non_tls_public_origin():
+    with pytest.raises(ValueError, match="PUBLIC_ORIGIN must use https"):
+        validate_relay_config(
+            _cfg(public_origin="http://remote.example", allow_insecure_http=False)
+        )
+
+
+def test_allow_insecure_http_cookie_is_not_secure_for_plain_http_public_origin():
+    cfg = _cfg(
+        public_origin="http://198.51.100.10:8765", allow_insecure_http=True
+    )
+    with TestClient(create_app(cfg), base_url=cfg.public_origin) as client:
+        response = _login(client, cfg)
+    cookie = response.headers["set-cookie"].lower()
+    assert "secure" not in cookie
+    assert "httponly" in cookie
+    assert "samesite=strict" in cookie
+
+
 @pytest.mark.parametrize(
     ("configured", "canonical"),
     [

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -92,7 +92,12 @@ def test_setup_script_is_valid_shell_and_keeps_safe_install_order():
     assert "require_secret LOGIN_PASSWORD 16" in source
     assert "require_secret SESSION_SECRET 32" in source
     assert "require_secret WRAPPER_TOKEN 32" in source
-    assert 'DOMAIN="${DOMAIN_INPUT,,}"' in source
+    assert 'TARGET="${TARGET_INPUT,,}"' in source
+    assert 'PUBLIC_SCHEME=http' in source
+    assert 'CADDY_TEMPLATE="$APPDIR/deploy/Caddyfile.insecure"' in source
+    assert "address.version == 4 and address.is_global" in source
+    assert "not address.is_multicast" in source
+    assert '"$CONFIGURED_ORIGIN" == "$PUBLIC_SCHEME://$TARGET"' in source
     assert '[[ "$CONFIGURED_RELAY_HOST" == "127.0.0.1" ]]' in source
     assert '[[ "$CONFIGURED_RELAY_PORT" == "8765" ]]' in source
     assert '[[ "$CONFIGURED_STATIC_DIR" == "$APPDIR/web/dist" ]]' in source
@@ -103,6 +108,22 @@ def test_setup_script_is_valid_shell_and_keeps_safe_install_order():
     assert "UNIT_BACKUP=" in source
     assert 'cp -a "$RELAY_UNIT_FILE" "$UNIT_BACKUP"' in source
     assert "RELAY_SERVICE_TOUCHED=1" in source
+
+
+def test_insecure_caddy_template_is_explicit_http_without_tls_headers():
+    source = (ROOT / "deploy" / "Caddyfile.insecure").read_text()
+    assert "http://cc-remote.example.com {" in source
+    assert "ws://cc-remote.example.com" in source
+    assert "reverse_proxy 127.0.0.1:8765" in source
+    assert "Strict-Transport-Security" not in source
+    assert "https://" not in source
+
+
+def test_deploy_examples_configure_insecure_flag_on_both_sides():
+    relay = (ROOT / "deploy" / "env.relay.example").read_text()
+    wrapper = (ROOT / "deploy" / "env.wrapper.example").read_text()
+    assert "ALLOW_INSECURE_HTTP=0" in relay
+    assert "ALLOW_INSECURE_HTTP=0" in wrapper
 
 
 def test_setup_does_not_make_network_service_owner_of_root_executed_code():

--- a/tests/test_transport_bounds.py
+++ b/tests/test_transport_bounds.py
@@ -26,6 +26,11 @@ def test_wrapper_startup_config_fails_closed():
         validate_wrapper_config(WrapperConfig(wrapper_token="change-me-wrapper"))
     with pytest.raises(ValueError, match="must use wss"):
         validate_wrapper_config(_wrapper_cfg(relay_url="ws://relay.example/ws"))
+    # ALLOW_INSECURE_HTTP is an explicit opt-in escape hatch for a bare public
+    # IP without TLS in front; it must not affect the default (off) path above.
+    validate_wrapper_config(
+        _wrapper_cfg(relay_url="ws://relay.example/ws", allow_insecure_http=True)
+    )
     with pytest.raises(ValueError, match="path must be /ws"):
         validate_wrapper_config(_wrapper_cfg(relay_url="wss://relay.example/other"))
     with pytest.raises(ValueError, match="WRAPPER_INBOX_BYTES"):

--- a/tests/test_tui_reliability.py
+++ b/tests/test_tui_reliability.py
@@ -414,3 +414,15 @@ def test_tui_rejects_unsafe_relay_url_before_login(url):
 ])
 def test_tui_accepts_tls_or_loopback_relay_url(url):
     assert _validate_relay_url(url) == url
+
+
+def test_tui_rejects_plain_ws_public_ip_unless_allow_insecure_http(monkeypatch):
+    import cc_remote.tui as tui_module
+
+    url = "ws://198.51.100.10:8765/ws"
+    monkeypatch.setattr(tui_module, "ALLOW_INSECURE_HTTP", False)
+    with pytest.raises(ValueError):
+        _validate_relay_url(url)
+
+    monkeypatch.setattr(tui_module, "ALLOW_INSECURE_HTTP", True)
+    assert _validate_relay_url(url) == url


### PR DESCRIPTION
## Summary
- Add an `ALLOW_INSECURE_HTTP` opt-in flag (default off) that lets a non-loopback `PUBLIC_ORIGIN` / `RELAY_URL` stay on plain `http`/`ws` instead of requiring TLS.
- Apply the flag consistently across relay and wrapper validation, relay cookie handling, and the standalone TUI.
- Support the bundled VPS installer in two fail-closed modes: domain + automatic TLS, or an explicitly opted-in public IPv4 + plain HTTP Caddy configuration.
- Keep the relay loopback-only behind Caddy in insecure mode so request limits, service hardening, and transactional rollback remain active.
- Document the cleartext credential, cookie, wrapper-token, and session-traffic risk in both languages and in the relay/wrapper deployment examples.

## Test plan
- [x] Added coverage for relay/wrapper/TUI opt-in behavior and the HTTP cookie attributes.
- [x] Added deployment checks for the dedicated plain-HTTP Caddy template, strict public-IPv4 selection, and matching relay/wrapper examples.
- [x] Ran the complete Python suite: `546 passed, 1 skipped`.
- [x] Ran `shellcheck deploy/setup-vps.sh deploy/setup_transaction.sh`.
- [x] Ran `bash -n deploy/setup-vps.sh` and `git diff --check`.
