### PR TITLE
ci(web): retry transient Playwright failures in CI

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   testMatch: "history-browser.spec.ts",
   fullyParallel: false,
   workers: 1,
+  retries: process.env.CI ? 2 : 0,
   reporter: "line",
   use: {
     baseURL: "http://127.0.0.1:4174",


### PR DESCRIPTION
## Summary

- retry failed Playwright browser tests up to two times in CI
- keep local Playwright runs fail-fast for deterministic debugging

## Motivation

The history-browser suite exercises timing-sensitive WebKit behavior, including
virtualized scroll anchoring, deferred Mermaid rendering, and touch completion.
Under CI load, an isolated attempt can time out even when the same test passes
immediately on retry without a code change.

This uses Playwright's built-in CI retry mechanism. Assertions, worker count,
trace collection, and local behavior remain unchanged, so persistent
regressions still fail after three total attempts.

## Testing

- full `act pull_request` workflow: Web, Python, and Deploy jobs passed
- Python: 1206 passed, 1 skipped
- Ruff 0.15.13: passed
- Web build and reliability suite: passed
- Playwright history-browser suite with `CI=1`: 77 passed, 9 skipped, 2 flaky tests passed on retry
- Oxlint, `bash -n`, ShellCheck, and `git diff --check`: passed
