### PR TITLE
fix(web): recover cleanly from protocol upgrades

### DIFF
--- a/cc_remote/relay/server.py
+++ b/cc_remote/relay/server.py
@@ -466,6 +466,24 @@ def create_app(
     app.state.push_dispatcher = push_dispatcher
     app.state.device_store = devices
 
+    @app.middleware("http")
+    async def static_shell_cache_policy(req: Request, call_next):
+        """Never let a protocol upgrade reload into a stale application shell."""
+        response = await call_next(req)
+        path = req.url.path
+        if path in {"/", "/index.html", "/sw.js", "/cc-remote-build.json"}:
+            response.headers["Cache-Control"] = "no-cache, must-revalidate"
+        elif (
+            path.startswith("/assets/")
+            and response.status_code in {200, 206}
+        ):
+            # Vite asset names are content-addressed; old pages can keep using
+            # their exact files while a new navigation picks up the new index.
+            response.headers["Cache-Control"] = (
+                "public, max-age=31536000, immutable"
+            )
+        return response
+
     @app.get("/api/auth-config")
     async def auth_config() -> JSONResponse:
         return JSONResponse(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -693,6 +693,35 @@ def test_relay_config_rejects_non_tls_public_origin():
         validate_relay_config(_cfg(public_origin="http://remote.example"))
 
 
+def test_static_shell_revalidates_across_protocol_upgrades(tmp_path):
+    (tmp_path / "assets").mkdir()
+    (tmp_path / "index.html").write_text("<p>shell</p>", encoding="utf-8")
+    (tmp_path / "sw.js").write_text("// worker", encoding="utf-8")
+    (tmp_path / "cc-remote-build.json").write_text(
+        '{"version":"3.0.0","protocol":20}', encoding="utf-8",
+    )
+    (tmp_path / "assets" / "index-hash.js").write_text(
+        "// hashed", encoding="utf-8",
+    )
+    cfg = _cfg(static_dir=str(tmp_path))
+
+    with TestClient(create_app(cfg), base_url=cfg.public_origin) as client:
+        for path in ("/", "/index.html", "/sw.js", "/cc-remote-build.json"):
+            response = client.get(path)
+            assert response.status_code == 200
+            assert response.headers["cache-control"] == (
+                "no-cache, must-revalidate"
+            )
+        asset = client.get("/assets/index-hash.js")
+        assert asset.status_code == 200
+        assert asset.headers["cache-control"] == (
+            "public, max-age=31536000, immutable"
+        )
+        missing = client.get("/assets/not-yet-deployed.js")
+        assert missing.status_code == 404
+        assert "immutable" not in missing.headers.get("cache-control", "")
+
+
 def test_allow_insecure_http_permits_a_plain_http_public_ip_origin():
     # Explicit opt-in escape hatch: a bare public IP without a TLS terminator.
     cfg = _cfg(public_origin="http://198.51.100.10:8765", allow_insecure_http=True)

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   testMatch: "history-browser.spec.ts",
   fullyParallel: false,
   workers: 1,
+  retries: process.env.CI ? 2 : 0,
   reporter: "line",
   use: {
     baseURL: "http://127.0.0.1:4174",

--- a/web/src/reducer.ts
+++ b/web/src/reducer.ts
@@ -865,6 +865,9 @@ export function reduce(state: AppState, action: Action): AppState {
       if (action.connState === "connected") banner = undefined;
       else if (action.connState === "reconnecting") banner = action.detail || "正在重新连接…";
       else if (action.connState === "connecting") banner = "正在连接…";
+      else if (action.connState === "disconnected" && action.detail) {
+        banner = action.detail;
+      }
       const runtimes = action.connState === "connected"
         ? state.runtimes
         : Object.fromEntries(Object.entries(state.runtimes).map(

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -55,6 +55,33 @@ const OUTBOX_MAX_BYTES = 64 * 1024 * 1024;
 // that can enter the 64 MiB aggregate outbox but can never cross the relay.
 const OUTBOX_MAX_FRAME_BYTES = 14 * 1024 * 1024;
 const MAX_REPLAY_SESSIONS = 128;
+const PROTOCOL_RELOAD_KEY = "cc-remote:protocol-reload";
+
+function readProtocolReloadMarker(): string | null | undefined {
+  try {
+    return globalThis.sessionStorage.getItem(PROTOCOL_RELOAD_KEY);
+  } catch {
+    return undefined;
+  }
+}
+
+function writeProtocolReloadMarker(): boolean {
+  try {
+    globalThis.sessionStorage.setItem(
+      PROTOCOL_RELOAD_KEY, String(PROTOCOL_VERSION));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function clearProtocolReloadMarker(): void {
+  try {
+    globalThis.sessionStorage.removeItem(PROTOCOL_RELOAD_KEY);
+  } catch {
+    // Storage can be unavailable in privacy-restricted or sandboxed contexts.
+  }
+}
 
 function nowTs(): number {
   return Date.now() / 1000;
@@ -1093,6 +1120,9 @@ export class RelayWs {
       try {
         const decoded = JSON.parse(e.data) as ServerEvent;
         this.lastRecvAt = Date.now();  // any valid JSON frame proves the link is alive
+        // A real frame proves that this bundle and the relay agree. Clear the
+        // one-shot mismatch guard so a future deployment may refresh once too.
+        clearProtocolReloadMarker();
         const msg = this.filterControl(decoded);
         if (!msg) return;
         if ((msg as { type: string }).type === "pong") return;  // heartbeat reply — consume, don't dispatch
@@ -1320,7 +1350,21 @@ export class RelayWs {
       if (this.ws === ws) this.ws = null;
       this.stopHeartbeat();
       if (ev.code === 4406) {
-        window.location.reload();
+        // Static assets and the relay cannot be swapped atomically on every
+        // deployment target. Refresh once to pick up the matching bundle, but
+        // never trap mobile browsers in an unbounded reload loop while the
+        // other tier is still rolling forward.
+        const reloadMarker = readProtocolReloadMarker();
+        if (reloadMarker !== undefined
+            && reloadMarker !== String(PROTOCOL_VERSION)
+            && writeProtocolReloadMarker()) {
+          window.location.reload();
+        } else {
+          this.cb.onConnState(
+            "disconnected",
+            "页面与服务端版本不一致；请等待部署完成后手动刷新。",
+          );
+        }
         return;
       }
       if (ev.code === 1008) {

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -5978,12 +5978,79 @@ class FakeWebSocket {
   }
 }
 
+const sessionValues = new Map<string, string>();
+const browserSessionStorage = {
+  getItem: (key: string) => sessionValues.get(key) ?? null,
+  setItem: (key: string, value: string) => { sessionValues.set(key, value); },
+  removeItem: (key: string) => { sessionValues.delete(key); },
+};
+let protocolReloads = 0;
 Object.assign(globalThis, {
   window: {
-    location: { protocol: "http:", host: "relay.test", reload: () => {} },
+    location: {
+      protocol: "http:", host: "relay.test",
+      reload: () => { protocolReloads += 1; },
+    },
   },
   WebSocket: FakeWebSocket,
+  sessionStorage: browserSessionStorage,
 });
+
+const firstMismatch = new RelayWs({
+  onEvent: () => {},
+  onConnState: () => {},
+});
+firstMismatch.start();
+FakeWebSocket.instances.at(-1)?.onclose?.({ code: 4406 });
+assert.equal(protocolReloads, 1,
+  "the first protocol mismatch should refresh the bundle once");
+
+const mismatchStates: Array<{ state: string; detail?: string }> = [];
+const repeatedMismatch = new RelayWs({
+  onEvent: () => {},
+  onConnState: (state, detail) => {
+    mismatchStates.push({ state, detail });
+  },
+});
+repeatedMismatch.start();
+FakeWebSocket.instances.at(-1)?.onclose?.({ code: 4406 });
+assert.equal(protocolReloads, 1,
+  "a rolling deploy must not trap the browser in a reload loop");
+assert.deepEqual(mismatchStates.at(-1), {
+  state: "disconnected",
+  detail: "页面与服务端版本不一致；请等待部署完成后手动刷新。",
+});
+
+Object.assign(globalThis, {
+  sessionStorage: {
+    getItem: () => { throw new DOMException("blocked", "SecurityError"); },
+    setItem: () => { throw new DOMException("blocked", "SecurityError"); },
+    removeItem: () => { throw new DOMException("blocked", "SecurityError"); },
+  },
+});
+const storageBlockedEvents: ServerEvent[] = [];
+const storageBlockedStates: Array<{ state: string; detail?: string }> = [];
+const storageBlocked = new RelayWs({
+  onEvent: (event) => { storageBlockedEvents.push(event); },
+  onConnState: (state, detail) => {
+    storageBlockedStates.push({ state, detail });
+  },
+});
+storageBlocked.start();
+const storageBlockedSocket = FakeWebSocket.instances.at(-1);
+storageBlockedSocket?.receive({
+  type: "state", sid: "storage-blocked", state: "idle",
+});
+assert.equal(storageBlockedEvents.length, 1,
+  "blocked sessionStorage must not make a valid frame look malformed");
+storageBlockedSocket?.onclose?.({ code: 4406 });
+assert.equal(protocolReloads, 1,
+  "a mismatch cannot auto-reload safely when the reload guard is unavailable");
+assert.deepEqual(storageBlockedStates.at(-1), {
+  state: "disconnected",
+  detail: "页面与服务端版本不一致；请等待部署完成后手动刷新。",
+});
+Object.assign(globalThis, { sessionStorage: browserSessionStorage });
 
 const observed: ServerEvent[] = [];
 let wrapperGenerationChanges = 0;


### PR DESCRIPTION
## Summary

- force browser navigation requests to revalidate the deployed Web shell
- bound automatic reload attempts after a protocol-version mismatch
- preserve a useful mismatch error instead of entering a refresh loop

## Motivation

After a coordinated Wrapper/Relay/Web upgrade, a browser could reuse stale
shell HTML and repeatedly reload against a newer relay. Revalidating navigation
responses makes the newest hashed bundle discoverable, while the client-side
reload budget prevents a persistent cache or deployment mismatch from making
the application unusable.

## Dependencies

- Direct dependency: #8 provides the shared CI-only Playwright retry configuration.
- No other PR dependencies; the runtime fix is functionally independent of #8.
- Required merge order: #8 → #9.

## Testing

- full `act pull_request` workflow: Web, Python, and Deploy jobs passed
- protocol mismatch, authentication-cache, and reload-boundary regression tests
- Ruff, Oxlint, ShellCheck, and `git diff --check`
