### PR TITLE
feat(relay): allow authenticated private-IP origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ RELAY_PORT=8765
 # Exact browser origin allowed for cookie-authenticated WebSockets. Plain HTTP
 # is accepted only on loopback; production must use https://.
 PUBLIC_ORIGIN=http://127.0.0.1:8765
+# Optional direct browser access through literal private/loopback IPs on
+# RELAY_PORT. Covers 127/8, 10/8, 172.16/12, 192.168/16, Tailscale's
+# 100.64/10, IPv6 loopback and ULA. Hostnames, public IPs and other ports stay
+# rejected. Plain HTTP still exposes the password, cookie and traffic to the
+# local network, and it cannot provide an installable PWA.
+ALLOW_PRIVATE_ORIGINS=0
 # Opt-in escape hatch: set to 1 to allow PUBLIC_ORIGIN/RELAY_URL to be a
 # non-loopback plain http://IP (or ws://IP) instead of requiring https/wss —
 # e.g. reaching the relay over a bare public IP with no TLS terminator in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,13 @@ local `claude` or `codex` session through a WebSocket relay. Two independent lin
   the user's `settings.json` that decides.
 - **Auth is URL-secret-free**: the wrapper uses `Authorization: Bearer <token>`
   at WS upgrade. Web clients POST `LOGIN_PASSWORD` to `/api/login` and receive a
-  short-lived HttpOnly/SameSite cookie; `/ws` also enforces exact
-  `PUBLIC_ORIGIN`. Never put tokens in URLs or protocol message bodies; logging
-  redacts token/password fields.
+  short-lived HttpOnly/SameSite cookie; `/ws` enforces exact `PUBLIC_ORIGIN`.
+  When `ALLOW_PRIVATE_ORIGINS=1`, the only additional origins are literal
+  private/loopback IPs on `RELAY_PORT`, and their scheme/host/port must match
+  the effective request target. Cookie `Secure` follows that trusted request
+  transport, never the caller's Origin. Uvicorn trusts forwarded transport
+  metadata only from loopback Caddy. Never put tokens in URLs or protocol
+  message bodies; logging redacts token/password fields.
 - **Protocol version gate**: `PROTOCOL_VERSION` in both `protocol.py` and
   `web/src/protocol.ts`. `deserialize` hard-rejects a version mismatch, and
   `_Base` is `extra="forbid"`, so ANY protocol change must be deployed to all

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,13 @@ local `claude` or `codex` session through a WebSocket relay. Two independent lin
   the user's `settings.json` that decides.
 - **Auth is URL-secret-free**: the wrapper uses `Authorization: Bearer <token>`
   at WS upgrade. Web clients POST `LOGIN_PASSWORD` to `/api/login` and receive a
-  short-lived HttpOnly/SameSite cookie; `/ws` also enforces exact
-  `PUBLIC_ORIGIN`. Never put tokens in URLs or protocol message bodies; logging
-  redacts token/password fields.
+  short-lived HttpOnly/SameSite cookie; `/ws` enforces exact `PUBLIC_ORIGIN`.
+  When `ALLOW_PRIVATE_ORIGINS=1`, the only additional origins are literal
+  private/loopback IPs on `RELAY_PORT`, and their scheme/host/port must match
+  the effective request target. Cookie `Secure` follows that trusted request
+  transport, never the caller's Origin. Uvicorn trusts forwarded transport
+  metadata only from loopback Caddy. Never put tokens in URLs or protocol
+  message bodies; logging redacts token/password fields.
 - **History scroll anchoring lives in `@tanstack/virtual-core`, not in
   `react-virtual`**: `web/package.json` pins `@tanstack/react-virtual`, but
   `anchorTo` / `followOnAppend` / `scrollEndThreshold` /

--- a/README.md
+++ b/README.md
@@ -312,6 +312,17 @@ Linux 上脚本会自行请求 `sudo`。首次安装会交互要求一个至少 
 不可变 staging、原子 `current` 切换和失败回滚。已有
 `/opt/cc-remote/.env` 会原样保留。
 
+如果还要通过 LAN/Tailscale IPv4 地址直连同一台 Relay，首次安装时显式开启：
+
+```bash
+./install.sh relay --domain remote.example.com --allow-private-origins
+```
+
+这会让 Relay 监听 `0.0.0.0:8765`，公网域名仍由 Caddy 提供 HTTPS。端口 8765
+会出现在所有 IPv4 网卡上，必须用主机防火墙只允许可信 LAN/Tailscale 对端。
+已有安装仍保留 `.env`；要开启该模式，先手动把其中的
+`RELAY_HOST=0.0.0.0` 和 `ALLOW_PRIVATE_ORIGINS=1` 一起设置，再用相同参数升级。
+
 打开 `https://remote.example.com/` 登录，在顶部设备中心选择“允许添加设备”，复制
 一次性配对码。
 
@@ -532,7 +543,7 @@ HTTPS_PROXY=http://your-proxy:port      # SOCKS 用 ALL_PROXY=socks5://...
 
 | 变量 | 默认 | 说明 |
 |---|---|---|
-| `RELAY_HOST` / `RELAY_PORT` | `127.0.0.1` / `8765` | 监听地址（公网部署交给 Caddy，保持 127.0.0.1）。 |
+| `RELAY_HOST` / `RELAY_PORT` | `127.0.0.1` / `8765` | 监听地址（仅 Caddy 公网入口时保持 `127.0.0.1`；同时开放 LAN/Tailscale IPv4 直连时必须配合 `ALLOW_PRIVATE_ORIGINS=1` 改为 `0.0.0.0` 并限制防火墙）。 |
 | `LOGIN_PASSWORD` | 空 | 单用户网页登录口令。未设置 `LOGIN_USERS_JSON` 时**必须设**。 |
 | `LOGIN_USERS_JSON` | 空 | 可选多用户策略：`{"alice":{"password":"…","machines":["mac","nono"]}}`；设置后替代 `LOGIN_PASSWORD`。 |
 | `SESSION_SECRET` | 空 | 给会话 token 签名的 HMAC 密钥。**必须设**（`openssl rand -hex 32`）。 |
@@ -544,6 +555,7 @@ HTTPS_PROXY=http://your-proxy:port      # SOCKS 用 ALL_PROXY=socks5://...
 | `DEVICE_DB_PATH` | `~/.cc-remote/relay-devices.sqlite3` | 持久设备注册、显示名、最近在线时间和凭据哈希；不保存会话或 Artifact。 |
 | `DEVICE_PAIRING_TTL_SECONDS` | `600` | 一次性配对码有效秒数，允许 60–3600。 |
 | `PUBLIC_ORIGIN` | 空 | 浏览器允许连接 WS 的精确来源，如 `https://remote.example.com`；**必须设**，非 loopback 必须 HTTPS（除非开了 `ALLOW_INSECURE_HTTP`）。 |
+| `ALLOW_PRIVATE_ORIGINS` | `0` | 设为 `1` 后，在保留 `PUBLIC_ORIGIN` 的同时，允许浏览器通过 `RELAY_PORT` 上的私网/loopback 字面 IP 直连：`127/8`、`10/8`、`172.16/12`、`192.168/16`、Tailscale `100.64/10`、IPv6 loopback/ULA。Origin 的协议/主机/端口还必须与实际请求目标完全一致；主机名、公网 IP 和其他端口仍拒绝。内网 HTTP 不加密，且通常不能安装 PWA。 |
 | `ALLOW_INSECURE_HTTP` | `0` | 逃生开关：设为 `1` 允许 `PUBLIC_ORIGIN` / `RELAY_URL` 在非 loopback 时仍用明文 `http://`/`ws://`（例如直接暴露一个没有 TLS 终端的公网 IP）。默认关闭；开启后登录口令、会话 cookie 和全部流量都走明文，链路上任何人都能窃取或劫持会话，务必优先使用 TLS。 |
 | `WRAPPER_TOKEN` | 占位值 | 单机器/兼容模式下的 wrapper Bearer token；未设置 `WRAPPER_TOKENS_JSON` 时必须配置。 |
 | `WRAPPER_TOKENS_JSON` | 空 | 可选机器绑定 token：`{"mac":"…","nono":"…"}`；设置后替代 relay 的通配 `WRAPPER_TOKEN`。 |
@@ -599,7 +611,7 @@ HTTPS_PROXY=http://your-proxy:port      # SOCKS 用 ALL_PROXY=socks5://...
 
 - Code 会话仍是远程开发控制面：Claude 默认使用 `permissionMode: bypassPermissions`；Codex 默认审批策略是 `never` 并继承本机 Codex sandbox 配置，也可切到 `on-request` / `untrusted`。**能登录且能进入 Code 的人，仍应等同于拿到了这台机器的远程 agent/shell 权限。** Work 会话使用独立私有根目录且不开放外部目录，但这只是缩小默认能力面，不替代操作系统级的独立用户、容器或虚拟机隔离。
 - `LOGIN_PASSWORD` / `LOGIN_USERS_JSON`、`WRAPPER_TOKEN` / `WRAPPER_TOKENS_JSON` 和 `SESSION_SECRET` 是认证边界：用强随机值、别提交 git、别贴到聊天里、定期轮换。仓库 `.env` 只适合本机开发；生产 wrapper 必须使用上述 root-only `/etc/cc-remote/wrapper.env`。systemd 模板会禁止服务及模型子进程读取这个源文件和遗留仓库 `.env`；Linux wrapper 还会关闭 dumpability，避免子进程从 `/proc/<pid>/environ` 或进程内存取回已经捕获的 token。
-- 公网必须上 TLS（`wss://`，本仓库用 Caddy 自动签证书）。只有明确需要临时使用公网 IPv4 + 明文 HTTP/WS 时才设 `ALLOW_INSECURE_HTTP=1`；开启后登录口令、cookie、wrapper token 和全部会话流量都不加密，应尽快切回 TLS。
+- 公网必须上 TLS（`wss://`，本仓库用 Caddy 自动签证书）。只有明确需要临时使用公网 IPv4 + 明文 HTTP/WS 时才设 `ALLOW_INSECURE_HTTP=1`；开启后登录口令、cookie、wrapper token 和全部会话流量都不加密，应尽快切回 TLS。`ALLOW_PRIVATE_ORIGINS=1` 只为同端口私网字面 IP 增加与实际请求目标一致的直连入口，不会放宽公网域名校验；Cookie 的 `Secure` 属性按受信请求传输判断，不读取调用者提供的 Origin。但使用内网 HTTP 时，登录口令、cookie 和会话内容在该网络中仍是明文。
 - 建议：给中继加 IP 白名单 / 只在需要时开、给登录加失败限速（已内置每 IP 每分钟 5 次）。
 
 ## 模型后端（可选）

--- a/README_en.md
+++ b/README_en.md
@@ -362,6 +362,19 @@ Caddy/systemd, and performs immutable staging, atomic `current` activation, and
 rollback under `/opt/cc-remote/releases/`. An existing
 `/opt/cc-remote/.env` is preserved.
 
+To add direct LAN/Tailscale IPv4 access to the same Relay, opt in on the first
+install:
+
+```bash
+./install.sh relay --domain remote.example.com --allow-private-origins
+```
+
+This binds the Relay to `0.0.0.0:8765`; Caddy still serves the public domain
+over HTTPS. Port 8765 is then present on every IPv4 interface, so use the host
+firewall to admit only trusted LAN/Tailscale peers. Existing installs preserve
+`.env`; enable this mode by setting both `RELAY_HOST=0.0.0.0` and
+`ALLOW_PRIVATE_ORIGINS=1` there before upgrading with the same option.
+
 Open `https://remote.example.com/`, sign in, choose **Allow adding devices** in
 Device Center, and copy the one-time pair code.
 
@@ -600,7 +613,7 @@ HTTPS_PROXY=http://your-proxy:port      # for SOCKS use ALL_PROXY=socks5://...
 
 | Var | Default | Notes |
 |---|---|---|
-| `RELAY_HOST` / `RELAY_PORT` | `127.0.0.1` / `8765` | Listen address (behind Caddy in prod — keep 127.0.0.1). |
+| `RELAY_HOST` / `RELAY_PORT` | `127.0.0.1` / `8765` | Listen address (keep `127.0.0.1` for Caddy-only public access; use `0.0.0.0` together with `ALLOW_PRIVATE_ORIGINS=1` for simultaneous LAN/Tailscale IPv4 access, and restrict it with a firewall). |
 | `LOGIN_PASSWORD` | empty | Single-user web login password. **Required** unless `LOGIN_USERS_JSON` is set. |
 | `LOGIN_USERS_JSON` | empty | Optional multi-user policy: `{"alice":{"password":"…","machines":["mac","nono"]}}`; replaces `LOGIN_PASSWORD`. |
 | `SESSION_SECRET` | empty | HMAC secret to sign session tokens. **Required** (`openssl rand -hex 32`). |
@@ -612,6 +625,7 @@ HTTPS_PROXY=http://your-proxy:port      # for SOCKS use ALL_PROXY=socks5://...
 | `DEVICE_DB_PATH` | `~/.cc-remote/relay-devices.sqlite3` | Durable device names, last-seen metadata, and credential hashes; never sessions or artifacts. |
 | `DEVICE_PAIRING_TTL_SECONDS` | `600` | Lifetime of a single-use pairing code in seconds; allowed range 60–3600. |
 | `PUBLIC_ORIGIN` | empty | Exact browser origin allowed to connect, e.g. `https://remote.example.com`; **required**, and non-loopback origins must use HTTPS unless `ALLOW_INSECURE_HTTP` is enabled. |
+| `ALLOW_PRIVATE_ORIGINS` | `0` | Set to `1` to retain `PUBLIC_ORIGIN` while also accepting literal private/loopback IP origins on `RELAY_PORT`: `127/8`, `10/8`, `172.16/12`, `192.168/16`, Tailscale `100.64/10`, IPv6 loopback, and ULA. The Origin scheme/host/port must also exactly match the effective request target; hostnames, public IPs, and other ports remain rejected. Private HTTP is unencrypted and normally cannot install a PWA. |
 | `ALLOW_INSECURE_HTTP` | `0` | Escape hatch for a bare public IPv4 address: allows plain `http://`/`ws://` outside loopback. Off by default; login credentials, cookies, wrapper tokens, and all session traffic are unencrypted while enabled. Prefer TLS whenever possible. |
 | `WRAPPER_TOKEN` | placeholder | Wrapper Bearer token for single-machine/compatibility mode; required unless `WRAPPER_TOKENS_JSON` is set. |
 | `WRAPPER_TOKENS_JSON` | empty | Optional machine-bound tokens: `{"mac":"…","nono":"…"}`; replaces the relay's wildcard `WRAPPER_TOKEN`. |
@@ -667,7 +681,7 @@ Each message accepts at most 8 attachments, at most 6 MiB each and 8 MiB decoded
 
 - Code sessions remain a remote development control plane: Claude defaults to `permissionMode: bypassPermissions`, and Codex defaults to approval policy `never` while inheriting the machine's Codex sandbox configuration; both can expose approval controls in the web client. **Treat anyone who can log in and enter Code as holding remote agent/shell authority on the wrapper machine.** Work uses a separate private root and does not expose external directories, but this only narrows the default capability surface; it is not a substitute for OS-user, container, or VM isolation.
 - `LOGIN_PASSWORD` / `LOGIN_USERS_JSON`, `WRAPPER_TOKEN` / `WRAPPER_TOKENS_JSON`, and `SESSION_SECRET` form the authentication boundary: use strong random values, never commit or paste them into chats, and rotate them. A repository `.env` is for local development only; production wrappers must use the root-only `/etc/cc-remote/wrapper.env` above. The systemd template prevents the service and model descendants from reading that source file or a legacy repository `.env`; on Linux the wrapper also disables dumpability so children cannot recover captured credentials through `/proc/<pid>/environ` or process memory.
-- Always use TLS (`wss://`) in production. Only set `ALLOW_INSECURE_HTTP=1` for a temporary bare-public-IPv4 deployment; login credentials, cookies, wrapper tokens, and all session traffic are unencrypted while it is enabled, so switch back to TLS as soon as possible.
+- Always use TLS (`wss://`) in production. Only set `ALLOW_INSECURE_HTTP=1` for a temporary bare-public-IPv4 deployment; login credentials, cookies, wrapper tokens, and all session traffic are unencrypted while it is enabled, so switch back to TLS as soon as possible. `ALLOW_PRIVATE_ORIGINS=1` adds only same-port literal private-IP entry points that match the effective request target and does not relax the public-domain check. Cookie `Secure` follows the trusted request transport, not the caller-provided Origin, but login credentials, cookies, and session traffic are still plaintext when a private HTTP entry point is used.
 - Recommended: restrict the relay by IP / only run it when needed; login is rate-limited (5/min per IP) out of the box.
 
 ## Model backend (optional)

--- a/cc_remote/config.py
+++ b/cc_remote/config.py
@@ -140,6 +140,12 @@ class RelayConfig:
     # Exact browser Origin accepted for cookie-authenticated WebSockets, for
     # example https://remote.example.com (no path or trailing slash).
     public_origin: str = field(default_factory=lambda: _env("PUBLIC_ORIGIN", ""))
+    # Optional same-port browser access through literal private/loopback IPs.
+    # PUBLIC_ORIGIN remains the canonical external origin; this narrowly adds
+    # direct LAN/Tailscale entry points without trusting arbitrary hostnames.
+    allow_private_origins: bool = field(
+        default_factory=lambda: _bool("ALLOW_PRIVATE_ORIGINS")
+    )
     # Opt-in escape hatch: allow a non-loopback PUBLIC_ORIGIN/RELAY_URL to stay
     # on plain http(s)/ws(s) instead of requiring TLS. Off by default; turning
     # it on trades transport confidentiality (password, cookie, tokens, and all

--- a/cc_remote/relay/__main__.py
+++ b/cc_remote/relay/__main__.py
@@ -25,6 +25,8 @@ def main() -> None:
         log_level="info",
         log_config=uvicorn_log_config(),
         access_log=False,
+        proxy_headers=True,
+        forwarded_allow_ips="127.0.0.1,::1",
         ws_max_size=cfg.ws_max_size_bytes,
         ws_max_queue=2,
     )

--- a/cc_remote/relay/server.py
+++ b/cc_remote/relay/server.py
@@ -4,7 +4,8 @@ origin.
 
 Auth: wrapper authenticates with a Bearer WRAPPER_TOKEN header; web clients
 authenticate with a Secure HttpOnly session cookie obtained from /api/login.
-Cookie-authenticated WebSockets must also match PUBLIC_ORIGIN when configured.
+Cookie-authenticated WebSockets must also match PUBLIC_ORIGIN, or an explicitly
+enabled same-port private-IP origin.
 
 The relay never imports claude_agent_sdk and never touches the model API.
 """
@@ -65,6 +66,18 @@ SESSION_REVOKED_CLOSE_REASON = "session revoked"
 _PUSH_BODY_MAX_BYTES = 16 * 1024
 _DEVICE_BODY_MAX_BYTES = 8 * 1024
 _PUSH_KEY_RE = re.compile(r"[A-Za-z0-9_-]{16,1024}")
+_PRIVATE_ORIGIN_NETWORKS = tuple(
+    ipaddress.ip_network(network)
+    for network in (
+        "127.0.0.0/8",
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "100.64.0.0/10",
+        "::1/128",
+        "fc00::/7",
+    )
+)
 
 
 class LoginRateLimiter:
@@ -207,26 +220,114 @@ class _BodyTooLarge(ValueError):
     pass
 
 
-def _cookie_secure(cfg: RelayConfig) -> bool:
-    """Allow an insecure cookie for the loopback quick-start, or when the
-    operator has explicitly opted into ALLOW_INSECURE_HTTP for a plain-http
-    public origin."""
-    origin = urlsplit(cfg.public_origin.strip().rstrip("/"))
-    if origin.scheme != "http":
-        return True
-    if origin.hostname in {"127.0.0.1", "::1", "localhost"}:
+def _private_origin_allowed(origin: str, cfg: RelayConfig) -> bool:
+    """Allow only a literal private IP on the relay's direct listening port."""
+    if not cfg.allow_private_origins:
         return False
-    return not cfg.allow_insecure_http
+    try:
+        parsed = urlsplit(origin)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return False
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or hostname is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path
+        or parsed.query
+        or parsed.fragment
+    ):
+        return False
+    effective_port = port or (443 if parsed.scheme == "https" else 80)
+    if effective_port != cfg.port:
+        return False
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        return False
+    return any(address in network for network in _PRIVATE_ORIGIN_NETWORKS)
+
+
+def _origin_allowed(origin: str, cfg: RelayConfig) -> bool:
+    candidate = origin.strip()
+    return candidate == cfg.public_origin or _private_origin_allowed(candidate, cfg)
+
+
+def _canonical_origin_host(hostname: str) -> str | None:
+    try:
+        return str(ipaddress.ip_address(hostname))
+    except ValueError:
+        try:
+            return hostname.encode("idna").decode("ascii").lower()
+        except UnicodeError:
+            return None
+
+
+def _origin_parts(origin: str) -> tuple[str, str, int] | None:
+    try:
+        parsed = urlsplit(origin)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return None
+    if parsed.scheme not in {"http", "https"} or hostname is None:
+        return None
+    host = _canonical_origin_host(hostname)
+    if host is None:
+        return None
+    return (
+        parsed.scheme,
+        host,
+        port or (443 if parsed.scheme == "https" else 80),
+    )
+
+
+def _request_target_parts(
+    req: Request | WebSocket,
+) -> tuple[str, str, int] | None:
+    scheme = req.url.scheme.lower()
+    if scheme == "ws":
+        scheme = "http"
+    elif scheme == "wss":
+        scheme = "https"
+    if scheme not in {"http", "https"} or req.url.hostname is None:
+        return None
+    host = _canonical_origin_host(req.url.hostname)
+    if host is None:
+        return None
+    return (
+        scheme,
+        host,
+        req.url.port or (443 if scheme == "https" else 80),
+    )
+
+
+def _request_cookie_secure(req: Request) -> bool:
+    """Select Secure from the trusted effective request transport."""
+    return req.url.scheme.lower() == "https"
 
 
 def _rate_limited(ip: str) -> bool:
     return _login_limiter.limited(ip)
 
 
-def _request_origin_allowed(req: Request, cfg: RelayConfig) -> bool:
-    """Reject browser cross-origin POSTs while retaining non-browser CLI use."""
+def _request_origin_allowed(
+    req: Request | WebSocket,
+    cfg: RelayConfig,
+    *,
+    allow_missing: bool = True,
+) -> bool:
+    """Bind an accepted browser Origin to the effective request target."""
     origin = req.headers.get("origin", "").strip()
-    return not origin or origin == cfg.public_origin
+    if not origin:
+        return allow_missing
+    return (
+        _origin_allowed(origin, cfg)
+        and _origin_parts(origin) == _request_target_parts(req)
+    )
 
 
 def _request_ip(req: Request) -> str:
@@ -621,7 +722,7 @@ def create_app(
             token,
             max_age=cfg.session_ttl_seconds,
             path="/",
-            secure=_cookie_secure(cfg),
+            secure=_request_cookie_secure(req),
             httponly=True,
             samesite="strict",
         )
@@ -663,7 +764,7 @@ def create_app(
         response.delete_cookie(
             SESSION_COOKIE_NAME,
             path="/",
-            secure=_cookie_secure(cfg),
+            secure=_request_cookie_secure(req),
             httponly=True,
             samesite="strict",
         )
@@ -872,8 +973,9 @@ def create_app(
         if role is None:
             token = websocket.cookies.get(SESSION_COOKIE_NAME, "")
             origin = websocket.headers.get("origin", "")
-            expected_origin = cfg.public_origin.strip().rstrip("/")
-            origin_ok = not expected_origin or origin == expected_origin
+            origin_ok = _request_origin_allowed(
+                websocket, cfg, allow_missing=False,
+            )
             claims = session_token_claims(token, cfg.session_secret)
             if (
                 claims is not None
@@ -883,7 +985,7 @@ def create_app(
             ):
                 role = "client"
             elif token and not origin_ok:
-                log.warning("ws origin rejected", origin=origin or "-")
+                log.warning("ws origin rejected", origin=(origin or "-")[:512])
         if role is None:
             await websocket.close(code=1008, reason="unauthorized")
             return

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,7 +16,10 @@ machine). The **full step-by-step guide is in the main [README](../README.md#生
   protocol, full Git SHA, OS, architecture, and Python runtime contract.
 - `install-relay.sh` — first-install/upgrade entry for a published Relay
   bundle. It creates secrets only when `/opt/cc-remote/.env` does not exist,
-  then delegates to the existing transactional VPS installer.
+  then delegates to the existing transactional VPS installer. The explicit
+  `--allow-private-origins` first-install option binds IPv4 `0.0.0.0:8765`
+  for simultaneous LAN/Tailscale access and requires firewall restriction;
+  the default remains loopback-only behind Caddy.
 - `install-wrapper.sh` — first-install/upgrade entry for published macOS and
   Linux Wrapper bundles. It builds the immutable release before pairing and
   activation, stores device authority outside the release, atomically switches

--- a/deploy/env.relay.example
+++ b/deploy/env.relay.example
@@ -4,6 +4,10 @@
 # and SESSION_SECRET / WRAPPER_TOKEN shorter than 32 characters.
 RELAY_HOST=127.0.0.1
 RELAY_PORT=8765
+# To add direct LAN/Tailscale IPv4 access alongside the public Caddy origin,
+# set this to 1 and RELAY_HOST to 0.0.0.0. Port 8765 then listens on every IPv4
+# interface; restrict it to trusted private peers with the host firewall.
+ALLOW_PRIVATE_ORIGINS=0
 # Exact browser origin allowed to open a cookie-authenticated WebSocket.
 PUBLIC_ORIGIN=https://cc-remote.example.com
 # Leave at 0 for the normal domain + TLS path. Set to 1 only for the supported

--- a/deploy/install-relay.sh
+++ b/deploy/install-relay.sh
@@ -8,7 +8,7 @@ die() {
 }
 
 usage() {
-  echo "usage: install-relay.sh BUNDLE --domain remote.example.com" >&2
+  echo "usage: install-relay.sh BUNDLE --domain remote.example.com [--allow-private-origins]" >&2
   exit 2
 }
 
@@ -16,12 +16,17 @@ bundle="${1:-}"
 [ -n "$bundle" ] || usage
 shift
 domain=""
+allow_private_origins=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --domain)
       [ "$#" -ge 2 ] || usage
       domain="$2"
       shift 2
+      ;;
+    --allow-private-origins)
+      allow_private_origins=1
+      shift
       ;;
     *) die "unknown relay installer argument: $1" ;;
   esac
@@ -113,11 +118,16 @@ if [ ! -e "$env_file" ]; then
   install -d -o root -g root -m 0755 "$appdir"
   umask 077
   new_env="$(mktemp "$appdir/.env.new.XXXXXX")"
+  relay_host=127.0.0.1
+  if [ "$allow_private_origins" -eq 1 ]; then
+    relay_host=0.0.0.0
+  fi
   {
     printf '%s\n' \
-      'RELAY_HOST=127.0.0.1' \
+      "RELAY_HOST=${relay_host}" \
       'RELAY_PORT=8765' \
       "PUBLIC_ORIGIN=https://${domain}" \
+      "ALLOW_PRIVATE_ORIGINS=${allow_private_origins}" \
       "LOGIN_PASSWORD='${password}'" \
       "SESSION_SECRET=${session_secret}" \
       "WRAPPER_TOKEN=${wrapper_token}" \
@@ -129,11 +139,43 @@ if [ ! -e "$env_file" ]; then
   install -o root -g root -m 0600 "$new_env" "$env_file"
   rm -f -- "$new_env"
   new_env=""
-  unset password password_repeat session_secret wrapper_token
+  unset password password_repeat session_secret wrapper_token relay_host
   echo "==> created root-only relay configuration"
+  if [ "$allow_private_origins" -eq 1 ]; then
+    echo "WARNING: relay port 8765 will listen on every IPv4 interface."
+    echo "Restrict direct access to trusted LAN/Tailscale peers with a firewall."
+  fi
 else
   if [ ! -f "$env_file" ] || [ -L "$env_file" ]; then
     die "$env_file must be a regular file"
+  fi
+  if [ "$allow_private_origins" -eq 1 ]; then
+    private_setting="$(
+      awk -F= '
+        /^[[:space:]]*ALLOW_PRIVATE_ORIGINS[[:space:]]*=/ {
+          value = $0
+          sub(/^[^=]*=/, "", value)
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+          print tolower(value)
+        }
+      ' "$env_file" | tail -n 1
+    )"
+    relay_setting="$(
+      awk -F= '
+        /^[[:space:]]*RELAY_HOST[[:space:]]*=/ {
+          value = $0
+          sub(/^[^=]*=/, "", value)
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+          print value
+        }
+      ' "$env_file" | tail -n 1
+    )"
+    case "$private_setting" in
+      1|true|yes|on) ;;
+      *) die "--allow-private-origins requires ALLOW_PRIVATE_ORIGINS=1 in the existing $env_file" ;;
+    esac
+    [ "$relay_setting" = "0.0.0.0" ] || \
+      die "--allow-private-origins requires RELAY_HOST=0.0.0.0 in the existing $env_file"
   fi
   echo "==> preserving existing relay configuration"
 fi

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -17,7 +17,7 @@ die() {
 usage() {
   cat >&2 <<'EOF'
 Usage:
-  install.sh relay --domain remote.example.com
+  install.sh relay --domain remote.example.com [--allow-private-origins]
   install.sh wrapper --relay https://remote.example.com --pair PAIR-CODE
 
 The role is explicit. The script detects only the operating system and CPU.

--- a/deploy/setup-vps.sh
+++ b/deploy/setup-vps.sh
@@ -39,6 +39,7 @@ UNIT_HAD_FILE=0
 RELAY_SERVICE_TOUCHED=0
 ROLLBACK_DONE=0
 INSECURE_HTTP=0
+PRIVATE_DIRECT=0
 PUBLIC_SCHEME=https
 CADDY_TEMPLATE=""
 
@@ -146,6 +147,16 @@ PY
     die "ALLOW_INSECURE_HTTP must be one of 1/true/yes/on or 0/false/no/off"
     ;;
 esac
+ALLOW_PRIVATE_VALUE="$(
+  read_env_value ALLOW_PRIVATE_ORIGINS 2>/dev/null || printf '0'
+)"
+case "${ALLOW_PRIVATE_VALUE,,}" in
+  1|true|yes|on) PRIVATE_DIRECT=1 ;;
+  0|false|no|off|"") ;;
+  *)
+    die "ALLOW_PRIVATE_ORIGINS must be one of 1/true/yes/on or 0/false/no/off"
+    ;;
+esac
 [ -d "$SOURCE_DIR/web/dist" ] || die "$SOURCE_DIR/web/dist missing (run 'npm --prefix web run build' before uploading)"
 [ -s "$SOURCE_DIR/web/dist/index.html" ] || die "$SOURCE_DIR/web/dist/index.html missing or empty"
 [ -s "$SOURCE_DIR/web/dist/cc-remote-build.json" ] || die "$SOURCE_DIR/web/dist/cc-remote-build.json missing"
@@ -192,8 +203,15 @@ CONFIGURED_RELAY_PORT="$(read_env_value RELAY_PORT)" || \
   die "RELAY_PORT is missing from $ENV_FILE"
 CONFIGURED_STATIC_DIR="$(read_env_value WEB_STATIC_DIR)" || \
   die "WEB_STATIC_DIR is missing from $ENV_FILE"
-[[ "$CONFIGURED_RELAY_HOST" == "127.0.0.1" ]] || \
-  die "RELAY_HOST must be 127.0.0.1 for the bundled Caddy/systemd setup"
+if [[ "$PRIVATE_DIRECT" -eq 1 ]]; then
+  [[ "$CONFIGURED_RELAY_HOST" == "0.0.0.0" ]] || \
+    die "RELAY_HOST must be 0.0.0.0 when ALLOW_PRIVATE_ORIGINS is enabled"
+  echo "WARNING: relay port 8765 is exposed on every IPv4 interface."
+  echo "Restrict direct access to trusted LAN/Tailscale peers with a firewall."
+else
+  [[ "$CONFIGURED_RELAY_HOST" == "127.0.0.1" ]] || \
+    die "RELAY_HOST must be 127.0.0.1 unless ALLOW_PRIVATE_ORIGINS is enabled"
+fi
 [[ "$CONFIGURED_RELAY_PORT" == "8765" ]] || \
   die "RELAY_PORT must be 8765 for the bundled Caddy/readiness setup"
 [[ "$CONFIGURED_STATIC_DIR" == "$CURRENT_LINK/web/dist" ]] || \

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -72,6 +72,11 @@ def _cookie_header(response) -> str:
     return f"{SESSION_COOKIE_NAME}={token}"
 
 
+def _ws_url(origin: str, path: str = "/ws") -> str:
+    scheme = "wss" if origin.startswith("https://") else "ws"
+    return f"{scheme}://{origin.split('://', 1)[1]}{path}"
+
+
 async def _asgi_login(app, body: bytes = b'{}') -> tuple[int, bytes, list[tuple[bytes, bytes]]]:
     """Issue one login request without a socket (supports concurrency tests)."""
     sent = []
@@ -145,7 +150,9 @@ def test_multi_user_login_filters_machine_discovery_and_websocket_access():
             "ok": True, "machines": ["mac"],
         }
         headers = {"cookie": _cookie_header(login), "origin": cfg.public_origin}
-        with client.websocket_connect("/ws?machine=nono", headers=headers) as websocket:
+        with client.websocket_connect(
+            _ws_url(cfg.public_origin, "/ws?machine=nono"), headers=headers,
+        ) as websocket:
             closed = websocket.receive()
     assert closed == {
         "type": "websocket.close",
@@ -162,7 +169,8 @@ def test_wildcard_user_cannot_accumulate_empty_machine_buckets():
         headers = {"cookie": _cookie_header(login), "origin": cfg.public_origin}
         for index in range(4):
             with client.websocket_connect(
-                f"/ws?machine=unused-{index}", headers=headers
+                _ws_url(cfg.public_origin, f"/ws?machine=unused-{index}"),
+                headers=headers,
             ):
                 pass
 
@@ -245,6 +253,144 @@ def test_login_and_logout_reject_cross_origin_browser_posts():
             "/api/logout", headers={"Origin": "https://evil.example"})
         assert rejected_logout.status_code == 403
         assert client.get("/api/session").status_code == 200
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://127.1.2.3:8765",
+        "http://10.23.45.67:8765",
+        "http://172.16.0.1:8765",
+        "http://172.31.255.254:8765",
+        "http://192.168.88.9:8765",
+        "http://100.64.0.1:8765",
+        "http://100.127.255.254:8765",
+        "http://[::1]:8765",
+        "http://[fd12:3456::1]:8765",
+    ],
+)
+def test_private_literal_origins_on_relay_port_are_allowed(origin: str):
+    cfg = _cfg(allow_private_origins=True, port=8765)
+    assert server._origin_allowed(origin, cfg) is True
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://127.0.0.1:8764",
+        "http://10.0.0.1",
+        "http://172.15.255.255:8765",
+        "http://172.32.0.0:8765",
+        "http://192.0.2.1:8765",
+        "http://100.63.255.255:8765",
+        "http://100.128.0.0:8765",
+        "http://169.254.1.1:8765",
+        "http://8.8.8.8:8765",
+        "http://localhost:8765",
+        "http://router.lan:8765",
+        "http://user@192.168.1.2:8765",
+        "http://192.168.1.2:8765/",
+        "ws://192.168.1.2:8765",
+    ],
+)
+def test_private_origin_allowlist_rejects_broad_or_ambiguous_hosts(
+    origin: str,
+):
+    cfg = _cfg(allow_private_origins=True, port=8765)
+    assert server._origin_allowed(origin, cfg) is False
+
+
+def test_private_origins_remain_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("ALLOW_PRIVATE_ORIGINS", raising=False)
+    cfg = _cfg(port=8765)
+    assert cfg.allow_private_origins is False
+    assert server._origin_allowed("http://192.168.1.2:8765", cfg) is False
+
+
+def test_private_http_login_sets_host_cookie_and_authenticates_websocket():
+    origin = "http://192.168.1.2:8765"
+    cfg = _cfg(
+        allow_private_origins=True,
+        port=8765,
+    )
+    with TestClient(create_app(cfg), base_url=origin) as client:
+        login = client.post(
+            "/api/login",
+            json={"password": cfg.login_password},
+            headers={"origin": origin},
+        )
+        assert login.status_code == 200
+        cookie = login.headers["set-cookie"].lower()
+        assert "secure" not in cookie
+        assert "httponly" in cookie
+        assert "samesite=strict" in cookie
+        assert client.get("/api/session").status_code == 200
+
+        headers = {"cookie": _cookie_header(login), "origin": origin}
+        with client.websocket_connect(
+            _ws_url(origin), headers=headers,
+        ) as websocket:
+            websocket.send_text(serialize(Hello(
+                role="client",
+                client_id="private-origin-auth-test",
+            )))
+            assert json.loads(websocket.receive_text())["code"] == "wrapper_offline"
+            websocket.close()
+
+
+@pytest.mark.parametrize(
+    ("target", "origin"),
+    [
+        ("http://192.168.1.2:8765", "http://10.0.0.2:8765"),
+        ("http://remote.example", "https://remote.example"),
+    ],
+)
+def test_browser_origin_must_match_effective_request_target(target, origin):
+    cfg = _cfg(allow_private_origins=True, port=8765)
+    with TestClient(create_app(cfg), base_url=target) as client:
+        rejected = client.post(
+            "/api/login",
+            json={"password": cfg.login_password},
+            headers={"origin": origin},
+        )
+        assert rejected.status_code == 403
+
+
+def test_private_websocket_origin_must_match_effective_request_target():
+    target = "http://192.168.1.2:8765"
+    other_private_origin = "http://10.0.0.2:8765"
+    cfg = _cfg(allow_private_origins=True, port=8765)
+    with TestClient(create_app(cfg), base_url=target) as client:
+        login = client.post(
+            "/api/login",
+            json={"password": cfg.login_password},
+            headers={"origin": target},
+        )
+        assert login.status_code == 200
+        headers = {
+            "cookie": _cookie_header(login),
+            "origin": other_private_origin,
+        }
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect(_ws_url(target), headers=headers):
+                pass
+        assert exc.value.code == 1008
+
+
+def test_private_https_login_keeps_secure_cookie():
+    origin = "https://100.95.58.23:8765"
+    cfg = _cfg(
+        allow_private_origins=True,
+        port=8765,
+    )
+    with TestClient(create_app(cfg), base_url=origin) as client:
+        login = client.post(
+            "/api/login",
+            json={"password": cfg.login_password},
+            headers={"origin": origin},
+        )
+    assert login.status_code == 200
+    assert "secure" in login.headers["set-cookie"].lower()
 
 
 @pytest.mark.parametrize("message", [
@@ -460,8 +606,12 @@ def test_logout_revokes_session_and_closes_all_of_its_websockets():
     with TestClient(create_app(cfg), base_url=cfg.public_origin) as client:
         login = _login(client, cfg)
         headers = {"cookie": _cookie_header(login), "origin": cfg.public_origin}
-        with client.websocket_connect("/ws", headers=headers) as first:
-            with client.websocket_connect("/ws", headers=headers) as second:
+        with client.websocket_connect(
+            _ws_url(cfg.public_origin), headers=headers,
+        ) as first:
+            with client.websocket_connect(
+                _ws_url(cfg.public_origin), headers=headers,
+            ) as second:
                 response = client.post("/api/logout", headers={"cookie": _cookie_header(login)})
                 first_close = first.receive()
                 second_close = second.receive()
@@ -486,7 +636,9 @@ def test_relay_restart_invalidates_old_registry_session():
     with TestClient(create_app(cfg), base_url=cfg.public_origin) as restarted:
         assert restarted.get("/api/session", headers=headers).status_code == 401
         with pytest.raises(WebSocketDisconnect) as error:
-            with restarted.websocket_connect("/ws", headers=headers):
+            with restarted.websocket_connect(
+                _ws_url(cfg.public_origin), headers=headers,
+            ):
                 pass
     assert error.value.code == 1008
 
@@ -505,7 +657,9 @@ def test_cookie_and_exact_origin_authenticate_browser_websocket():
     with TestClient(create_app(cfg), base_url=cfg.public_origin) as client:
         login = _login(client, cfg)
         headers = {"cookie": _cookie_header(login), "origin": cfg.public_origin}
-        with client.websocket_connect("/ws", headers=headers) as websocket:
+        with client.websocket_connect(
+            _ws_url(cfg.public_origin), headers=headers,
+        ) as websocket:
             websocket.send_text(serialize(Hello(role="client", client_id="auth-test")))
             assert json.loads(websocket.receive_text())["code"] == "wrapper_offline"
             websocket.close()
@@ -526,7 +680,9 @@ def test_cookie_websocket_is_bound_to_signed_expiry(monkeypatch):
     with TestClient(create_app(cfg), base_url=cfg.public_origin) as client:
         login = _login(client, cfg)
         headers = {"cookie": _cookie_header(login), "origin": cfg.public_origin}
-        with client.websocket_connect("/ws", headers=headers) as websocket:
+        with client.websocket_connect(
+            _ws_url(cfg.public_origin), headers=headers,
+        ) as websocket:
             closed = websocket.receive()
 
     assert guarded["expires_at"] == login.json()["exp"]
@@ -578,7 +734,9 @@ def test_cookie_websocket_rejects_missing_or_mismatched_origin(origin: str):
         if origin:
             headers["origin"] = origin
         with pytest.raises(WebSocketDisconnect) as error:
-            with client.websocket_connect("/ws", headers=headers):
+            with client.websocket_connect(
+                _ws_url(cfg.public_origin), headers=headers,
+            ):
                 pass
     assert error.value.code == 1008
 
@@ -589,7 +747,10 @@ def test_query_session_token_is_rejected_even_when_signature_is_valid():
     with TestClient(create_app(cfg), base_url=cfg.public_origin) as client:
         with pytest.raises(WebSocketDisconnect) as error:
             with client.websocket_connect(
-                f"/ws?token={quote(token, safe='')}",
+                _ws_url(
+                    cfg.public_origin,
+                    f"/ws?token={quote(token, safe='')}",
+                ),
                 headers={"origin": cfg.public_origin},
             ):
                 pass
@@ -766,6 +927,8 @@ def test_uvicorn_access_log_is_disabled(monkeypatch):
 
     assert called["args"] == (app,)
     assert called["kwargs"]["access_log"] is False
+    assert called["kwargs"]["proxy_headers"] is True
+    assert called["kwargs"]["forwarded_allow_ips"] == "127.0.0.1,::1"
     configured = called["kwargs"]["log_config"]
     expected = uvicorn_log_config()
     assert configured.keys() == expected.keys()

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -136,7 +136,9 @@ def test_setup_script_is_valid_shell_and_keeps_safe_install_order():
     assert "address.version == 4 and address.is_global" in source
     assert "not address.is_multicast" in source
     assert '"$CONFIGURED_ORIGIN" == "$PUBLIC_SCHEME://$TARGET"' in source
+    assert '[[ "$CONFIGURED_RELAY_HOST" == "0.0.0.0" ]]' in source
     assert '[[ "$CONFIGURED_RELAY_HOST" == "127.0.0.1" ]]' in source
+    assert 'if [[ "$PRIVATE_DIRECT" -eq 1 ]]' in source
     assert '[[ "$CONFIGURED_RELAY_PORT" == "8765" ]]' in source
     assert '[[ "$CONFIGURED_STATIC_DIR" == "$CURRENT_LINK/web/dist" ]]' in source
     assert 'chmod 0600 "$ENV_FILE"' in source
@@ -207,6 +209,7 @@ def test_deploy_examples_configure_insecure_flag_on_both_sides():
     wrapper = (ROOT / "deploy" / "env.wrapper.example").read_text()
     assert "ALLOW_INSECURE_HTTP=0" in relay
     assert "ALLOW_INSECURE_HTTP=0" in wrapper
+    assert "ALLOW_PRIVATE_ORIGINS=0" in relay
 
 
 def test_setup_does_not_make_network_service_owner_of_root_executed_code():

--- a/tests/test_release_distribution.py
+++ b/tests/test_release_distribution.py
@@ -389,6 +389,10 @@ def test_role_installers_keep_credentials_out_of_service_definitions():
     assert 'ubuntu) minimum_major=22' in relay_source
     assert 'debian) minimum_major=12' in relay_source
     assert "setup-vps.sh" in relay_source
+    assert "--allow-private-origins" in relay_source
+    assert '"RELAY_HOST=${relay_host}"' in relay_source
+    assert '"ALLOW_PRIVATE_ORIGINS=${allow_private_origins}"' in relay_source
+    assert "relay_host=0.0.0.0" in relay_source
     assert "--login-password" not in relay_source
     assert "LOGIN_PASSWORD=" in relay_source
 


### PR DESCRIPTION
## Summary

- optionally accept literal loopback and private-IP browser origins on the relay port
- keep the configured public origin as the only accepted public hostname
- select secure-cookie behavior from the validated request origin
- document and test LAN and Tailscale access

## Security model

`ALLOW_PRIVATE_ORIGINS=1` only admits literal loopback or private IP addresses
using the configured relay port. It does not allow arbitrary hostnames, public
IP addresses, alternate ports, or wildcard origins. Wrapper bearer
authentication and machine-scoped authorization remain unchanged.

## Dependencies

- Direct dependency: #8 provides the shared CI-only Playwright retry configuration.
- No other PR dependencies; the relay feature is functionally independent of #8.
- Required merge order: #8 → #10.

## Testing

- full `act pull_request` workflow: Web, Python, and Deploy jobs passed
- origin, login-cookie, WebSocket, and configuration regression coverage
- Ruff, Oxlint, ShellCheck, and `git diff --check`
