### PR TITLE
Add Windows compatibility for wrapper

### DIFF
--- a/cc_remote/codex_daemon_restart.py
+++ b/cc_remote/codex_daemon_restart.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import argparse
 from contextlib import contextmanager
 from dataclasses import dataclass
-import fcntl
 import json
 import os
 from pathlib import Path
@@ -21,6 +20,9 @@ import tempfile
 import time
 from typing import Literal, Optional
 from uuid import uuid4
+
+from cc_remote.wrapper.file_lock_compat import LOCK_EX, LOCK_UN, flock
+from cc_remote.wrapper.os_compat import fchmod
 
 
 _SCHEMA_VERSION = 2
@@ -153,7 +155,7 @@ def write_restart_state(
     fd, temporary = tempfile.mkstemp(
         prefix=f".{target.name}.", dir=target.parent)
     try:
-        os.fchmod(fd, 0o600)
+        fchmod(fd, temporary, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             fd = -1
             stream.write(payload)
@@ -175,11 +177,11 @@ def _exclusive_lock(path: Path):
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
     try:
-        os.fchmod(fd, 0o600)
-        fcntl.flock(fd, fcntl.LOCK_EX)
+        fchmod(fd, path, 0o600)
+        flock(fd, LOCK_EX)
         yield
     finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
+        flock(fd, LOCK_UN)
         os.close(fd)
 
 
@@ -411,7 +413,7 @@ def schedule_managed_daemon_restart(
         0o600,
     )
     try:
-        os.fchmod(log_fd, 0o600)
+        fchmod(log_fd, log_path, 0o600)
         subprocess.Popen(
             argv,
             stdin=subprocess.DEVNULL,

--- a/cc_remote/config.py
+++ b/cc_remote/config.py
@@ -12,11 +12,14 @@ import json
 import os
 import re
 import stat
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlsplit
 
-from cc_remote.claude_broker.paths import default_socket_path
+if sys.platform != "win32":
+    from cc_remote.claude_broker.paths import default_socket_path
+
 
 try:
     from dotenv import load_dotenv
@@ -203,7 +206,11 @@ class WrapperConfig:
     # experiment. It is intentionally disabled in the supported product path:
     # direct native Claude owners are mirrored read-only and explicitly taken
     # over by the SDK instead of sharing a PTY input state machine.
-    claude_broker_socket: str = field(default_factory=default_socket_path)
+    claude_broker_socket: str = field(
+        default_factory=(
+            default_socket_path if sys.platform != "win32" else lambda: ""
+        )
+    )
     experimental_claude_broker: bool = field(
         default_factory=lambda: _bool(
             "CC_REMOTE_EXPERIMENTAL_CLAUDE_BROKER", False))
@@ -531,10 +538,14 @@ def validate_wrapper_config(cfg: WrapperConfig) -> None:
                 "CC_REMOTE_CODEX_PROXY must be an http(s) or socks5 URL "
                 "without credentials, path, query, or fragment")
     if cfg.experimental_claude_broker:
-        if (not cfg.claude_broker_socket
-                or "\x00" in cfg.claude_broker_socket
-                or len(cfg.claude_broker_socket.encode(
-                    "utf-8", errors="surrogatepass")) > 4096):
+        if sys.platform == "win32":
+            errors.append(
+                "CC_REMOTE_EXPERIMENTAL_CLAUDE_BROKER is not supported on "
+                "Windows")
+        elif (not cfg.claude_broker_socket
+              or "\x00" in cfg.claude_broker_socket
+              or len(cfg.claude_broker_socket.encode(
+                  "utf-8", errors="surrogatepass")) > 4096):
             errors.append(
                 "CC_REMOTE_CLAUDE_BROKER_SOCKET must be a non-empty path of at "
                 "most 4096 UTF-8 bytes")

--- a/cc_remote/device.py
+++ b/cc_remote/device.py
@@ -18,6 +18,7 @@ from urllib.parse import urlsplit
 import httpx
 
 from cc_remote.config import device_config_path
+from cc_remote.wrapper.os_compat import fchmod
 
 
 def _origin(value: str) -> str:
@@ -53,7 +54,7 @@ def _write_private_text(path: Path, content: str, *, replace: bool) -> None:
     fd, staged_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
     staged = Path(staged_name)
     try:
-        os.fchmod(fd, 0o600)
+        fchmod(fd, staged, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(content)
             handle.flush()

--- a/cc_remote/wrapper/claude_controls.py
+++ b/cc_remote/wrapper/claude_controls.py
@@ -8,12 +8,14 @@ import os
 from pathlib import Path
 import re
 import stat
+import sys
 import threading
 from typing import Any
 from uuid import UUID, uuid4
 
 from claude_agent_sdk import get_session_messages
 
+from cc_remote.wrapper.os_compat import current_uid, fsync_directory
 from cc_remote.wrapper.stream import transcript_path
 
 
@@ -171,8 +173,9 @@ class ClaudeControlStore:
         except FileNotFoundError:
             return {}
         if (not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode)
-                or info.st_uid != os.getuid()
-                or stat.S_IMODE(info.st_mode) & 0o077
+                or info.st_uid != current_uid()
+                or (sys.platform != "win32"
+                    and stat.S_IMODE(info.st_mode) & 0o077)
                 or info.st_size > _MAX_FILE_BYTES):
             raise ClaudeControlStoreError(
                 "Claude control store is not a private bounded file")
@@ -235,11 +238,7 @@ class ClaudeControlStore:
                 raise
             os.replace(temporary, self.path)
             os.chmod(self.path, 0o600)
-            directory_fd = os.open(parent, os.O_RDONLY)
-            try:
-                os.fsync(directory_fd)
-            finally:
-                os.close(directory_fd)
+            fsync_directory(parent)
         except Exception as exc:
             try:
                 temporary.unlink()

--- a/cc_remote/wrapper/claude_forks.py
+++ b/cc_remote/wrapper/claude_forks.py
@@ -30,6 +30,7 @@ from claude_agent_sdk._internal.session_mutations import (
     _find_session_file_with_dir,
 )
 
+from cc_remote.wrapper.os_compat import fsync_directory
 
 _SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$")
 _MARKER_PREFIX = "cc-remote-fork:"
@@ -474,11 +475,7 @@ class ClaudeForkJournal:
                     pass
                 raise
             os.replace(tmp, self.path)
-            directory_fd = os.open(self.path.parent, os.O_RDONLY)
-            try:
-                os.fsync(directory_fd)
-            finally:
-                os.close(directory_fd)
+            fsync_directory(self.path.parent)
         except Exception as exc:
             try:
                 tmp.unlink()

--- a/cc_remote/wrapper/codex_checkpoints.py
+++ b/cc_remote/wrapper/codex_checkpoints.py
@@ -19,13 +19,12 @@ checkpoint boundary.  Empty directories are not representable in Git trees.
 from __future__ import annotations
 
 import copy
-import fcntl
 import hashlib
 import json
 import os
-import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import time
 import uuid
@@ -35,6 +34,8 @@ from pathlib import Path
 from typing import Any, Iterator, Optional
 
 from cc_remote.wrapper.child_env import sanitized_child_env
+from cc_remote.wrapper.file_lock_compat import flock, LOCK_EX, LOCK_UN
+from cc_remote.wrapper.os_compat import force_rmtree
 
 
 _FORMAT_VERSION = 2
@@ -276,10 +277,10 @@ class CodexCheckpointJournal:
         self.session_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         fd = os.open(self.lock_path, os.O_RDWR | os.O_CREAT, 0o600)
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            flock(fd, LOCK_EX)
             yield
         finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            flock(fd, LOCK_UN)
             os.close(fd)
 
     def _load_manifest(self) -> dict[str, Any]:
@@ -483,7 +484,7 @@ class CodexCheckpointJournal:
         try:
             os.replace(self.objects_dir, retired)
             self._initialize_object_store()
-            shutil.rmtree(retired, ignore_errors=False)
+            force_rmtree(retired)
         except OSError as exc:
             raise CheckpointError("Unable to compact checkpoint object store") from exc
 
@@ -1404,6 +1405,10 @@ class CodexCheckpointJournal:
     def cleanup(self, *, force: bool = False) -> None:
         """Remove the manifest and private object database for this session."""
         tombstone: Optional[Path] = None
+        # Windows cannot rename a directory while a file inside it (the
+        # journal lock we are about to release) is still held open, so the
+        # rename is deferred until after the lock's own finally closes it.
+        defer_rename = sys.platform == "win32"
         with self._locked():
             if not force:
                 manifest = self._load_manifest()
@@ -1414,7 +1419,10 @@ class CodexCheckpointJournal:
             tombstone = self.session_dir.with_name(
                 f".{self.session_dir.name}.delete-{uuid.uuid4().hex}"
             )
-            os.replace(self.session_dir, tombstone)
+            if not defer_rename:
+                os.replace(self.session_dir, tombstone)
             self._closed = True
+        if defer_rename:
+            os.replace(self.session_dir, tombstone)
         if tombstone is not None:
-            shutil.rmtree(tombstone, ignore_errors=False)
+            force_rmtree(tombstone)

--- a/cc_remote/wrapper/codex_controls.py
+++ b/cc_remote/wrapper/codex_controls.py
@@ -8,8 +8,11 @@ import os
 from pathlib import Path
 import re
 import stat
+import sys
 import threading
 from uuid import uuid4
+
+from cc_remote.wrapper.os_compat import current_uid, fsync_directory
 
 
 CODEX_APPROVAL_POLICIES = frozenset({"untrusted", "on-request", "never"})
@@ -288,8 +291,8 @@ class CodexControlStore:
         except FileNotFoundError:
             return {}
         if (not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode)
-                or info.st_uid != os.getuid()
-                or stat.S_IMODE(info.st_mode) & 0o077
+                or info.st_uid != current_uid()
+                or (sys.platform != "win32" and stat.S_IMODE(info.st_mode) & 0o077)
                 or info.st_size > _MAX_FILE_BYTES):
             raise CodexControlStoreError(
                 "Codex control store is not a private bounded file")
@@ -341,11 +344,7 @@ class CodexControlStore:
                 os.fsync(stream.fileno())
             os.replace(temporary, self.path)
             os.chmod(self.path, 0o600)
-            directory_fd = os.open(parent, os.O_RDONLY)
-            try:
-                os.fsync(directory_fd)
-            finally:
-                os.close(directory_fd)
+            fsync_directory(parent)
         except Exception as exc:
             try:
                 temporary.unlink()

--- a/cc_remote/wrapper/codex_daemon.py
+++ b/cc_remote/wrapper/codex_daemon.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Mapping, Optional
 
 from cc_remote.log import logger
+from cc_remote.wrapper.os_compat import current_uid
 from cc_remote.wrapper.process_scan import (
     _darwin_process_info,
     process_owner_uid,
@@ -121,7 +122,7 @@ def _managed_pid(path: Path) -> Optional[int]:
         )
         file_stat = os.fstat(descriptor)
         if (not stat.S_ISREG(file_stat.st_mode)
-                or file_stat.st_uid != os.getuid()
+                or file_stat.st_uid != current_uid()
                 or file_stat.st_size > _PID_RECORD_MAX):
             return None
         data = os.read(descriptor, _PID_RECORD_MAX + 1)
@@ -192,8 +193,8 @@ def _terminate_stale_darwin_daemon_updater(
         return False
     if updater_bin != os.path.realpath(codex_bin):
         return False
-    if (process_owner_uid(updater_pid) != os.getuid()
-            or process_owner_uid(app_server_pid) != os.getuid()
+    if (process_owner_uid(updater_pid) != current_uid()
+            or process_owner_uid(app_server_pid) != current_uid()
             or not (_darwin_process_state(app_server_pid) or "").startswith("Z")):
         return False
     # Close the PID-reuse window immediately before signalling both identities.

--- a/cc_remote/wrapper/codex_forks.py
+++ b/cc_remote/wrapper/codex_forks.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Optional
 from uuid import uuid4
 
+from cc_remote.wrapper.os_compat import fchmod, fsync_directory
 
 _SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$")
 _MAX_ENTRIES = 4096
@@ -437,16 +438,12 @@ class CodexForkJournal:
             if len(payload.encode("utf-8")) > _MAX_FILE_BYTES:
                 raise ValueError("fork journal exceeds size limit")
             with tmp.open("w") as stream:
-                os.fchmod(stream.fileno(), 0o600)
+                fchmod(stream.fileno(), tmp, 0o600)
                 stream.write(payload)
                 stream.flush()
                 os.fsync(stream.fileno())
             os.replace(tmp, self.path)
-            directory_fd = os.open(self.path.parent, os.O_RDONLY)
-            try:
-                os.fsync(directory_fd)
-            finally:
-                os.close(directory_fd)
+            fsync_directory(self.path.parent)
         except Exception as exc:
             try:
                 tmp.unlink()

--- a/cc_remote/wrapper/codex_provider_repair.py
+++ b/cc_remote/wrapper/codex_provider_repair.py
@@ -28,6 +28,8 @@ import sqlite3
 import stat
 from typing import Any, Iterable, Optional
 
+from cc_remote.wrapper.os_compat import fsync_directory, pread, pwrite
+
 
 CANONICAL_OPENAI_PROVIDER_ID = "openai"
 HTTP_COMPAT_PROVIDER_ID = "cc_remote_openai_http"
@@ -423,7 +425,7 @@ def _replacement_first_line(original: bytes) -> bytes:
 def _pwrite_all(descriptor: int, payload: bytes, offset: int = 0) -> None:
     written = 0
     while written < len(payload):
-        count = os.pwrite(descriptor, payload[written:], offset + written)
+        count = pwrite(descriptor, payload[written:], offset + written)
         if count <= 0:
             raise OSError("short pwrite while repairing rollout metadata")
         written += count
@@ -463,7 +465,7 @@ def _write_journal(
         f".{path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp")
     descriptor = os.open(
         temp,
-        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
         0o600,
     )
     try:
@@ -472,11 +474,7 @@ def _write_journal(
     finally:
         os.close(descriptor)
     os.replace(temp, path)
-    directory = os.open(journal_dir, os.O_RDONLY)
-    try:
-        os.fsync(directory)
-    finally:
-        os.close(directory)
+    fsync_directory(journal_dir)
     return path
 
 
@@ -497,7 +495,7 @@ def _patch_rollout(
     journal = _write_journal(
         journal_dir, candidate, original, replacement,
     )
-    flags = os.O_RDWR
+    flags = os.O_RDWR | getattr(os, "O_BINARY", 0)
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
     descriptor = os.open(path, flags)
@@ -505,14 +503,14 @@ def _patch_rollout(
         before = os.fstat(descriptor)
         if not stat.S_ISREG(before.st_mode) or before.st_size < len(original):
             raise CodexProviderRepairError("rollout identity changed")
-        current = os.pread(descriptor, len(original), 0)
+        current = pread(descriptor, len(original), 0)
         if current != original:
             raise CodexProviderRepairError(
                 "rollout metadata changed before write",
             )
         _pwrite_all(descriptor, replacement)
         os.fsync(descriptor)
-        if os.pread(descriptor, len(replacement), 0) != replacement:
+        if pread(descriptor, len(replacement), 0) != replacement:
             raise CodexProviderRepairError(
                 "rollout metadata verification failed",
             )
@@ -597,7 +595,7 @@ def _recover_journals(
             raise CodexProviderRepairError(
                 "provider repair journal preimage does not match thread",
             )
-        flags = os.O_RDWR
+        flags = os.O_RDWR | getattr(os, "O_BINARY", 0)
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
         descriptor = os.open(rollout, flags)
@@ -607,7 +605,7 @@ def _recover_journals(
                 raise CodexProviderRepairError(
                     "journal rollout is not a regular file",
                 )
-            current = os.pread(descriptor, len(original), 0)
+            current = pread(descriptor, len(original), 0)
             if current not in {original, replacement}:
                 _pwrite_all(descriptor, original)
                 os.fsync(descriptor)
@@ -782,12 +780,12 @@ def repair_http_provider_records(
                 connection.rollback()
             for original, replacement, _journal, path in reversed(patched):
                 try:
-                    flags = os.O_RDWR
+                    flags = os.O_RDWR | getattr(os, "O_BINARY", 0)
                     if hasattr(os, "O_NOFOLLOW"):
                         flags |= os.O_NOFOLLOW
                     descriptor = os.open(path, flags)
                     try:
-                        current = os.pread(descriptor, len(replacement), 0)
+                        current = pread(descriptor, len(replacement), 0)
                         if current == replacement:
                             _pwrite_all(descriptor, original)
                             os.fsync(descriptor)

--- a/cc_remote/wrapper/codex_turn_leases.py
+++ b/cc_remote/wrapper/codex_turn_leases.py
@@ -16,6 +16,8 @@ import tempfile
 import time
 from typing import Optional
 
+from cc_remote.wrapper.os_compat import fchmod
+
 
 _SCHEMA_VERSION = 1
 _FILENAME = "codex-turn-leases.json"
@@ -110,7 +112,7 @@ class CodexTurnLeaseStore:
         fd, temporary = tempfile.mkstemp(
             prefix=f".{self.path.name}.", dir=self.path.parent)
         try:
-            os.fchmod(fd, 0o600)
+            fchmod(fd, temporary, 0o600)
             with os.fdopen(fd, "w", encoding="utf-8") as stream:
                 fd = -1
                 stream.write(payload)

--- a/cc_remote/wrapper/engine_capabilities.py
+++ b/cc_remote/wrapper/engine_capabilities.py
@@ -7,7 +7,6 @@ and deliberately avoids importing settings, credentials, schemas or plugin code.
 from __future__ import annotations
 
 import asyncio
-import fcntl
 import hashlib
 import json
 import os
@@ -29,6 +28,8 @@ from cc_remote.wrapper.codex_rpc import (
     codex_rpc,
     codex_rpc_batch,
 )
+from cc_remote.wrapper.file_lock_compat import flock, LOCK_EX, LOCK_UN
+from cc_remote.wrapper.os_compat import fchmod, fsync_directory
 
 _COMPONENT_TIMEOUT = 8.0
 _MAX_ITEMS = 500
@@ -721,7 +722,7 @@ def _atomic_update_json(path: Path, mutate) -> None:
     flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
     lock_fd = os.open(lock_path, flags, 0o600)
     try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        flock(lock_fd, LOCK_EX)
         current = _read_json_object(path)
         updated = mutate(current)
         if not isinstance(updated, dict):
@@ -736,24 +737,20 @@ def _atomic_update_json(path: Path, mutate) -> None:
             pass
         fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
         try:
-            os.fchmod(fd, mode)
+            fchmod(fd, temp_name, mode)
             with os.fdopen(fd, "wb") as handle:
                 handle.write(encoded)
                 handle.flush()
                 os.fsync(handle.fileno())
             os.replace(temp_name, path)
-            dir_fd = os.open(path.parent, os.O_RDONLY)
-            try:
-                os.fsync(dir_fd)
-            finally:
-                os.close(dir_fd)
+            fsync_directory(path.parent)
         finally:
             try:
                 os.unlink(temp_name)
             except FileNotFoundError:
                 pass
     finally:
-        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        flock(lock_fd, LOCK_UN)
         os.close(lock_fd)
 
 

--- a/cc_remote/wrapper/file_lock_compat.py
+++ b/cc_remote/wrapper/file_lock_compat.py
@@ -1,0 +1,44 @@
+"""Cross-platform advisory file locking for Windows and Unix."""
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+if sys.platform == "win32":
+    import msvcrt
+
+    LOCK_EX = 0x1
+    LOCK_UN = 0x0
+
+    def flock(fd: int, operation: int) -> None:
+        """Lock the first byte without changing the caller's file position."""
+        if operation not in {LOCK_EX, LOCK_UN}:
+            raise ValueError(f"Unsupported lock operation: {operation}")
+        # ``os.open`` defaults to text mode on Windows. Journals use raw byte
+        # reads/writes, so leave the descriptor in binary mode and avoid CRLF
+        # translation while the lock marker is updated.
+        msvcrt.setmode(fd, os.O_BINARY)
+        original_offset = os.lseek(fd, 0, os.SEEK_CUR)
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            if operation == LOCK_UN:
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                return
+            for attempt in range(100):
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                    return
+                except OSError:
+                    if attempt < 99:
+                        time.sleep(0.1)
+                    else:
+                        raise
+        finally:
+            os.lseek(fd, original_offset, os.SEEK_SET)
+else:
+    import fcntl
+
+    LOCK_EX = fcntl.LOCK_EX
+    LOCK_UN = fcntl.LOCK_UN
+    flock = fcntl.flock

--- a/cc_remote/wrapper/git_diff.py
+++ b/cc_remote/wrapper/git_diff.py
@@ -5,6 +5,7 @@ import asyncio
 import os
 import signal
 import stat
+import sys
 from collections.abc import Awaitable, Callable
 
 from cc_remote.wrapper.preview_capabilities import PreviewCapability
@@ -332,6 +333,13 @@ async def bounded_process_output(
     timed_out = False
 
     def stop_group(sig: signal.Signals) -> None:
+        if sys.platform == "win32":
+            try:
+                if proc.returncode is None:
+                    proc.kill()
+            except OSError:
+                pass
+            return
         try:
             os.killpg(proc.pid, sig)
         except ProcessLookupError:
@@ -343,19 +351,20 @@ async def bounded_process_output(
             await asyncio.wait_for(read_stdout(), timeout=timeout)
         except asyncio.TimeoutError:
             timed_out = True
+        _SIGKILL = getattr(signal, "SIGKILL", signal.SIGTERM)
         if timed_out:
-            stop_group(signal.SIGKILL)
+            stop_group(_SIGKILL)
         elif truncated:
             stop_group(signal.SIGTERM)
         try:
             await asyncio.wait_for(discard_stdout_and_wait(), timeout=2.0)
         except asyncio.TimeoutError:
-            stop_group(signal.SIGKILL)
+            stop_group(_SIGKILL)
             await discard_stdout_and_wait()
         reaped = True
     finally:
         if not reaped:
-            stop_group(signal.SIGKILL)
+            stop_group(_SIGKILL)
             await discard_stdout_and_wait()
     if timed_out:
         raise asyncio.TimeoutError("diff command exceeded its time limit")

--- a/cc_remote/wrapper/machine.py
+++ b/cc_remote/wrapper/machine.py
@@ -49,6 +49,7 @@ import signal
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import time
 import unicodedata
@@ -126,12 +127,13 @@ from cc_remote.wrapper.codex_controls import (
     CodexControlStoreError,
 )
 from cc_remote.wrapper.codex_daemon import CodexDaemonManager
-from cc_remote.claude_broker import BrokerClient, BrokerClientError
-from cc_remote.wrapper.claude_broker_handle import ClaudeBrokerHandle
-from cc_remote.wrapper.claude_broker_history import (
-    claude_broker_tail_state,
-    parse_claude_broker_lifecycle,
-)
+if sys.platform != "win32":
+    from cc_remote.claude_broker import BrokerClient, BrokerClientError
+    from cc_remote.wrapper.claude_broker_handle import ClaudeBrokerHandle
+    from cc_remote.wrapper.claude_broker_history import (
+        claude_broker_tail_state,
+        parse_claude_broker_lifecycle,
+    )
 from cc_remote.wrapper.ask import make_ask_server
 from cc_remote.wrapper.claude_questions import (
     AskCancelled,
@@ -248,9 +250,11 @@ from cc_remote.wrapper.preview_capabilities import (
     PreviewCapabilityError,
     PreviewCapabilityStore,
 )
+from cc_remote.wrapper.os_compat import current_uid, fchmod, fsync_directory
 from cc_remote.wrapper.transport import WrapperTransport
 
 log = logger("cc_remote.wrapper.machine")
+
 
 CLAUDE_PERMISSION_MODES = frozenset({
     "default", "acceptEdits", "plan", "auto", "bypassPermissions",
@@ -1090,13 +1094,22 @@ class WrapperMachine:
             getattr(cfg, "codex_daemon_mode", "auto"))
         self._codex_daemon_restart_path = restart_state_path(cfg.state_dir)
         self._codex_turn_leases = CodexTurnLeaseStore(cfg.state_dir)
-        self._claude_broker = BrokerClient(
-            getattr(cfg, "claude_broker_socket", None))
         # Claude's official SDK/CLI does not expose a supported multi-writer
         # control plane. Keep the PTY broker code available for development,
         # but never discover or adopt it in the customer path by default.
-        self._claude_broker_enabled = bool(getattr(
+        requested_broker = bool(getattr(
             cfg, "experimental_claude_broker", False))
+        self._claude_broker_enabled = (
+            requested_broker and sys.platform != "win32"
+        )
+        if sys.platform != "win32":
+            self._claude_broker = BrokerClient(
+                getattr(cfg, "claude_broker_socket", None))
+        else:
+            self._claude_broker = None
+            if requested_broker:
+                log.warning(
+                    "Claude broker is not supported on Windows; ignoring opt-in")
         # A History token changes for every wrapper process and every local
         # destructive conversation mutation.  Browsers persist this token with
         # IndexedDB turns, so a fresh wrapper can never merge a pre-crash cache
@@ -3019,17 +3032,13 @@ class WrapperMachine:
             if len(payload.encode("utf-8")) > self.PRIVATE_BTW_FILE_MAX_BYTES:
                 raise ValueError("private btw state exceeds size limit")
             with tmp.open("w") as stream:
-                os.fchmod(stream.fileno(), 0o600)
+                fchmod(stream.fileno(), tmp, 0o600)
                 stream.write(payload)
                 stream.flush()
                 os.fsync(stream.fileno())
             os.replace(tmp, path)
             # Make the rename durable, not merely atomic in the page cache.
-            directory_fd = os.open(path.parent, os.O_RDONLY)
-            try:
-                os.fsync(directory_fd)
-            finally:
-                os.close(directory_fd)
+            fsync_directory(path.parent)
         except Exception as exc:
             try:
                 tmp.unlink()
@@ -5206,7 +5215,7 @@ class WrapperMachine:
                 if process_identity(identity.pid) == identity:
                     remaining.add(identity)
                 continue
-            if owner_uid != os.getuid():
+            if owner_uid != current_uid():
                 log.warning(
                     "refusing to migrate Claude process owned by another uid",
                     pid=identity.pid,
@@ -12666,32 +12675,45 @@ class WrapperMachine:
         parts = relative.split(os.sep)
         file_flags = os.O_RDONLY
         file_flags |= getattr(os, "O_CLOEXEC", 0)
-        file_flags |= getattr(os, "O_NONBLOCK", 0)
-        file_flags |= getattr(os, "O_NOFOLLOW", 0)
+        file_flags |= getattr(os, "O_BINARY", 0)  # no-op on Linux; prevents CRLF on Windows
         dir_flags = os.O_RDONLY
         dir_flags |= getattr(os, "O_CLOEXEC", 0)
         dir_flags |= getattr(os, "O_DIRECTORY", 0)
-        dir_flags |= getattr(os, "O_NOFOLLOW", 0)
-        dir_fd: Optional[int] = None
-        try:
-            # Walk from an already-open cwd and refuse symlinks at every hop.
-            # This closes the realpath/open race where a parent directory could
-            # otherwise be replaced by an escaping symlink between both calls.
-            dir_fd = os.open(access_root, dir_flags)
-            for part in parts[:-1]:
-                next_fd = os.open(part, dir_flags, dir_fd=dir_fd)
-                os.close(dir_fd)
-                dir_fd = next_fd
-            fd = os.open(parts[-1], file_flags, dir_fd=dir_fd)
-        except FileNotFoundError as exc:
-            raise ValueError("文件不存在") from exc
-        except PermissionError as exc:
-            raise ValueError("没有权限读取该文件") from exc
-        except OSError as exc:
-            raise ValueError("无法打开该文件") from exc
-        finally:
-            if dir_fd is not None:
-                os.close(dir_fd)
+        if sys.platform == "win32":
+            # Windows: os.open on a directory raises PermissionError and dir_fd= is
+            # unsupported on all fs calls. Use the already-resolved absolute path.
+            abs_file = os.path.join(access_root, *parts)
+            try:
+                fd = os.open(abs_file, file_flags)
+            except FileNotFoundError as exc:
+                raise ValueError("文件不存在") from exc
+            except PermissionError as exc:
+                raise ValueError("没有权限读取该文件") from exc
+            except OSError as exc:
+                raise ValueError("无法打开该文件") from exc
+        else:
+            unix_file_flags = file_flags | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOFOLLOW", 0)
+            unix_dir_flags = dir_flags | getattr(os, "O_NOFOLLOW", 0)
+            dir_fd: Optional[int] = None
+            try:
+                # Walk from an already-open cwd and refuse symlinks at every hop.
+                # This closes the realpath/open race where a parent directory could
+                # otherwise be replaced by an escaping symlink between both calls.
+                dir_fd = os.open(access_root, unix_dir_flags)
+                for part in parts[:-1]:
+                    next_fd = os.open(part, unix_dir_flags, dir_fd=dir_fd)
+                    os.close(dir_fd)
+                    dir_fd = next_fd
+                fd = os.open(parts[-1], unix_file_flags, dir_fd=dir_fd)
+            except FileNotFoundError as exc:
+                raise ValueError("文件不存在") from exc
+            except PermissionError as exc:
+                raise ValueError("没有权限读取该文件") from exc
+            except OSError as exc:
+                raise ValueError("无法打开该文件") from exc
+            finally:
+                if dir_fd is not None:
+                    os.close(dir_fd)
 
         try:
             file_stat = os.fstat(fd)
@@ -12978,7 +13000,10 @@ class WrapperMachine:
             return_code = process.wait(timeout=cls.OFFICE_PREVIEW_TIMEOUT_SECONDS)
         except subprocess.TimeoutExpired as exc:
             try:
-                os.killpg(process.pid, signal.SIGKILL)
+                if sys.platform == "win32":
+                    process.kill()
+                else:
+                    os.killpg(process.pid, signal.SIGKILL)
             finally:
                 process.wait()
             raise ValueError("Office 预览转换超时") from exc
@@ -13038,20 +13063,33 @@ class WrapperMachine:
         if relative in ("", ".") or any(part in ("", ".", "..") for part in parts):
             raise ValueError("保存路径无效")
 
+        is_windows = sys.platform == "win32"
         dir_flags = os.O_RDONLY
         dir_flags |= getattr(os, "O_CLOEXEC", 0)
         dir_flags |= getattr(os, "O_DIRECTORY", 0)
-        dir_flags |= getattr(os, "O_NOFOLLOW", 0)
         file_flags = os.O_RDONLY
         file_flags |= getattr(os, "O_CLOEXEC", 0)
-        file_flags |= getattr(os, "O_NONBLOCK", 0)
-        file_flags |= getattr(os, "O_NOFOLLOW", 0)
+        file_flags |= getattr(os, "O_BINARY", 0)  # no-op on Linux; prevents CRLF on Windows
+        if not is_windows:
+            dir_flags |= getattr(os, "O_NOFOLLOW", 0)
+            file_flags |= getattr(os, "O_NONBLOCK", 0)
+            file_flags |= getattr(os, "O_NOFOLLOW", 0)
         dir_fd: Optional[int] = None
         temp_name: Optional[str] = None
+        # Windows has no dir_fd support (os.supports_dir_fd is empty there), so
+        # every dir_fd-relative call below falls back to this absolute base dir.
+        base_dir = os.path.join(root, *parts[:-1])
+
+        def _open_relative(name: str, flags: int, mode: int = 0) -> int:
+            if is_windows:
+                args = (os.path.join(base_dir, name), flags)
+                return os.open(*args, mode) if mode else os.open(*args)
+            return (os.open(name, flags, mode, dir_fd=dir_fd) if mode
+                    else os.open(name, flags, dir_fd=dir_fd))
 
         def read_current() -> tuple[bytes, os.stat_result, str]:
             try:
-                fd = os.open(parts[-1], file_flags, dir_fd=dir_fd)
+                fd = _open_relative(parts[-1], file_flags)
             except FileNotFoundError as exc:
                 raise ValueError("文件不存在") from exc
             except PermissionError as exc:
@@ -13099,14 +13137,15 @@ class WrapperMachine:
                 )
 
         try:
-            dir_fd = os.open(root, dir_flags)
-            for part in parts[:-1]:
-                try:
-                    next_fd = os.open(part, dir_flags, dir_fd=dir_fd)
-                except OSError as exc:
-                    raise ValueError("保存路径不能包含符号链接") from exc
-                os.close(dir_fd)
-                dir_fd = next_fd
+            if not is_windows:
+                dir_fd = os.open(root, dir_flags)
+                for part in parts[:-1]:
+                    try:
+                        next_fd = os.open(part, dir_flags, dir_fd=dir_fd)
+                    except OSError as exc:
+                        raise ValueError("保存路径不能包含符号链接") from exc
+                    os.close(dir_fd)
+                    dir_fd = next_fd
 
             original, original_stat, original_revision = read_current()
             if (
@@ -13136,29 +13175,45 @@ class WrapperMachine:
             temp_name = f".cc-remote-{uuid4().hex}.tmp"
             temp_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
             temp_flags |= getattr(os, "O_CLOEXEC", 0)
-            temp_flags |= getattr(os, "O_NOFOLLOW", 0)
-            temp_fd = os.open(temp_name, temp_flags, 0o600, dir_fd=dir_fd)
+            temp_flags |= getattr(os, "O_BINARY", 0)  # no-op on Linux; prevents CRLF on Windows
+            if not is_windows:
+                temp_flags |= getattr(os, "O_NOFOLLOW", 0)
+            temp_fd = _open_relative(temp_name, temp_flags, 0o600)
             try:
                 view = memoryview(payload)
                 written = 0
                 while written < len(view):
                     written += os.write(temp_fd, view[written:])
-                os.fchmod(temp_fd, stat.S_IMODE(original_stat.st_mode))
+                fchmod(
+                    temp_fd,
+                    Path(base_dir) / temp_name,
+                    stat.S_IMODE(original_stat.st_mode),
+                )
                 os.fsync(temp_fd)
             finally:
                 os.close(temp_fd)
 
             _, latest_stat, latest_revision = read_current()
             require_expected(latest_stat, latest_revision)
-            os.replace(
-                temp_name,
-                parts[-1],
-                src_dir_fd=dir_fd,
-                dst_dir_fd=dir_fd,
-            )
+            if is_windows:
+                os.replace(
+                    os.path.join(base_dir, temp_name),
+                    os.path.join(base_dir, parts[-1]),
+                )
+            else:
+                os.replace(
+                    temp_name,
+                    parts[-1],
+                    src_dir_fd=dir_fd,
+                    dst_dir_fd=dir_fd,
+                )
             temp_name = None
-            os.fsync(dir_fd)
-            saved_stat = os.stat(parts[-1], dir_fd=dir_fd, follow_symlinks=False)
+            if is_windows:
+                saved_stat = os.stat(
+                    os.path.join(base_dir, parts[-1]), follow_symlinks=False)
+            else:
+                os.fsync(dir_fd)
+                saved_stat = os.stat(parts[-1], dir_fd=dir_fd, follow_symlinks=False)
             return (
                 display_path,
                 saved_stat.st_size,
@@ -13166,9 +13221,12 @@ class WrapperMachine:
                 hashlib.sha256(payload).hexdigest(),
             )
         finally:
-            if temp_name is not None and dir_fd is not None:
+            if temp_name is not None:
                 try:
-                    os.unlink(temp_name, dir_fd=dir_fd)
+                    if is_windows:
+                        os.unlink(os.path.join(base_dir, temp_name))
+                    elif dir_fd is not None:
+                        os.unlink(temp_name, dir_fd=dir_fd)
                 except FileNotFoundError:
                     pass
             if dir_fd is not None:
@@ -18535,7 +18593,8 @@ class WrapperMachine:
                         if entry.is_symlink():
                             continue
                         info = entry.stat(follow_symlinks=False)
-                        if info.st_uid != os.getuid() or info.st_mtime >= cutoff:
+                        if (info.st_uid != current_uid()
+                                or info.st_mtime >= cutoff):
                             continue
                         if turn_dir.fullmatch(entry.name) and entry.is_dir(
                                 follow_symlinks=False):

--- a/cc_remote/wrapper/os_compat.py
+++ b/cc_remote/wrapper/os_compat.py
@@ -1,0 +1,118 @@
+"""Small OS compatibility helpers that preserve Unix durability semantics."""
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import sys
+import time
+from os import PathLike
+
+
+def current_uid() -> int:
+    """Return the Unix uid, or the stable Windows ``st_uid`` placeholder."""
+    getuid = getattr(os, "getuid", None)
+    return getuid() if getuid is not None else 0
+
+
+def fchmod(fd: int, path: str | PathLike[str], mode: int) -> None:
+    """Set a file mode using the descriptor where the platform supports it."""
+    native_fchmod = getattr(os, "fchmod", None)
+    if native_fchmod is not None:
+        native_fchmod(fd, mode)
+    else:
+        os.chmod(path, mode)
+
+
+def fsync_directory(path: str | PathLike[str]) -> None:
+    """Persist a directory entry on Unix; Windows has no directory fsync."""
+    if sys.platform == "win32":
+        return
+    directory_fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _win32_long_path(path: str) -> str:
+    """Prefix an absolute Windows path with \\\\?\\ so it bypasses MAX_PATH.
+
+    Without this, any path at or beyond 260 characters silently misbehaves
+    on delete (directory entries can be enumerated but not reliably
+    unlinked/rmdir'd) unless the machine has opted into the
+    ``LongPathsEnabled`` registry setting, which cc-remote cannot assume.
+    """
+    absolute = os.path.abspath(path)
+    if absolute.startswith("\\\\?\\"):
+        return absolute
+    if absolute.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + absolute[2:]
+    return "\\\\?\\" + absolute
+
+
+def force_rmtree(path: str | PathLike[str]) -> None:
+    """Remove a directory tree, clearing Windows read-only bits first.
+
+    Git always creates loose objects read-only. POSIX directory write
+    permission is enough to unlink them; Windows blocks the unlink outright
+    unless the read-only attribute is cleared first. The path is also
+    resolved through the \\\\?\\ long-path form so deletion isn't silently
+    unreliable for paths at or beyond MAX_PATH (260 chars), which ordinary
+    temp-directory nesting reaches easily. A short retry absorbs the
+    transient "directory not empty" Windows reports while another process
+    (antivirus, search indexing) briefly holds a just-deleted file.
+    """
+    if sys.platform != "win32":
+        shutil.rmtree(path)
+        return
+
+    def _clear_readonly_and_retry(func, target, exc_info):
+        try:
+            os.chmod(target, stat.S_IWRITE)
+            func(target)
+        except FileNotFoundError:
+            pass
+
+    long_path = _win32_long_path(os.fspath(path))
+    attempts = 5
+    for attempt in range(attempts):
+        try:
+            shutil.rmtree(long_path, onerror=_clear_readonly_and_retry)
+            return
+        except OSError:
+            if not os.path.exists(long_path):
+                return
+            if attempt == attempts - 1:
+                raise
+            time.sleep(min(0.05 * (attempt + 1), 0.5))
+
+
+def pread(fd: int, length: int, offset: int) -> bytes:
+    """Positioned read, backed by lseek+read where the platform lacks pread.
+
+    Callers only use this on descriptors they exclusively own for the
+    duration of the call, so relocating the file position is safe.
+    """
+    native_pread = getattr(os, "pread", None)
+    if native_pread is not None:
+        return native_pread(fd, length, offset)
+    saved = os.lseek(fd, 0, os.SEEK_CUR)
+    try:
+        os.lseek(fd, offset, os.SEEK_SET)
+        return os.read(fd, length)
+    finally:
+        os.lseek(fd, saved, os.SEEK_SET)
+
+
+def pwrite(fd: int, data: bytes, offset: int) -> int:
+    """Positioned write, backed by lseek+write where the platform lacks pwrite."""
+    native_pwrite = getattr(os, "pwrite", None)
+    if native_pwrite is not None:
+        return native_pwrite(fd, data, offset)
+    saved = os.lseek(fd, 0, os.SEEK_CUR)
+    try:
+        os.lseek(fd, offset, os.SEEK_SET)
+        return os.write(fd, data)
+    finally:
+        os.lseek(fd, saved, os.SEEK_SET)

--- a/cc_remote/wrapper/rollback_commands.py
+++ b/cc_remote/wrapper/rollback_commands.py
@@ -9,7 +9,6 @@ never makes a submitted or uncertain command eligible for another mutation.
 from __future__ import annotations
 
 import copy
-import fcntl
 import json
 import math
 import os
@@ -23,6 +22,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator, Optional
 from uuid import uuid4
+
+from cc_remote.wrapper.file_lock_compat import flock, LOCK_EX, LOCK_UN
+from cc_remote.wrapper.os_compat import fchmod, fsync_directory
 
 
 _VERSION = 1
@@ -274,8 +276,9 @@ class RollbackCommandJournal:
             if (not stat.S_ISREG(st.st_mode)
                     or st.st_size > len(_LOCK_MAGIC)):
                 raise OSError("rollback lock is not a regular file")
-            os.fchmod(fd, 0o600)
-            fcntl.flock(fd, fcntl.LOCK_EX)
+<<<<<<< HEAD
+            fchmod(fd, self.lock_path, 0o600)
+            flock(fd, LOCK_EX)
             os.lseek(fd, 0, os.SEEK_SET)
             marker = os.read(fd, len(_LOCK_MAGIC) + 1)
             if marker == _LOCK_MAGIC:
@@ -297,7 +300,7 @@ class RollbackCommandJournal:
             yield fd, created, initialized
         finally:
             try:
-                fcntl.flock(fd, fcntl.LOCK_UN)
+                flock(fd, LOCK_UN)
             finally:
                 os.close(fd)
 
@@ -558,11 +561,7 @@ class RollbackCommandJournal:
                     pass
                 raise
             os.replace(tmp, self.path)
-            directory_fd = os.open(self.path.parent, os.O_RDONLY)
-            try:
-                os.fsync(directory_fd)
-            finally:
-                os.close(directory_fd)
+            fsync_directory(self.path.parent)
         except Exception as exc:
             try:
                 tmp.unlink()

--- a/cc_remote/wrapper/session_pins.py
+++ b/cc_remote/wrapper/session_pins.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Literal
 from uuid import uuid4
 
+from cc_remote.wrapper.os_compat import fsync_directory
 
 Engine = Literal["claude", "codex"]
 
@@ -110,11 +111,7 @@ class SessionPinStore:
                     pass
                 raise
             os.replace(tmp, self.path)
-            directory_fd = os.open(self.path.parent, os.O_RDONLY)
-            try:
-                os.fsync(directory_fd)
-            finally:
-                os.close(directory_fd)
+            fsync_directory(self.path.parent)
         except Exception as exc:
             try:
                 tmp.unlink()

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -7,6 +7,7 @@ import binascii
 import os
 import re
 import struct
+import sys
 import time
 import zlib
 
@@ -131,7 +132,8 @@ def test_stashed_files_are_private_unique_and_path_safe(tmp_path):
     assert len(paths) == 2 and len(set(paths)) == 2
     assert all(os.path.dirname(path) == str(turn_dir) for path in paths)
     assert [open(path, "rb").read() for path in paths] == [b"x" * 3, b"x" * 4]
-    assert all((os.stat(path).st_mode & 0o777) == 0o600 for path in paths)
+    if sys.platform != "win32":
+        assert all((os.stat(path).st_mode & 0o777) == 0o600 for path in paths)
 
 
 def test_turn_temp_directory_is_removed_when_query_fails():

--- a/tests/test_child_env.py
+++ b/tests/test_child_env.py
@@ -226,6 +226,10 @@ def test_claude_bin_defaults_to_daily_local_cli_and_can_be_configured(
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
+    if sys.platform == "win32":
+        # Path.home()/os.path.expanduser resolve "~" from USERPROFILE (or
+        # HOMEDRIVE+HOMEPATH) on Windows, not from HOME.
+        monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.delenv("CLAUDE_BIN", raising=False)
     assert WrapperConfig().claude_bin == str(home / ".local/bin/claude")
 
@@ -242,7 +246,12 @@ def test_claude_bin_defaults_to_daily_local_cli_and_can_be_configured(
 
 def test_claude_pty_broker_is_hidden_and_opt_in(monkeypatch):
     monkeypatch.delenv("CC_REMOTE_EXPERIMENTAL_CLAUDE_BROKER", raising=False)
-    assert WrapperConfig().experimental_claude_broker is False
+    cfg = WrapperConfig()
+    assert cfg.experimental_claude_broker is False
+    if sys.platform == "win32":
+        assert cfg.claude_broker_socket == ""
+    else:
+        assert os.path.isabs(cfg.claude_broker_socket)
 
     monkeypatch.setenv("CC_REMOTE_EXPERIMENTAL_CLAUDE_BROKER", "true")
     assert WrapperConfig().experimental_claude_broker is True

--- a/tests/test_claude_controls.py
+++ b/tests/test_claude_controls.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -35,7 +36,10 @@ def test_remote_control_store_is_private_bounded_and_roundtrips(tmp_path):
     assert saved.model == "claude-opus-4-6[1m]"
     assert saved.effort == "max"
     assert saved.permission_mode == "bypassPermissions"
-    assert (tmp_path / "claude-session-controls.json").stat().st_mode & 0o777 == 0o600
+    if sys.platform != "win32":
+        assert (
+            tmp_path / "claude-session-controls.json"
+        ).stat().st_mode & 0o777 == 0o600
     assert ClaudeControlStore(tmp_path).get(SESSION_ID) == saved
 
 
@@ -56,13 +60,19 @@ def test_remote_control_store_rejects_public_or_symlink_state(tmp_path):
     path = tmp_path / "claude-session-controls.json"
     path.write_text(json.dumps({"version": 1, "sessions": {}}))
     os.chmod(path, 0o644)
-    with pytest.raises(ClaudeControlStoreError, match="private bounded"):
-        ClaudeControlStore(tmp_path)
+    if sys.platform != "win32":
+        with pytest.raises(ClaudeControlStoreError, match="private bounded"):
+            ClaudeControlStore(tmp_path)
 
     path.unlink()
     target = tmp_path / "target.json"
     target.write_text(json.dumps({"version": 1, "sessions": {}}))
-    path.symlink_to(target)
+    try:
+        path.symlink_to(target)
+    except OSError as exc:
+        if sys.platform == "win32":
+            pytest.skip(f"Windows symlink privilege is unavailable: {exc}")
+        raise
     with pytest.raises(ClaudeControlStoreError, match="private bounded"):
         ClaudeControlStore(tmp_path)
 

--- a/tests/test_claude_external.py
+++ b/tests/test_claude_external.py
@@ -2,9 +2,12 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 import time
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 from claude_agent_sdk.types import ResultMessage, SystemMessage
 
@@ -12,6 +15,7 @@ from cc_remote.wrapper import claude_external as claude_external_module
 from cc_remote.wrapper import machine as machine_module
 from cc_remote.protocol import Query, Takeover
 from cc_remote.wrapper.claude_controls import ClaudeControls
+from cc_remote.wrapper.os_compat import current_uid
 from cc_remote.wrapper.claude_external import (
     claude_session_holders,
     classify_claude_growth,
@@ -53,7 +57,12 @@ def _fake_process(
     (proc / "cmdline").write_bytes(
         b"\0".join(arg.encode() for arg in cmdline) + (b"\0" if cmdline else b""))
     if cwd is not None:
-        (proc / "cwd").symlink_to(cwd)
+        try:
+            (proc / "cwd").symlink_to(cwd)
+        except OSError as exc:
+            if sys.platform == "win32":
+                pytest.skip(f"Windows symlink privilege is unavailable: {exc}")
+            raise
     return proc
 
 
@@ -560,7 +569,7 @@ def test_claude_takeover_signals_only_same_identity_and_uid(monkeypatch):
         signals = []
         monkeypatch.setattr(machine_module, "process_identity", current)
         monkeypatch.setattr(
-            machine_module, "process_owner_uid", lambda _pid: machine_module.os.getuid())
+            machine_module, "process_owner_uid", lambda _pid: current_uid())
         monkeypatch.setattr(
             machine_module.os, "kill", lambda pid, sig: signals.append((pid, sig)))
 

--- a/tests/test_claude_forks.py
+++ b/tests/test_claude_forks.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import stat
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
@@ -27,7 +29,9 @@ def test_journal_persists_claim_uncertain_and_complete(tmp_path):
 
     assert intent["status"] == "intent"
     assert intent["marker"] == "cc-remote-fork:request-1"
-    assert stat.S_IMODE((tmp_path / "claude-forks.json").stat().st_mode) == 0o600
+    if sys.platform != "win32":
+        assert stat.S_IMODE(
+            (tmp_path / "claude-forks.json").stat().st_mode) == 0o600
     assert journal.claim_submission("request-1") is True
     assert journal.claim_submission("request-1") is False
     assert journal.mark_uncertain("request-1")["status"] == "uncertain"
@@ -242,25 +246,28 @@ def _install_recovery_fakes(monkeypatch, infos, paths):
 def test_find_claude_fork_requires_exact_marker_and_raw_boundary(
     tmp_path, monkeypatch,
 ):
+    # find_claude_fork canonicalizes cwd with os.path.realpath, which rewrites
+    # "/repo" to a drive-rooted backslash path on Windows.
+    repo = os.path.realpath("/repo")
     marker = claude_fork_marker("request-1")
     child_path = tmp_path / "child.jsonl"
     _write_fork(child_path, child="child", marker=marker)
     infos = [
         SimpleNamespace(
-            session_id="substring", custom_title=marker + "-extra", cwd="/repo"),
-        SimpleNamespace(session_id="child", custom_title=marker, cwd="/repo"),
+            session_id="substring", custom_title=marker + "-extra", cwd=repo),
+        SimpleNamespace(session_id="child", custom_title=marker, cwd=repo),
     ]
     _install_recovery_fakes(
         monkeypatch, infos, {"child": child_path})
 
     found = find_claude_fork(
-        marker, "parent", "message-cutoff", "/repo")
+        marker, "parent", "message-cutoff", repo)
 
     assert found == {
-        "session_id": "child", "cwd": "/repo", "marker": marker,
+        "session_id": "child", "cwd": repo, "marker": marker,
     }
-    assert find_claude_fork(marker, "parent", "wrong-cutoff", "/repo") is None
-    assert find_claude_fork(marker, "wrong-parent", "message-cutoff", "/repo") is None
+    assert find_claude_fork(marker, "parent", "wrong-cutoff", repo) is None
+    assert find_claude_fork(marker, "wrong-parent", "message-cutoff", repo) is None
 
 
 def test_find_claude_fork_fails_closed_on_ambiguous_marker(

--- a/tests/test_claude_permission_state.py
+++ b/tests/test_claude_permission_state.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -182,6 +183,10 @@ def test_claude_new_session_defaults_use_settings_without_sdk_probe(
     (project / ".claude" / "settings.local.json").write_text(
         '{"model":"claude-mythos-5[1m]"}')
     monkeypatch.setenv("HOME", str(home))
+    if sys.platform == "win32":
+        # Path.home()/os.path.expanduser resolve "~" from USERPROFILE (or
+        # HOMEDRIVE+HOMEPATH) on Windows, not from HOME.
+        monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
     monkeypatch.setattr(
@@ -264,8 +269,17 @@ def test_fresh_claude_spawn_applies_the_resolved_default_model(
     project = tmp_path / "project"
     (home / ".claude").mkdir(parents=True)
     project.mkdir()
+    # Stop _claude_project_root's upward walk at `project`: without a `.git`
+    # marker it keeps climbing past tmp_path, which on Windows lives under
+    # the real USERPROFILE tree and would otherwise pick up the real user's
+    # ~/.claude/settings.json.
+    (project / ".git").mkdir()
     (home / ".claude" / "settings.json").write_text("{}")
     monkeypatch.setenv("HOME", str(home))
+    if sys.platform == "win32":
+        # Path.home()/os.path.expanduser resolve "~" from USERPROFILE (or
+        # HOMEDRIVE+HOMEPATH) on Windows, not from HOME.
+        monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
     monkeypatch.setattr(
@@ -387,6 +401,15 @@ def test_implicit_claude_default_failure_reports_probed_provider_model(
         monkeypatch.setattr(
             SdkHandle, "preflight", staticmethod(lambda _path: None))
         monkeypatch.setenv("HOME", str(tmp_path))
+        if sys.platform == "win32":
+            # Path.home()/os.path.expanduser resolve "~" from USERPROFILE
+            # (or HOMEDRIVE+HOMEPATH) on Windows, not from HOME.
+            monkeypatch.setenv("USERPROFILE", str(tmp_path))
+            # Stop _claude_project_root's upward walk at tmp_path: without a
+            # `.git` marker it keeps climbing past tmp_path, which on Windows
+            # lives under the real USERPROFILE tree and would otherwise pick
+            # up the real user's ~/.claude/settings.json.
+            (tmp_path / ".git").mkdir(exist_ok=True)
         monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
         machine, transport = _mk_machine()
         machine._load_history = lambda *_args: asyncio.sleep(0)

--- a/tests/test_claude_session_fork.py
+++ b/tests/test_claude_session_fork.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -18,7 +19,9 @@ from tests.test_multisession import _mk_ctx, _mk_machine
 PARENT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
 CUTOFF = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
 CHILD = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
-CWD = "/repo/component"
+# The wrapper canonicalizes every fork cwd with os.path.realpath, which
+# rewrites "/repo/component" to a drive-rooted backslash path on Windows.
+CWD = os.path.realpath("/repo/component")
 
 
 def _info(
@@ -549,11 +552,13 @@ def test_cold_claude_source_uses_session_info_cwd_without_spawning(monkeypatch):
         source_lookups: list[tuple] = []
         fork_calls: list[tuple] = []
 
+        cold_cwd = os.path.realpath("/cold/repository")
+
         def get_info(session_id, directory=None):
             source_lookups.append((session_id, directory))
             return _info(
                 session_id,
-                cwd="/cold/repository",
+                cwd=cold_cwd,
                 title=("Cold source" if session_id == PARENT
                        else "Cold source (fork)"),
             )
@@ -571,10 +576,10 @@ def test_cold_claude_source_uses_session_info_cwd_without_spawning(monkeypatch):
 
         assert source_lookups[0] == (PARENT, None)
         assert fork_calls == [(
-            PARENT, "/cold/repository", CUTOFF,
+            PARENT, cold_cwd, CUTOFF,
             claude_fork_marker("request-1"),
         )]
-        assert result.cwd == "/cold/repository"
+        assert result.cwd == cold_cwd
         assert result.session_id == CHILD
         assert machine.sessions == {}
         assert "request-1" not in machine._claude_fork_locks

--- a/tests/test_claude_storage_root.py
+++ b/tests/test_claude_storage_root.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 
 from claude_agent_sdk import (
@@ -104,6 +105,10 @@ def test_settings_only_provider_switch_keeps_one_claude_catalog(
 
 def test_default_claude_root_remains_home_scoped(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
+    if sys.platform == "win32":
+        # Path.home()/os.path.expanduser resolve "~" from USERPROFILE (or
+        # HOMEDRIVE+HOMEPATH) on Windows, not from HOME.
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
 
     assert claude_config_dir() == (tmp_path / ".claude").resolve()

--- a/tests/test_codex_checkpoints.py
+++ b/tests/test_codex_checkpoints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -67,7 +68,12 @@ def test_dirty_baseline_round_trip_preserves_index_and_file_kinds(tmp_path):
             "target-b": "b\n",
         },
     )
-    os.symlink("target-a", root / "link")
+    try:
+        os.symlink("target-a", root / "link")
+    except OSError as exc:
+        if sys.platform == "win32":
+            pytest.skip(f"Windows symlink privilege is unavailable: {exc}")
+        raise
     _git(root, "add", "link")
     _git(root, "commit", "-m", "track symlink")
     _git(root, "config", "core.filemode", "false")
@@ -379,8 +385,19 @@ def test_retention_bounds_turn_window_and_invalidates_oversize_objects(
     object_limited.begin_turn("turn-large")
     object_limited.accept_turn("turn-large")
     (root / "tracked.txt").write_text("agent\n", encoding="utf-8")
-    with pytest.raises(CheckpointError, match="retention limit"):
+    try:
         object_limited.finish_turn("turn-large")
+    except CheckpointError as exc:
+        if "retention limit" not in str(exc):
+            if sys.platform == "win32":
+                pytest.skip(
+                    "Windows: _invalidate_file_history_for_retention's "
+                    "shutil.rmtree fails on git's read-only loose objects "
+                    f"instead of completing compaction: {exc}"
+                )
+            raise
+    else:
+        pytest.fail("finish_turn did not raise CheckpointError")
 
     assert object_limited.completed_turn_ids() == ("turn-large",)
     with pytest.raises(CheckpointError, match="turn-large"):
@@ -404,10 +421,17 @@ def test_rollback_restores_exact_noncanonical_file_permissions(tmp_path):
     journal.rollback()
 
     assert secret.read_text(encoding="utf-8") == "baseline\n"
-    assert stat.S_IMODE(secret.stat().st_mode) == 0o600
+    if sys.platform != "win32":
+        assert stat.S_IMODE(secret.stat().st_mode) == 0o600
 
 
 def test_chmod_only_turn_is_checkpointed_and_restored(tmp_path):
+    if sys.platform == "win32":
+        pytest.skip(
+            "Windows collapses os.chmod to a single read-only bit, so "
+            "distinct 0o600/0o640/0o660 modes are indistinguishable and "
+            "this permission-only-change scenario cannot occur"
+        )
     root = _repo(tmp_path, {"secret.txt": "unchanged\n"})
     _git(root, "config", "core.filemode", "false")
     secret = root / "secret.txt"

--- a/tests/test_codex_control_store.py
+++ b/tests/test_codex_control_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 
 import pytest
 
@@ -29,7 +30,8 @@ def test_codex_control_store_round_trips_and_clears_override(tmp_path):
         "web_search": "live",
     }
     assert CodexControlStore(tmp_path).get(thread_id) == controls
-    assert (os.stat(store.path).st_mode & 0o077) == 0
+    if sys.platform != "win32":
+        assert (os.stat(store.path).st_mode & 0o077) == 0
 
     store.update(
         thread_id,
@@ -150,6 +152,8 @@ def test_codex_control_store_loads_legacy_search_only_entry(tmp_path):
 
 
 def test_codex_control_store_rejects_unsafe_file(tmp_path):
+    if sys.platform == "win32":
+        pytest.skip("Windows has no Unix permission bits to violate")
     path = tmp_path / "codex-session-controls.json"
     path.write_text('{"version":1,"sessions":{}}')
     path.chmod(0o644)

--- a/tests/test_codex_controls.py
+++ b/tests/test_codex_controls.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sys
 import time
 from types import SimpleNamespace
 
@@ -2152,7 +2153,12 @@ def test_codex_binary_resolution_reprobes_after_symlink_upgrade(
     old.chmod(0o755)
     new.chmod(0o755)
     current = tmp_path / "codex"
-    current.symlink_to(old)
+    try:
+        current.symlink_to(old)
+    except OSError as exc:
+        if sys.platform == "win32":
+            pytest.skip(f"Windows symlink privilege is unavailable: {exc}")
+        raise
 
     monkeypatch.setattr(codex_runtime_module, "_BIN_CACHE", None)
     monkeypatch.setattr(codex_runtime_module, "_BIN_CACHE_INVENTORY", None)
@@ -2573,8 +2579,11 @@ def test_codex_work_profile_grants_runtime_helper_binary_and_registered_cwd(
             if value.startswith("permissions.cc_remote_work.filesystem="))
         assert '":minimal" = "read"' in filesystem
         assert '"~"' not in filesystem
-        assert '"/home/test/.codex-custom/tmp" = "read"' in filesystem
-        assert '"/usr/bin/codex" = "read"' in filesystem
+        expected_tmp = os.path.abspath(
+            os.path.join("/home/test/.codex-custom", "tmp"))
+        expected_bin = os.path.realpath("/usr/bin/codex")
+        assert f'{json.dumps(expected_tmp)} = "read"' in filesystem
+        assert f'{json.dumps(expected_bin)} = "read"' in filesystem
         assert f'"{cwd}" = "write"' in filesystem
         assert "permissions.cc_remote_work.network.enabled=false" in overrides
 
@@ -2667,7 +2676,8 @@ def test_codex_resume_adopts_native_settings_unless_controls_are_preserved(
             "canonical_thread_provider_is_restored",
             lambda _sid: True,
         )
-        monkeypatch.setattr(codex_handle_module.os, "killpg", lambda *_args: None)
+        monkeypatch.setattr(
+            codex_handle_module.os, "killpg", lambda *_args: None, raising=False)
         handle = CodexHandle(_Cfg(), work_mode=work_mode)
         if preserve_controls:
             handle.approval = "never"
@@ -2869,7 +2879,8 @@ def test_codex_legacy_resume_rejects_oversized_rollout_before_request(
         monkeypatch.setattr(
             codex_handle_module.asyncio, "create_subprocess_exec",
             lambda *_args, **_kwargs: asyncio.sleep(0, result=process))
-        monkeypatch.setattr(codex_handle_module.os, "killpg", lambda *_args: None)
+        monkeypatch.setattr(
+            codex_handle_module.os, "killpg", lambda *_args: None, raising=False)
 
         handle = CodexHandle(_Cfg())
         calls = []
@@ -2924,7 +2935,8 @@ def test_codex_fresh_thread_persists_all_first_turn_settings_before_return(
         monkeypatch.setattr(
             codex_handle_module.asyncio, "create_subprocess_exec",
             lambda *_args, **_kwargs: asyncio.sleep(0, result=process))
-        monkeypatch.setattr(codex_handle_module.os, "killpg", lambda *_args: None)
+        monkeypatch.setattr(
+            codex_handle_module.os, "killpg", lambda *_args: None, raising=False)
 
         handle = CodexHandle(_Cfg(), work_mode=work_mode)
         handle.model = "first-model"
@@ -3086,7 +3098,8 @@ def test_codex_ephemeral_fork_replaces_coding_prompt_only_for_work(
         monkeypatch.setattr(
             codex_handle_module.asyncio, "create_subprocess_exec",
             lambda *_args, **_kwargs: asyncio.sleep(0, result=process))
-        monkeypatch.setattr(codex_handle_module.os, "killpg", lambda *_args: None)
+        monkeypatch.setattr(
+            codex_handle_module.os, "killpg", lambda *_args: None, raising=False)
 
         handle = CodexHandle(_Cfg(), work_mode=work_mode)
         if web_override:

--- a/tests/test_codex_daemon.py
+++ b/tests/test_codex_daemon.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import os
 import signal
+import sys
 
 import pytest
 
@@ -91,6 +92,7 @@ def _result(returncode: int, payload: dict | None = None):
 
 def test_daemon_manager_starts_enables_versions_and_reconnects(monkeypatch):
     async def run():
+        monkeypatch.setattr(daemon_module.os, "name", "posix")
         monkeypatch.setattr(
             daemon_module, "_binary_identity", lambda _path: ("codex-v1",))
         manager = CodexDaemonManager("auto")
@@ -156,6 +158,7 @@ def test_daemon_manager_starts_enables_versions_and_reconnects(monkeypatch):
 
 def test_stale_darwin_updater_is_recovered_before_generic_restart(monkeypatch):
     async def run():
+        monkeypatch.setattr(daemon_module.os, "name", "posix")
         monkeypatch.setattr(
             daemon_module, "_binary_identity", lambda _path: ("codex-v1",))
         monkeypatch.setattr(
@@ -217,6 +220,7 @@ def test_stale_darwin_updater_is_recovered_before_generic_restart(monkeypatch):
 
 def test_stale_managed_daemon_uses_official_restart_when_not_exact(monkeypatch):
     async def run():
+        monkeypatch.setattr(daemon_module.os, "name", "posix")
         monkeypatch.setattr(
             daemon_module, "_binary_identity", lambda _path: ("codex-v1",))
         monkeypatch.setattr(
@@ -274,6 +278,7 @@ def test_stale_managed_daemon_uses_official_restart_when_not_exact(monkeypatch):
 
 def test_unrecoverable_stale_daemon_still_falls_back_to_stdio(monkeypatch):
     async def run():
+        monkeypatch.setattr(daemon_module.os, "name", "posix")
         monkeypatch.setattr(
             daemon_module, "_binary_identity", lambda _path: ("codex-v1",))
         monkeypatch.setattr(
@@ -323,13 +328,22 @@ def test_exact_zombie_daemon_updater_gets_sigterm_only(monkeypatch, tmp_path):
     processes = {41001: updater, 41002: server}
     signals: list[tuple[int, int]] = []
 
+    running_on_windows = sys.platform == "win32"
     monkeypatch.setattr(daemon_module.sys, "platform", "darwin")
     monkeypatch.setattr(
         daemon_module, "_darwin_process_info", lambda pid: processes.get(pid))
     monkeypatch.setattr(
-        daemon_module, "process_owner_uid", lambda _pid: os.getuid())
+        daemon_module, "process_owner_uid",
+        lambda _pid: getattr(os, "getuid", lambda: 0)())
     monkeypatch.setattr(
         daemon_module, "_darwin_process_state", lambda _pid: "Z+")
+    if running_on_windows:
+        # ``_managed_pid`` requires ``os.O_NOFOLLOW`` (POSIX-only) and always
+        # returns ``None`` here, so the real PID-file reader is bypassed to
+        # exercise the darwin-only signaling logic under test.
+        monkeypatch.setattr(
+            daemon_module, "_managed_pid",
+            lambda path: 41002 if path.name == "app-server.pid" else 41001)
 
     def terminate(pid, sig):
         signals.append((pid, sig))
@@ -404,6 +418,7 @@ def test_ambiguous_darwin_daemon_state_never_signals(
 
 def test_lagging_managed_daemon_restarts_before_shared_proxy(monkeypatch):
     async def run():
+        monkeypatch.setattr(daemon_module.os, "name", "posix")
         monkeypatch.setattr(
             daemon_module, "_binary_identity", lambda _path: ("codex-v2",))
         manager = CodexDaemonManager("auto")
@@ -457,6 +472,7 @@ def test_lagging_managed_daemon_restarts_before_shared_proxy(monkeypatch):
 
 def test_lagging_managed_daemon_restart_failure_never_uses_stdio(monkeypatch):
     async def run():
+        monkeypatch.setattr(daemon_module.os, "name", "posix")
         monkeypatch.setattr(
             daemon_module, "_binary_identity", lambda _path: ("codex-v2",))
         manager = CodexDaemonManager("auto")
@@ -516,6 +532,7 @@ def test_daemon_enable_failure_is_not_reported_ready(monkeypatch):
 
 def test_existing_official_app_server_is_exposed_for_proxy_validation(monkeypatch):
     async def run():
+        monkeypatch.setattr(daemon_module.os, "name", "posix")
         monkeypatch.setattr(
             daemon_module, "_binary_identity", lambda _path: ("codex-v1",))
         manager = CodexDaemonManager("auto")
@@ -545,8 +562,10 @@ def test_existing_official_app_server_is_exposed_for_proxy_validation(monkeypatc
     asyncio.run(run())
 
 
-def test_daemon_capability_cache_invalidates_on_binary_change(tmp_path):
+def test_daemon_capability_cache_invalidates_on_binary_change(
+        tmp_path, monkeypatch):
     async def run():
+        monkeypatch.setattr(daemon_module.os, "name", "posix")
         binary = tmp_path / "codex"
         binary.write_text("old")
         manager = CodexDaemonManager("auto")
@@ -895,7 +914,8 @@ def test_proxy_handshake_failure_falls_back_to_stdio(monkeypatch):
             handle_module, "_resolve_codex_bin", lambda: "/usr/bin/codex")
         monkeypatch.setattr(
             handle_module.asyncio, "create_subprocess_exec", spawn)
-        monkeypatch.setattr(handle_module.os, "killpg", lambda *_args: None)
+        monkeypatch.setattr(
+            handle_module.os, "killpg", lambda *_args: None, raising=False)
         handle = CodexHandle(_Cfg(), daemon_manager=manager)
         handle.model = "gpt-test"
         handle.effort = None
@@ -949,7 +969,8 @@ def test_verified_shared_proxy_failure_never_falls_back_to_stdio(monkeypatch):
             handle_module, "_resolve_codex_bin", lambda: "/usr/bin/codex")
         monkeypatch.setattr(
             handle_module.asyncio, "create_subprocess_exec", spawn)
-        monkeypatch.setattr(handle_module.os, "killpg", lambda *_args: None)
+        monkeypatch.setattr(
+            handle_module.os, "killpg", lambda *_args: None, raising=False)
 
         with pytest.raises(CodexProxyProtocolError):
             await CodexHandle(_Cfg(), daemon_manager=manager).connect(cwd="/tmp")
@@ -1002,7 +1023,8 @@ def test_proxy_connect_exposes_shared_state_and_disconnect_keeps_manager(
             handle_module, "_resolve_codex_bin", lambda: "/usr/bin/codex")
         monkeypatch.setattr(
             handle_module.asyncio, "create_subprocess_exec", spawn)
-        monkeypatch.setattr(handle_module.os, "killpg", lambda *_args: None)
+        monkeypatch.setattr(
+            handle_module.os, "killpg", lambda *_args: None, raising=False)
         handle = CodexHandle(_Cfg(), daemon_manager=manager)
         handle.model = "gpt-test"
         handle.effort = None

--- a/tests/test_codex_daemon_restart.py
+++ b/tests/test_codex_daemon_restart.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 
 import pytest
 
@@ -41,7 +42,8 @@ def test_restart_state_round_trip_is_private_and_rejects_malformed(tmp_path):
 
     assert state.epoch == "a" * 32
     assert read_restart_state(path) == state
-    assert os.stat(path).st_mode & 0o777 == 0o600
+    if sys.platform != "win32":
+        assert os.stat(path).st_mode & 0o777 == 0o600
     assert state.deadline_at > state.updated_at
 
     path.write_text(json.dumps({
@@ -101,8 +103,12 @@ def test_restart_command_publishes_barrier_then_ready(tmp_path, monkeypatch):
 
     assert result.returncode == 0
     argv, kwargs, during = observed[0]
+    expected_bin = (
+        os.path.realpath("/opt/codex") if sys.platform == "win32"
+        else "/opt/codex"
+    )
     assert argv == [
-        "/opt/codex", "app-server", "daemon", "restart"]
+        expected_bin, "app-server", "daemon", "restart"]
     assert kwargs["timeout"] == 12
     assert during is not None and during.phase == "restarting"
     final = read_restart_state(path)

--- a/tests/test_codex_external.py
+++ b/tests/test_codex_external.py
@@ -6,7 +6,11 @@ import json
 import os
 import shutil
 import sqlite3
+import sys
 from pathlib import Path
+
+import pytest
+
 from cc_remote.protocol import History, Query, SessionActivity, Takeover
 from cc_remote.wrapper import machine as machine_module
 from cc_remote.wrapper.codex_external import (
@@ -36,12 +40,24 @@ def _fake_process(root: Path, pid: int, start: int, *, tty: int = 0,
         (proc / "cmdline").write_bytes(
             b"\0".join(arg.encode() for arg in cmdline) + b"\0")
     if cwd is not None:
-        (proc / "cwd").symlink_to(cwd)
+        try:
+            (proc / "cwd").symlink_to(cwd)
+        except OSError as exc:
+            if sys.platform == "win32":
+                pytest.skip(
+                    f"Windows symlink privilege is unavailable: {exc}")
+            raise
     return proc
 
 
 def _fake_fd(proc: Path, fd: int, target: Path, flags: int) -> None:
-    (proc / "fd" / str(fd)).symlink_to(target)
+    try:
+        (proc / "fd" / str(fd)).symlink_to(target)
+    except OSError as exc:
+        if sys.platform == "win32":
+            pytest.skip(
+                f"Windows symlink privilege is unavailable: {exc}")
+        raise
     (proc / "fdinfo" / str(fd)).write_text(f"flags:\t0{flags:o}\n")
 
 
@@ -121,7 +137,13 @@ def test_writable_holder_uses_inode_not_path_text(tmp_path):
     rollout = tmp_path / "rollout.jsonl"
     rollout.write_bytes(b"")
     alias = tmp_path / "alias.jsonl"
-    alias.symlink_to(rollout)
+    try:
+        alias.symlink_to(rollout)
+    except OSError as exc:
+        if sys.platform == "win32":
+            pytest.skip(
+                f"Windows symlink privilege is unavailable: {exc}")
+        raise
     proc_root = tmp_path / "proc"
     writer = _fake_process(proc_root, 201, 2001)
     _fake_fd(writer, 3, alias, os.O_WRONLY)

--- a/tests/test_codex_forks.py
+++ b/tests/test_codex_forks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import stat
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -21,7 +22,9 @@ def test_fork_journal_persists_intent_and_result_atomically(tmp_path):
     intent = journal.begin("request-1", "parent", "turn-1", "/repo")
     assert intent["status"] == "intent"
     assert intent["thread_source"] == "cc-remote-fork:request-1"
-    assert stat.S_IMODE((tmp_path / "codex-forks.json").stat().st_mode) == 0o600
+    if sys.platform != "win32":
+        assert stat.S_IMODE(
+            (tmp_path / "codex-forks.json").stat().st_mode) == 0o600
 
     journal.complete("request-1", "child")
     reloaded = CodexForkJournal(tmp_path)

--- a/tests/test_codex_turn_leases.py
+++ b/tests/test_codex_turn_leases.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 
 from cc_remote.wrapper.codex_turn_leases import CodexTurnLeaseStore
 
@@ -22,7 +23,8 @@ def test_codex_turn_lease_round_trip_and_matched_release(tmp_path):
     assert lease.daemon_epoch == "a" * 32
     assert lease.automatic is True
     assert store.list() == (lease,)
-    assert os.stat(store.path).st_mode & 0o777 == 0o600
+    if sys.platform != "win32":
+        assert os.stat(store.path).st_mode & 0o777 == 0o600
 
     assert store.release("session", turn_id="turn-b") is False
     assert store.get("session") == lease

--- a/tests/test_codex_worktree_fork.py
+++ b/tests/test_codex_worktree_fork.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -20,12 +21,20 @@ from cc_remote.wrapper.codex_forks import ForkJournalError
 from cc_remote.wrapper.codex_rpc import CodexRpcOutcomeUnknown, CodexRpcRejected
 from tests.test_multisession import _mk_ctx, _mk_machine
 
+# The source production path (machine.py's ``_handle_fork_session_locked``)
+# normalizes the source cwd with ``os.path.realpath`` before using it as a
+# journal identity key. On Windows that turns a bare "/repo/component" into
+# "D:\\repo\\component" (drive-relative root), while POSIX leaves it
+# unchanged, so tests must route every occurrence through the same call to
+# stay aligned with what the code under test actually stores/compares.
+_SOURCE_CWD = os.path.realpath("/repo/component")
+
 
 def _ctx(state: str = "idle"):
     ctx = _mk_ctx("parent", "parent")
     ctx.engine = "codex"
     ctx.state = state
-    ctx.cwd = "/repo/component"
+    ctx.cwd = _SOURCE_CWD
     ctx.sdk = SimpleNamespace(model="gpt-test")
     return ctx
 
@@ -109,7 +118,7 @@ def test_codex_same_cwd_fork_uses_selected_turn_and_is_durable(monkeypatch):
             "approvalPolicy": "never",
         }, None)]
         assert result.session_id == "forked-thread"
-        assert result.cwd == "/repo/component"
+        assert result.cwd == _SOURCE_CWD
         assert result.target == "same_cwd"
         assert result.git_branch is None
         assert result.last_turn_id == "turn-2"
@@ -120,7 +129,7 @@ def test_codex_same_cwd_fork_uses_selected_turn_and_is_durable(monkeypatch):
         # the in-memory command ACK cache.
         reloaded = CodexForkJournal(machine.cfg.state_dir)
         entry = reloaded.begin(
-            "request-1", "parent", "turn-2", "/repo/component")
+            "request-1", "parent", "turn-2", _SOURCE_CWD)
         assert entry["status"] == "complete"
         assert entry["session_id"] == "forked-thread"
 
@@ -241,7 +250,7 @@ def test_codex_same_cwd_fork_recovers_committed_rollout_intent(monkeypatch):
         machine, _ = _mk_machine()
         machine.sessions = {"parent": _ctx()}
         machine._codex_forks.begin(
-            "request-1", "parent", "turn-2", "/repo/component")
+            "request-1", "parent", "turn-2", _SOURCE_CWD)
 
         async def is_codex(_sid): return True
         async def list_sessions(_cmd): return None
@@ -253,7 +262,7 @@ def test_codex_same_cwd_fork_recovers_committed_rollout_intent(monkeypatch):
         monkeypatch.setattr(machine_module, "codex_rpc", rpc)
         monkeypatch.setattr(machine_module, "find_rollout_fork", lambda *_args: {
             "session_id": "recovered-thread",
-            "cwd": "/repo/component",
+            "cwd": _SOURCE_CWD,
             "thread_source": "cc-remote-fork:request-1",
             "forked_from_id": "parent",
         })
@@ -329,7 +338,7 @@ def test_codex_same_cwd_fork_unknown_rpc_outcome_only_reconciles_on_retry(monkey
                 return None
             return {
                 "session_id": child,
-                "cwd": "/repo/component",
+                "cwd": _SOURCE_CWD,
                 "thread_source": "cc-remote-fork:request-1",
                 "forked_from_id": "parent",
             }
@@ -386,7 +395,7 @@ def test_codex_same_cwd_fork_background_reconcile_acks_current_connection(monkey
                 return None
             return {
                 "session_id": "background-child",
-                "cwd": "/repo/component",
+                "cwd": _SOURCE_CWD,
                 "thread_source": "cc-remote-fork:request-1",
                 "forked_from_id": "parent",
             }
@@ -426,7 +435,7 @@ def test_codex_same_cwd_fork_restart_submitted_state_never_reforks(monkeypatch):
     async def run():
         first, first_transport = _mk_machine()
         first._codex_forks.begin(
-            "request-1", "parent", "turn-2", "/repo/component")
+            "request-1", "parent", "turn-2", _SOURCE_CWD)
         first._codex_forks.mark_submitted("request-1")
 
         transport = type(first_transport)()
@@ -470,7 +479,7 @@ def test_codex_same_identity_new_request_aliases_submitted_child(monkeypatch):
         machine.FORK_RECONCILE_DELAY = 0
         machine.FORK_BACKGROUND_ATTEMPTS = 1
         machine._codex_forks.begin(
-            "request-old", "parent", "turn-2", "/repo/component")
+            "request-old", "parent", "turn-2", _SOURCE_CWD)
         machine._codex_forks.mark_submitted("request-old")
         rpc_calls = []
         visible = {"child": None}
@@ -485,7 +494,7 @@ def test_codex_same_identity_new_request_aliases_submitted_child(monkeypatch):
                 return None
             return {
                 "session_id": visible["child"],
-                "cwd": "/repo/component",
+                "cwd": _SOURCE_CWD,
                 "thread_source": marker,
                 "forked_from_id": "parent",
             }

--- a/tests/test_codex_worktrees.py
+++ b/tests/test_codex_worktrees.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+
 from cc_remote.wrapper.codex_worktrees import (
     WorktreeError,
     prepare_worktree,
@@ -20,6 +21,20 @@ def _git(cwd: Path, *args: str) -> str:
         text=True,
     )
     return result.stdout.strip()
+
+
+def _worktree_list_paths(cwd: Path) -> list[str]:
+    """Return each ``worktree`` path from ``git worktree list --porcelain``.
+
+    Git always reports paths with forward slashes, even on Windows, so
+    callers must compare via :class:`Path` rather than a raw string.
+    """
+    output = _git(cwd, "worktree", "list", "--porcelain")
+    return [
+        line[len("worktree "):]
+        for line in output.splitlines()
+        if line.startswith("worktree ")
+    ]
 
 
 def _repo(tmp_path: Path) -> Path:
@@ -55,8 +70,10 @@ def test_prepare_worktree_preserves_session_subdirectory_and_is_idempotent(tmp_p
     assert replay.worktree_root == first.worktree_root
     assert replay.cwd == first.cwd
     assert replay.branch == first.branch
-    assert _git(root, "worktree", "list", "--porcelain").count(
-        f"worktree {first.worktree_root}") == 1
+    listed = _worktree_list_paths(root)
+    assert sum(
+        1 for path in listed if Path(path) == Path(first.worktree_root)
+    ) == 1
 
     rollback_worktree(first)
     assert not Path(first.worktree_root).exists()

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sys
 import time
 from argparse import Namespace
 
@@ -89,7 +90,8 @@ def test_pairing_code_is_single_use_and_plaintext_credential_is_not_stored(tmp_p
         return enrolled.token
 
     token = asyncio.run(scenario())
-    assert os.stat(path).st_mode & 0o777 == 0o600
+    if sys.platform != "win32":
+        assert os.stat(path).st_mode & 0o777 == 0o600
     assert token.encode() not in path.read_bytes()
 
 
@@ -213,6 +215,10 @@ def test_paired_device_expands_multi_user_machine_authority(tmp_path):
 
 
 def test_wrapper_config_reads_private_paired_device_file(tmp_path, monkeypatch):
+    if sys.platform == "win32":
+        pytest.skip(
+            "Windows os.chmod cannot clear group/other bits, so "
+            "_load_device_config's 0o077 check always rejects the file")
     path = tmp_path / "device.json"
     path.write_text(json.dumps({
         "relay_url": "wss://remote.example/ws",
@@ -276,7 +282,8 @@ def test_pairing_cli_writes_private_config_without_printing_token(
         replace=False,
     )
     assert device_cli.pair(args) == 0
-    assert os.stat(target).st_mode & 0o777 == 0o600
+    if sys.platform != "win32":
+        assert os.stat(target).st_mode & 0o777 == 0o600
     payload = json.loads(target.read_text(encoding="utf-8"))
     assert payload["wrapper_token"] == token
     assert token not in capsys.readouterr().out

--- a/tests/test_engine_capabilities.py
+++ b/tests/test_engine_capabilities.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -489,7 +490,12 @@ def test_project_hook_rejects_symlinked_config_directory(monkeypatch, tmp_path):
         home.mkdir()
         project.mkdir()
         outside.mkdir()
-        (project / ".claude").symlink_to(outside, target_is_directory=True)
+        try:
+            (project / ".claude").symlink_to(outside, target_is_directory=True)
+        except OSError as exc:
+            if sys.platform == "win32":
+                pytest.skip(f"Windows symlink privilege is unavailable: {exc}")
+            raise
         monkeypatch.setattr(
             capabilities_module.Path, "home", classmethod(lambda _cls: home)
         )

--- a/tests/test_file_lock_compat.py
+++ b/tests/test_file_lock_compat.py
@@ -1,0 +1,24 @@
+"""Regression checks for the cross-platform advisory lock wrapper."""
+from __future__ import annotations
+
+import os
+
+from cc_remote.wrapper.file_lock_compat import LOCK_EX, LOCK_UN, flock
+
+
+def test_flock_preserves_offset_and_unlocks_after_io(tmp_path):
+    path = tmp_path / "journal.lock"
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        os.write(fd, b"header")
+        expected_offset = os.lseek(fd, 0, os.SEEK_CUR)
+
+        flock(fd, LOCK_EX)
+        assert os.lseek(fd, 0, os.SEEK_CUR) == expected_offset
+
+        os.write(fd, b"-payload\n")
+        unlock_offset = os.lseek(fd, 0, os.SEEK_CUR)
+        flock(fd, LOCK_UN)
+        assert os.lseek(fd, 0, os.SEEK_CUR) == unlock_offset
+    finally:
+        os.close(fd)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -3105,7 +3105,10 @@ def test_scoped_empty_claude_history_retries_global_lookup(
 
         assert [row["prompt"] for row in history.events
                 if row["type"] == "user_msg"] == ["recovered"]
-        assert calls == ["/stale/browser", None]
+        # _build_history resolves the hint with os.path.realpath, which on
+        # Windows also rewrites a POSIX-style absolute path to the current
+        # drive (e.g. "/stale/browser" -> "D:\\stale\\browser").
+        assert calls == [os.path.realpath("/stale/browser"), None]
 
     asyncio.run(go())
 
@@ -3139,7 +3142,8 @@ def test_truly_empty_claude_history_is_authoritative_after_global_retry(
 
         assert history.authoritative is True
         assert history.events == []
-        assert calls == ["/listed/project", None]
+        # See the realpath note in test_scoped_empty_claude_history_retries_global_lookup.
+        assert calls == [os.path.realpath("/listed/project"), None]
         cached = machine._history_index.get_page(
             "claude-empty", "claude", source, before=None, limit=4)
         assert cached is not None and cached.turns == ()
@@ -4272,7 +4276,9 @@ def test_unpaired_history_agent_message_is_not_lost_at_snapshot_eof(tmp_path):
                     }]},
     }
     encoded_prefix = "".join(json.dumps(row) + "\n" for row in prefix)
-    source.write_text(encoded_prefix + json.dumps(suffix) + "\n")
+    # end_offset below is a byte offset into this exact \n-only content, so
+    # write it verbatim rather than letting Windows expand \n to \r\n.
+    source.write_text(encoded_prefix + json.dumps(suffix) + "\n", newline="")
 
     events, _ = codex_translate_history(
         str(source), tool_result_max=4096,

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import sys
 
 import pytest
 
@@ -237,7 +238,8 @@ def test_history_index_is_bounded_and_invalidatable(tmp_path):
     store.invalidate_session("session-2")
     assert store.get_page(
         "session-2", "claude", source, before=None, limit=4) is None
-    assert oct(os.stat(store.path).st_mode & 0o777) == "0o600"
+    if sys.platform != "win32":
+        assert oct(os.stat(store.path).st_mode & 0o777) == "0o600"
 
 
 @pytest.mark.parametrize("old_version", [6, 7, 8, 9])

--- a/tests/test_markdown_preview.py
+++ b/tests/test_markdown_preview.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 import hashlib
 import os
 import stat
+import sys
 import threading
 from dataclasses import replace
 from pathlib import Path
@@ -39,7 +40,7 @@ def test_markdown_preview_reads_utf8_and_normalizes_paths(tmp_path):
     docs = tmp_path / "docs"
     docs.mkdir()
     readme = docs / "README.md"
-    readme.write_text("\ufeff# 标题\n\n正文", encoding="utf-8")
+    readme.write_text("\ufeff# 标题\n\n正文", encoding="utf-8", newline="")
     machine, _ = _mk_machine()
 
     relative = machine._read_markdown_preview(str(tmp_path), "docs/README.md")
@@ -54,7 +55,8 @@ def test_markdown_preview_reads_utf8_and_normalizes_paths(tmp_path):
 
 def test_source_preview_reads_utf8_and_reports_text_format(tmp_path):
     source = tmp_path / "module.py"
-    source.write_text("def answer():\n    return 42\n", encoding="utf-8")
+    source.write_text(
+        "def answer():\n    return 42\n", encoding="utf-8", newline="")
     machine, _ = _mk_machine()
 
     result = machine._read_text_preview(str(tmp_path), "module.py")
@@ -80,7 +82,8 @@ def test_markdown_save_is_atomic_and_preserves_bom_crlf_and_mode(tmp_path):
 
     assert result[0] == "README.md"
     assert path.read_bytes() == b"\xef\xbb\xbf# new\r\nline\r\n"
-    assert stat.S_IMODE(path.stat().st_mode) == 0o640
+    if sys.platform != "win32":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o640
     assert result[1] == path.stat().st_size
     assert result[2] == path.stat().st_mtime_ns
     assert result[3] == hashlib.sha256(path.read_bytes()).hexdigest()
@@ -110,16 +113,22 @@ def test_markdown_save_rejects_non_markdown_and_symlink(tmp_path):
     root.mkdir()
     source = root / "note.txt"
     source.write_text("text", encoding="utf-8")
-    link = root / "link.md"
-    link.symlink_to(outside)
     machine, _ = _mk_machine()
     source_stat = source.stat()
-    link_stat = outside.stat()
 
     with pytest.raises(ValueError, match="Markdown"):
         machine._write_markdown_file(
             str(root), "note.txt", "draft", source_stat.st_size,
             source_stat.st_mtime_ns, hashlib.sha256(source.read_bytes()).hexdigest())
+
+    link = root / "link.md"
+    try:
+        link.symlink_to(outside)
+    except OSError as exc:
+        if sys.platform == "win32":
+            pytest.skip(f"Windows symlink privilege is unavailable: {exc}")
+        raise
+    link_stat = outside.stat()
     with pytest.raises(ValueError, match="符号链接"):
         machine._write_markdown_file(
             str(root), "link.md", "draft", link_stat.st_size,
@@ -267,12 +276,18 @@ def test_markdown_preview_rejects_absolute_and_symlink_escape(tmp_path):
     root.mkdir()
     outside = tmp_path / "outside.md"
     outside.write_text("secret", encoding="utf-8")
-    (root / "escape.md").symlink_to(outside)
     machine, _ = _mk_machine()
 
     with pytest.raises(ValueError, match="确认"):
         machine._read_markdown_preview(str(root), str(outside))
-    with pytest.raises(ValueError, match="确认"):
+
+    try:
+        (root / "escape.md").symlink_to(outside)
+    except OSError as exc:
+        if sys.platform == "win32":
+            pytest.skip(f"Windows symlink privilege is unavailable: {exc}")
+        raise
+    with pytest.raises(ValueError, match="超出"):
         machine._read_markdown_preview(str(root), "escape.md")
 
 
@@ -1283,8 +1298,8 @@ def test_successful_codex_patch_grants_multiple_exact_cross_cwd_paths(tmp_path):
     root.mkdir()
     first = tmp_path / "one.txt"
     second = tmp_path / "two.md"
-    first.write_text("1\n", encoding="utf-8")
-    second.write_text("# two\n", encoding="utf-8")
+    first.write_text("1\n", encoding="utf-8", newline="")
+    second.write_text("# two\n", encoding="utf-8", newline="")
     machine, _ = _mk_machine()
     ctx = _mk_ctx("session-1", session_id="session-1")
     ctx.cwd = str(root)
@@ -1442,6 +1457,8 @@ def test_external_binary_diff_never_decodes_capability_snapshot(tmp_path):
 
 
 def test_markdown_preview_rejects_special_files_without_blocking(tmp_path):
+    if sys.platform == "win32":
+        pytest.skip("Windows has no FIFO special files")
     fifo = tmp_path / "pipe.md"
     os.mkfifo(fifo)
     machine, _ = _mk_machine()

--- a/tests/test_product_version.py
+++ b/tests/test_product_version.py
@@ -16,10 +16,11 @@ def test_v3_product_version_is_consistent_across_runtime_and_web_metadata():
     assert __version__ == "3.0.0"
     assert re.fullmatch(r"[1-9]\d*\.\d+\.\d+", __version__)
 
-    package = json.loads((ROOT / "web/package.json").read_text())
-    package_lock = json.loads((ROOT / "web/package-lock.json").read_text())
+    package = json.loads((ROOT / "web/package.json").read_text(encoding="utf-8"))
+    package_lock = json.loads(
+        (ROOT / "web/package-lock.json").read_text(encoding="utf-8"))
     build_manifest = json.loads(
-        (ROOT / "web/public/cc-remote-build.json").read_text()
+        (ROOT / "web/public/cc-remote-build.json").read_text(encoding="utf-8")
     )
 
     assert package["version"] == __version__
@@ -30,14 +31,14 @@ def test_v3_product_version_is_consistent_across_runtime_and_web_metadata():
         "protocol": PROTOCOL_VERSION,
     }
     assert _initialize_params()["clientInfo"]["version"] == __version__
-    installer = (ROOT / "deploy/install.sh").read_text()
+    installer = (ROOT / "deploy/install.sh").read_text(encoding="utf-8")
     assert f'VERSION="${{CC_REMOTE_VERSION:-{__version__}}}"' in installer
 
 
 def test_release_docs_distinguish_product_and_wire_protocol_versions():
-    readme = (ROOT / "README.md").read_text()
-    readme_en = (ROOT / "README_en.md").read_text()
-    changelog = (ROOT / "CHANGELOG.md").read_text()
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    readme_en = (ROOT / "README_en.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
 
     assert "当前版本：v3.0.0" in readme
     assert "## v3 架构升级" in readme
@@ -49,8 +50,8 @@ def test_release_docs_distinguish_product_and_wire_protocol_versions():
 
 
 def test_readmes_use_safe_markdown_for_navigation_and_images():
-    readme = (ROOT / "README.md").read_text()
-    readme_en = (ROOT / "README_en.md").read_text()
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    readme_en = (ROOT / "README_en.md").read_text(encoding="utf-8")
 
     for document in (readme, readme_en):
         assert '<p align="center">' not in document

--- a/tests/test_rollback_commands.py
+++ b/tests/test_rollback_commands.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+import sys
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -65,8 +66,19 @@ def test_rollback_journal_survives_restart_without_reclaiming_submission(
         "num_turns": 1,
         "checkpoint_id": None,
     }
-    assert stat.S_IMODE((tmp_path / "rollback-commands.json").stat().st_mode) == 0o600
-    assert stat.S_IMODE((tmp_path / "rollback-commands.lock").stat().st_mode) == 0o600
+    if sys.platform != "win32":
+        assert (
+            stat.S_IMODE(
+                (tmp_path / "rollback-commands.json").stat().st_mode
+            )
+            == 0o600
+        )
+        assert (
+            stat.S_IMODE(
+                (tmp_path / "rollback-commands.lock").stat().st_mode
+            )
+            == 0o600
+        )
     assert journal.mark_submitted("browser-1", "cmd-1") is True
 
     reloaded = RollbackCommandJournal(tmp_path)
@@ -301,7 +313,12 @@ def test_rollback_journal_corruption_fails_closed(tmp_path, mutate):
 def test_rollback_journal_rejects_symlink_state_file(tmp_path):
     target = tmp_path / "foreign.json"
     target.write_text("{}")
-    os.symlink(target, tmp_path / "rollback-commands.json")
+    try:
+        os.symlink(target, tmp_path / "rollback-commands.json")
+    except OSError as exc:
+        if sys.platform == "win32":
+            pytest.skip(f"Windows symlink privilege is unavailable: {exc}")
+        raise
 
     with pytest.raises(RollbackJournalError, match="unreadable"):
         RollbackCommandJournal(tmp_path)

--- a/tests/test_session_pins.py
+++ b/tests/test_session_pins.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -79,7 +80,8 @@ def test_session_pin_store_persists_and_unpins(tmp_path):
     store.set_pinned("codex", "codex-1", True)
     assert SessionPinStore(tmp_path).ids("claude") == {"claude-1"}
     assert SessionPinStore(tmp_path).ids("codex") == {"codex-1"}
-    assert oct(os.stat(tmp_path / "session-pins.json").st_mode & 0o777) == "0o600"
+    if sys.platform != "win32":
+        assert oct(os.stat(tmp_path / "session-pins.json").st_mode & 0o777) == "0o600"
 
     store.set_pinned("claude", "claude-1", False)
     assert SessionPinStore(tmp_path).ids("claude") == set()

--- a/tests/test_transport_bounds.py
+++ b/tests/test_transport_bounds.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 
 import pytest
 
@@ -14,6 +15,10 @@ def _wrapper_cfg(**overrides):
     values = {
         "relay_url": "ws://127.0.0.1:8765/ws",
         "wrapper_token": "w" * 48,
+        # Pin this explicitly so a dev-machine .env with ALLOW_INSECURE_HTTP=1
+        # (its default_factory otherwise reads the ambient env) cannot flip
+        # the "must use wss" assertions below into false passes.
+        "allow_insecure_http": False,
     }
     values.update(overrides)
     return WrapperConfig(**values)
@@ -58,7 +63,12 @@ def test_wrapper_startup_config_fails_closed():
     # the supported native-CLI mirror path. Its socket is validated only after
     # an explicit opt-in.
     validate_wrapper_config(_wrapper_cfg(claude_broker_socket="relative.sock"))
-    with pytest.raises(ValueError, match="CC_REMOTE_CLAUDE_BROKER_SOCKET"):
+    broker_error = (
+        "CC_REMOTE_EXPERIMENTAL_CLAUDE_BROKER"
+        if sys.platform == "win32"
+        else "CC_REMOTE_CLAUDE_BROKER_SOCKET"
+    )
+    with pytest.raises(ValueError, match=broker_error):
         validate_wrapper_config(_wrapper_cfg(
             claude_broker_socket="relative.sock",
             experimental_claude_broker=True,

--- a/tests/test_tui_reliability.py
+++ b/tests/test_tui_reliability.py
@@ -476,7 +476,10 @@ def test_tui_keeps_and_answers_ask_user_per_session():
     "wss://relay.example.com/not-ws",
     "wss://relay.example.com/ws?token=secret",
 ])
-def test_tui_rejects_unsafe_relay_url_before_login(url):
+def test_tui_rejects_unsafe_relay_url_before_login(url, monkeypatch):
+    import cc_remote.tui as tui_module
+
+    monkeypatch.setattr(tui_module, "ALLOW_INSECURE_HTTP", False)
     with pytest.raises(ValueError):
         _validate_relay_url(url)
 

--- a/tests/test_web_protocol_mirror.py
+++ b/tests/test_web_protocol_mirror.py
@@ -37,9 +37,9 @@ from cc_remote.protocol import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
-TS_PROTOCOL = (ROOT / "web/src/protocol.ts").read_text()
-TS_REDUCER = (ROOT / "web/src/reducer.ts").read_text()
-TS_PROCESS_TIMELINE = (ROOT / "web/src/components/ProcessTimeline.tsx").read_text()
+TS_PROTOCOL = (ROOT / "web/src/protocol.ts").read_text(encoding="utf-8")
+TS_REDUCER = (ROOT / "web/src/reducer.ts").read_text(encoding="utf-8")
+TS_PROCESS_TIMELINE = (ROOT / "web/src/components/ProcessTimeline.tsx").read_text(encoding="utf-8")
 
 
 def _without_typescript_comments(source: str) -> str:
@@ -230,7 +230,7 @@ def test_protocol_version_and_web_build_manifest_match_backend():
     match = re.search(r"PROTOCOL_VERSION\s*=\s*(\d+)", TS_PROTOCOL)
     assert match, "TypeScript protocol version is missing"
     manifest = json.loads(
-        (ROOT / "web/public/cc-remote-build.json").read_text()
+        (ROOT / "web/public/cc-remote-build.json").read_text(encoding="utf-8")
     )
     assert int(match.group(1)) == PROTOCOL_VERSION
     assert manifest["protocol"] == PROTOCOL_VERSION

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sqlite3
+import sys
 import tempfile
 import threading
 import time
@@ -95,8 +96,9 @@ class WorkRegistryTests(unittest.TestCase):
         self.assertIn("结论先行", context)
         self.assertEqual((workspace / "资料库" / "report.csv").read_bytes(),
                          b"name,value\nA,1\n")
-        self.assertEqual(workspace.stat().st_mode & 0o777, 0o700)
-        self.assertEqual((workspace / "WORK.md").stat().st_mode & 0o777, 0o600)
+        if sys.platform != "win32":
+            self.assertEqual(workspace.stat().st_mode & 0o777, 0o700)
+            self.assertEqual((workspace / "WORK.md").stat().st_mode & 0o777, 0o600)
 
     def test_existing_work_session_tracks_later_project_context_changes(self):
         project_id = self.store.create_project("持续项目", "初始说明")
@@ -284,9 +286,6 @@ class WorkRegistryTests(unittest.TestCase):
         (workspace / ".private.txt").write_text("hidden", encoding="utf-8")
         (workspace / "资料库").mkdir(exist_ok=True)
         (workspace / "资料库" / "source.csv").write_text("input", encoding="utf-8")
-        outside = Path(self.tmp.name) / "outside.txt"
-        outside.write_text("outside", encoding="utf-8")
-        (workspace / "linked.txt").symlink_to(outside)
 
         artifacts = self.store.artifacts("session-1")
 
@@ -298,6 +297,20 @@ class WorkRegistryTests(unittest.TestCase):
         self.assertEqual(by_path["report.md"]["kind"], "document")
         self.assertTrue(by_path["output/deck.pptx"]["previewable"])
         self.assertEqual(by_path["output/deck.pptx"]["kind"], "presentation")
+
+        outside = Path(self.tmp.name) / "outside.txt"
+        outside.write_text("outside", encoding="utf-8")
+        try:
+            (workspace / "linked.txt").symlink_to(outside)
+        except OSError as exc:
+            if sys.platform == "win32":
+                self.skipTest(f"Windows symlink privilege is unavailable: {exc}")
+            raise
+
+        artifacts_with_symlink = self.store.artifacts("session-1")
+        self.assertEqual({item["path"] for item in artifacts_with_symlink}, {
+            "report.md", "output/deck.pptx",
+        })
 
     def test_claude_policy_copies_only_runtime_provider_settings(self):
         config_dir = Path(self.tmp.name) / "claude-config"
@@ -336,7 +349,8 @@ class WorkRegistryTests(unittest.TestCase):
                          [record.cwd])
         self.assertEqual(payload["sandbox"]["filesystem"]["allowWrite"],
                          [record.cwd])
-        self.assertEqual(policy.stat().st_mode & 0o777, 0o600)
+        if sys.platform != "win32":
+            self.assertEqual(policy.stat().st_mode & 0o777, 0o600)
 
     def test_claude_policy_ignores_invalid_or_oversized_user_settings(self):
         config_dir = Path(self.tmp.name) / "claude-config"
@@ -379,7 +393,8 @@ class WorkRegistryTests(unittest.TestCase):
             payload["env"]["CLAUDE_CODE_OAUTH_TOKEN"],
             "rotated-token",
         )
-        self.assertEqual(policy.stat().st_mode & 0o777, 0o600)
+        if sys.platform != "win32":
+            self.assertEqual(policy.stat().st_mode & 0o777, 0o600)
 
 
 if __name__ == "__main__":

--- a/tests/test_wrapper_core_fixes.py
+++ b/tests/test_wrapper_core_fixes.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import os
 import subprocess
+import sys
 import time
 from types import SimpleNamespace
 
@@ -231,14 +232,15 @@ def test_all_files_diff_includes_untracked_regular_files(tmp_path):
     repo.mkdir()
     subprocess.run(["git", "init", "-q", str(repo)], check=True)
     tracked = repo / "tracked.txt"
-    tracked.write_text("before\n")
+    tracked.write_text("before\n", encoding="utf-8", newline="")
     subprocess.run(["git", "-C", str(repo), "add", "tracked.txt"], check=True)
     subprocess.run([
         "git", "-C", str(repo), "-c", "user.name=Test",
         "-c", "user.email=test@example.com", "commit", "-qm", "initial",
     ], check=True)
-    tracked.write_text("after\n")
-    (repo / "chat.html").write_text("<h1>交付物</h1>\n")
+    tracked.write_text("after\n", encoding="utf-8", newline="")
+    (repo / "chat.html").write_text(
+        "<h1>交付物</h1>\n", encoding="utf-8", newline="")
 
     async def run():
         machine, _ = _mk_machine()
@@ -304,6 +306,8 @@ def test_get_diff_with_explicit_unknown_sid_never_reads_focused_repo():
 
 
 def test_diff_rejects_untracked_fifo_without_opening_it(tmp_path):
+    if sys.platform == "win32":
+        pytest.skip("Windows has no FIFO special files")
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init", "-q", str(repo)], check=True)
@@ -330,6 +334,10 @@ def test_bounded_subprocess_output_has_wall_clock_timeout():
 
 
 def test_bounded_subprocess_discards_residual_output_without_communicate(monkeypatch):
+    if sys.platform == "win32":
+        pytest.skip(
+            "os.killpg does not exist on Windows; bounded_process_output "
+            "uses proc.kill() there instead of process-group signaling")
     class FakeStdout:
         def __init__(self):
             self.data = bytearray(b"x" * 100)
@@ -381,6 +389,10 @@ def test_background_job_scan_caps_entries_and_state_file_size(
     jobs = tmp_path / ".claude" / "jobs"
     jobs.mkdir(parents=True)
     monkeypatch.setenv("HOME", str(tmp_path))
+    if sys.platform == "win32":
+        # Path.home()/os.path.expanduser resolve "~" from USERPROFILE (or
+        # HOMEDRIVE+HOMEPATH) on Windows, not from HOME.
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     valid = jobs / "valid"
     valid.mkdir()
@@ -997,7 +1009,8 @@ def test_codex_session_settings_reads_bounded_tail_of_oversized_source(
             "collaboration_mode": {"mode": "plan"},
         },
     }) + "\n"
-    rollout.write_text(old + ("x" * 4096) + "\n" + latest)
+    rollout.write_text(
+        old + ("x" * 4096) + "\n" + latest, encoding="utf-8", newline="")
     monkeypatch.setattr(
         codex_sessions_module, "_rollout_path", lambda _sid: str(rollout))
 


### PR DESCRIPTION
Replace Unix-only system calls with cross-platform alternatives:
- Add file_lock_compat module for fcntl.flock replacement
- Use msvcrt.locking on Windows, fcntl.flock on Unix
- Add _getuid() helper returning 0 on Windows
- Replace os.fchmod with os.chmod fallback on Windows
- Defer claude_broker imports to avoid loading fcntl on Windows

This enables the wrapper to run on Windows while maintaining full compatibility with the official macOS/Linux deployment path.