### PR TITLE
fix(history): keep cached pages and mobile scroll coherent

### DIFF
--- a/cc_remote/wrapper/history_store.py
+++ b/cc_remote/wrapper/history_store.py
@@ -25,6 +25,7 @@ from cc_remote.attachments import (
     decode_attachment,
     image_dimensions,
 )
+from cc_remote.protocol import ConversationTurn
 
 
 _SCHEMA_VERSION = 10
@@ -153,6 +154,18 @@ class MaterializedHistoryPage:
         if not isinstance(turns, (list, tuple)) or not all(
                 isinstance(turn, dict) for turn in turns):
             raise ValueError("invalid materialized history turns")
+        # The SQLite projection is rebuildable, but can outlive a wire-schema
+        # change.  Validate its cached summary at this single boundary so an
+        # obsolete field is never served to the client; callers invalidate the
+        # whole session and rebuild from the engine source on validation error.
+        normalized_turns: list[dict[str, Any]] = []
+        for turn in turns:
+            # Preserve omitted defaults in old cache rows: they remain omitted
+            # on the wire today, while values that *are* present get Pydantic's
+            # canonical JSON form.  Unknown keys are rejected by the model.
+            normalized = ConversationTurn.model_validate(turn).model_dump(
+                mode="json")
+            normalized_turns.append({key: normalized[key] for key in turn})
         return cls(
             events=tuple(events),
             has_more=bool(payload.get("has_more")),
@@ -160,7 +173,7 @@ class MaterializedHistoryPage:
                        if isinstance(payload.get("oldest_id"), str) else None),
             newest_id=(payload.get("newest_id")
                        if isinstance(payload.get("newest_id"), str) else None),
-            turns=tuple(turns),
+            turns=tuple(normalized_turns),
         )
 
 

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 
@@ -47,6 +48,48 @@ def test_history_index_roundtrip_is_bound_to_exact_source_snapshot(tmp_path):
     assert changed.token != source.token
     assert store.get_page(
         "session-1", "codex", changed, before=None, limit=4) is None
+
+
+def test_history_index_invalidates_obsolete_cached_turn_schema_and_rebuilds(
+    tmp_path,
+):
+    source_path = tmp_path / "rollout.jsonl"
+    source_path.write_text('{"type":"first"}\n')
+    source = HistorySourceFingerprint.capture(source_path)
+    store = HistoryIndexStore(tmp_path / "state")
+    page = MaterializedHistoryPage(
+        events=({"type": "user_msg", "msg_id": "message-1", "prompt": "hi"},),
+        has_more=False,
+        oldest_id="message-1",
+        newest_id="message-1",
+        turns=({"id": "message-1", "prompt": "hi"},),
+    )
+    assert store.put_page(
+        "session-1", "codex", source, before=None, limit=4, page=page)
+
+    # Simulate a retained pre-schema cache row.  ``origin`` is deliberately
+    # forbidden by ConversationTurn and must invalidate, rather than leak to
+    # the browser or make the current process crash while constructing History.
+    with sqlite3.connect(store.path) as connection:
+        row = connection.execute(
+            "SELECT payload_json FROM history_pages WHERE session_id=?",
+            ("session-1",),
+        ).fetchone()
+        payload = json.loads(bytes(row[0]).decode("utf-8"))
+        payload["turns"][0]["origin"] = "legacy-cache"
+        connection.execute(
+            "UPDATE history_pages SET payload_json=? WHERE session_id=?",
+            (json.dumps(payload).encode("utf-8"), "session-1"),
+        )
+
+    assert store.get_page(
+        "session-1", "codex", source, before=None, limit=4) is None
+
+    # The engine-backed caller can now replace the discarded projection.
+    assert store.put_page(
+        "session-1", "codex", source, before=None, limit=4, page=page)
+    assert store.get_page(
+        "session-1", "codex", source, before=None, limit=4) == page
 
 
 def test_turn_detail_survives_append_but_not_destructive_invalidation(tmp_path):

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   testMatch: "history-browser.spec.ts",
   fullyParallel: false,
   workers: 1,
+  retries: process.env.CI ? 2 : 0,
   reporter: "line",
   use: {
     baseURL: "http://127.0.0.1:4174",

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -85,6 +85,13 @@ interface CapturedHistoryBoundary extends HistoryAnchorPoint {
   anchorOffset: number;
 }
 
+interface TouchAppliedBoundary {
+  generation: number;
+  appliedEventTimestamp: number;
+  baselineY: number;
+  movedAfterApply: boolean;
+}
+
 interface RetainedMeasurementBoundary {
   sid: string | null;
   revision: string | null;
@@ -283,7 +290,9 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
   const lastScrollTopRef = useRef(0);
   const renderedScrollScopeRef = useRef<string | null>(null);
   const touchYRef = useRef<number | null>(null);
-  const touchRebaseAppliedRef = useRef(false);
+  const touchEventClockOffsetRef = useRef<number | null>(null);
+  const touchAppliedBoundaryRef = useRef<TouchAppliedBoundary | null>(null);
+  const touchHistoryGenerationRef = useRef<number | null>(null);
   const userScrollIntentRef = useRef(false);
   const userScrollDirectionRef = useRef<UserScrollDirection | null>(null);
   const userScrollIntentTimerRef = useRef<number | null>(null);
@@ -542,6 +551,10 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
       historyAnchorRef.current.current()?.generation ?? null;
     const cancelled = historyAnchorRef.current.cancel(generation);
     if (!cancelled) return false;
+    if (touchHistoryGenerationRef.current === activeGeneration) {
+      touchHistoryGenerationRef.current = null;
+      touchAppliedBoundaryRef.current = null;
+    }
     if (historyReleaseFrameRef.current !== null) {
       window.cancelAnimationFrame(historyReleaseFrameRef.current);
       historyReleaseFrameRef.current = null;
@@ -901,6 +914,9 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
         oldestTurnId: point.oldestTurnId,
         anchorOffset: point.anchorOffset,
       });
+      touchHistoryGenerationRef.current =
+        touchYRef.current !== null ? generation : null;
+      touchAppliedBoundaryRef.current = null;
       setActiveHistoryGeneration(generation);
     }
     clearHistoryRequestTimeout();
@@ -1027,7 +1043,19 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
       return;
     }
     if (historyAnchorRef.current.markRendering(anchor.generation)) {
-      historyAnchorRef.current.markApplied(anchor.generation);
+      if (historyAnchorRef.current.markApplied(anchor.generation)
+          && touchHistoryGenerationRef.current === anchor.generation
+          && touchYRef.current !== null) {
+        const clockOffset = touchEventClockOffsetRef.current;
+        touchAppliedBoundaryRef.current = {
+          generation: anchor.generation,
+          appliedEventTimestamp: clockOffset == null
+            ? Number.POSITIVE_INFINITY
+            : window.performance.now() - clockOffset,
+          baselineY: touchYRef.current,
+          movedAfterApply: false,
+        };
+      }
       scheduleHistoryAnchorRelease(anchor.generation);
     }
   }, [
@@ -1093,7 +1121,8 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
       cancelHistoryAnchor();
       clearHistoryRequestTimeout();
       touchYRef.current = null;
-      touchRebaseAppliedRef.current = false;
+      touchAppliedBoundaryRef.current = null;
+      touchEventClockOffsetRef.current = null;
       userScrollIntentRef.current = false;
       userScrollDirectionRef.current = null;
       if (userScrollIntentTimerRef.current !== null) {
@@ -1221,10 +1250,21 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
       textSelectionRef.current?.scope === scrollScope
       && textSelectionRef.current.dragging;
     const currentHistoryAnchor = historyAnchorRef.current.current();
+    const touchOwnsHistoryAnchor = currentHistoryAnchor != null
+      && touchHistoryGenerationRef.current === currentHistoryAnchor.generation;
     const explicitAppliedMovement = keyedPrependResponseReady
       && currentHistoryAnchor?.phase === "applied"
       && intendedDirection !== null
-      && intendedDirection !== "unknown";
+      && intendedDirection !== "unknown"
+      // Mobile WebKit can deliver the scroll that reached the paging edge
+      // only after the response has already rendered. For a touch-owned page,
+      // only a touchmove observed after that render may replace the original
+      // retained row. clearTouch synchronously captures that explicit move
+      // before clearing this marker.
+      && (!touchOwnsHistoryAnchor
+        || (touchAppliedBoundaryRef.current?.generation
+            === currentHistoryAnchor.generation
+          && touchAppliedBoundaryRef.current.movedAfterApply));
     const userDrivenScroll = movementDirection !== null && (
       textSelectionDragging
       || (userScrollIntentRef.current
@@ -1350,7 +1390,9 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
   const onTouchStart = (event: TouchEvent<HTMLDivElement>) => {
     markUserScrollIntent("unknown");
     historyLoadGateRef.current.beginGesture();
-    touchRebaseAppliedRef.current = false;
+    touchAppliedBoundaryRef.current = null;
+    touchEventClockOffsetRef.current =
+      window.performance.now() - event.timeStamp;
     touchYRef.current = event.touches[0]?.clientY ?? null;
   };
 
@@ -1358,6 +1400,9 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
     const currentY = event.touches[0]?.clientY;
     const previousY = touchYRef.current;
     if (currentY == null || previousY == null) return;
+    // Publish the newest finger position before a paging state update can
+    // synchronously commit and capture the applied boundary.
+    touchYRef.current = currentY;
     // A finger moving down scrolls the viewport toward earlier messages.
     if (currentY > previousY) {
       markUserScrollIntent("history");
@@ -1377,8 +1422,12 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
     } else if (currentY < previousY) {
       markUserScrollIntent("latest");
       const anchor = historyAnchorRef.current.current();
-      if (anchor?.phase === "applied") {
-        touchRebaseAppliedRef.current = true;
+      const appliedBoundary = touchAppliedBoundaryRef.current;
+      if (anchor?.phase === "applied"
+          && appliedBoundary?.generation === anchor.generation
+          && event.timeStamp > appliedBoundary.appliedEventTimestamp
+          && currentY < appliedBoundary.baselineY - 0.5) {
+        appliedBoundary.movedAfterApply = true;
       }
       if (anchor?.direction !== "newer"
           && (anchor?.phase === "pending" || anchor?.phase === "rendering")) {
@@ -1392,7 +1441,6 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
         maybeAutoLoadNewer(true, "touch");
       }
     }
-    touchYRef.current = currentY;
   };
 
   const rebaseAppliedHistoryAnchor = () => {
@@ -1415,10 +1463,11 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
     // Mobile WebKit may defer React's scroll event until touchend. Capture the
     // DOM's already-moved reading row before clearing the touch lock, otherwise
     // the residual prepend correction can restore the pre-gesture row first.
-    if (touchRebaseAppliedRef.current) {
+    if (touchAppliedBoundaryRef.current?.movedAfterApply) {
       rebaseAppliedHistoryAnchor();
     }
-    touchRebaseAppliedRef.current = false;
+    touchAppliedBoundaryRef.current = null;
+    touchEventClockOffsetRef.current = null;
     touchYRef.current = null;
     historyLoadGateRef.current.endGesture();
     // A page can finish while the finger is still down. Re-render after the

--- a/web/tests/history-browser.spec.ts
+++ b/web/tests/history-browser.spec.ts
@@ -405,6 +405,49 @@ async function dispatchTouchPhase(
   }, { type, clientY });
 }
 
+async function stageDelayedTouchMove(
+  page: import("@playwright/test").Page,
+  startY: number,
+  clientY: number,
+): Promise<void> {
+  await page.locator(".thread").evaluate((node, input) => {
+    const target = node as HTMLElement & { __delayedTouchMove?: Event };
+    const startTouch = {
+      identifier: 1,
+      target,
+      clientX: 120,
+      clientY: input.startY,
+    };
+    const start = new Event("touchstart", { bubbles: true, cancelable: true });
+    Object.defineProperties(start, {
+      touches: { value: [startTouch] },
+      targetTouches: { value: [startTouch] },
+      changedTouches: { value: [startTouch] },
+    });
+    target.dispatchEvent(start);
+    const touch = { ...startTouch, clientY: input.clientY };
+    const event = new Event("touchmove", { bubbles: true, cancelable: true });
+    Object.defineProperties(event, {
+      touches: { value: [touch] },
+      targetTouches: { value: [touch] },
+      changedTouches: { value: [touch] },
+    });
+    target.__delayedTouchMove = event;
+  }, { startY, clientY });
+}
+
+async function dispatchDelayedTouchMove(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.locator(".thread").evaluate((node) => {
+    const target = node as HTMLElement & { __delayedTouchMove?: Event };
+    const event = target.__delayedTouchMove;
+    delete target.__delayedTouchMove;
+    if (!event) throw new Error("delayed touchmove was not staged");
+    target.dispatchEvent(event);
+  });
+}
+
 async function requestOlderHistory(
   page: import("@playwright/test").Page,
   projectName: string,
@@ -956,7 +999,7 @@ test("invalid Mermaid falls back to copyable source", async ({ page }) => {
 
 test("offscreen historical Mermaid does not load until its row is mounted", async ({
   page,
-}) => {
+}, testInfo) => {
   await page.goto("/tests/history-browser.html?mermaid-history=1");
   await expect(page.locator('[data-turn-id="after-mermaid-40"]')).toBeVisible();
   await expect(page.locator(".mermaid-block")).toHaveCount(0);
@@ -966,7 +1009,7 @@ test("offscreen historical Mermaid does not load until its row is mounted", asyn
     /\/node_modules\/\.vite\/deps\/mermaid(?:\.js|-)/i.test(url),
   )).toBe(false);
 
-  await page.locator(".thread").evaluate((node) => { node.scrollTop = 0; });
+  await scrollThreadToEdge(page, "start", testInfo.project.name);
   const diagramTurn = page.locator('[data-turn-id="mermaid"]');
   await expect(diagramTurn).toBeVisible();
   await expect(diagramTurn.locator(".mermaid-block")).toHaveCount(2);
@@ -1072,6 +1115,15 @@ test("a page that finishes under an active touch restores its retained boundary"
   await dispatchTouchPhase(page, "touchmove", 220);
   await expect(page.getByTestId("load-count")).toHaveText("1");
   await expect(page.locator('[data-turn-id="n8"]')).toBeAttached();
+  // WebKit may deliver the scroll that reached the paging edge only after the
+  // prepended rows have committed. Reproduce that stale metrics sequence
+  // deterministically: without a post-commit touchmove it must not replace o1.
+  await viewport.evaluate((node) => {
+    node.scrollTop = 400;
+    node.dispatchEvent(new Event("scroll"));
+    node.scrollTop = 0;
+    node.dispatchEvent(new Event("scroll"));
+  });
   await dispatchTouchPhase(page, "touchend", 220);
 
   await expect.poll(async () => (await readingAnchor(page)).id).toBe(before.id);
@@ -1082,6 +1134,36 @@ test("a page that finishes under an active touch restores its retained boundary"
   const settled = await readingAnchor(page);
   expect(settled.id).toBe(before.id);
   expect(Math.abs(settled.offset - before.offset)).toBeLessThan(2);
+});
+
+test("a delayed pre-commit touchmove never rebases a retained page", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "webkit", "iOS WebKit touch settlement");
+  await page.goto("/tests/history-browser.html?delay=5&manual-growth=1");
+  const viewport = page.locator(".thread");
+  await viewport.evaluate((node) => { node.scrollTop = 0; });
+  const before = await readingAnchor(page);
+
+  // Create the reverse move before the page request. WebKit may queue that
+  // native event and deliver it only after React commits the prepend.
+  await stageDelayedTouchMove(page, 160, 80);
+  await dispatchTouchPhase(page, "touchmove", 220);
+  await expect(page.getByTestId("load-count")).toHaveText("1");
+  await expect(page.locator('[data-turn-id="n8"]')).toBeAttached();
+  await dispatchDelayedTouchMove(page);
+  await viewport.evaluate((node) => {
+    node.scrollTop = 400;
+    node.dispatchEvent(new Event("scroll"));
+    node.scrollTop = 0;
+    node.dispatchEvent(new Event("scroll"));
+  });
+  await dispatchTouchPhase(page, "touchend", 80);
+
+  await expect.poll(async () => (await readingAnchor(page)).id).toBe(before.id);
+  await expect.poll(async () =>
+    Math.abs((await readingAnchor(page)).offset - before.offset),
+  ).toBeLessThan(2);
 });
 
 test("a cached-newer page that finishes under touch keeps its retained row", async ({


### PR DESCRIPTION
## Summary

- invalidate materialized turn pages when their source fingerprint changes
- avoid reusing obsolete heavy-detail projections after transcript rollback
- ignore delayed touch-scroll events after the active gesture has ended

## Motivation

History correctness spans both ends of the control link. The wrapper must not
serve detail cached from an obsolete transcript revision, and the browser must
not let a delayed mobile scroll event move a newly restored reading anchor.
These two commits keep the materialized history and its viewport projection
aligned without creating a model turn.

## Dependencies

- Direct dependency: #8 provides the shared CI-only Playwright retry configuration.
- No other PR dependencies; the history fixes are functionally independent of #8.
- Required merge order: #8 → #11.

## Testing

- full `act pull_request` workflow: Web, Python, and Deploy jobs passed
- history-store fingerprint and rollback regression tests
- Chromium and WebKit history-browser scroll tests
- Ruff, Oxlint, ShellCheck, and `git diff --check`
