### PR TITLE
feat(web): suggest Codex Skills from the composer

### DIFF
--- a/cc_remote/wrapper/codex_rpc.py
+++ b/cc_remote/wrapper/codex_rpc.py
@@ -139,3 +139,137 @@ async def codex_rpc(
             ) from exc
     finally:
         await _stop_process(proc)
+
+
+async def codex_rpc_batch(
+    requests: list[tuple[str, Optional[dict[str, Any]]]],
+    cwd: Optional[str] = None,
+) -> list[Any | Exception]:
+    """Issue a read-only request batch through one initialized app-server.
+
+    Each response occupies the same position as its request. An individual
+    JSON-RPC rejection is returned as ``CodexRpcRejected`` so inventory callers
+    can preserve successful components. Process/initialization failures before
+    submission still raise; transport failures after submission become
+    per-request ``CodexRpcOutcomeUnknown`` values.
+    """
+    if not isinstance(requests, list):
+        raise TypeError("codex RPC batch must be a list")
+    for method, params in requests:
+        if not isinstance(method, str) or not method:
+            raise ValueError("codex RPC method must be a non-empty string")
+        if params is not None and not isinstance(params, dict):
+            raise TypeError("codex RPC params must be a dict or None")
+    if not requests:
+        return []
+
+    bin_path = await asyncio.to_thread(_resolve_codex_bin)
+    workdir = os.path.realpath(os.path.expanduser(cwd or "~"))
+    proc = await asyncio.create_subprocess_exec(
+        bin_path,
+        "app-server",
+        "--stdio",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+        cwd=workdir,
+        env=_codex_env(bin_path),
+        limit=_STREAM_LIMIT,
+    )
+
+    async def send(message: dict[str, Any]) -> None:
+        if proc.stdin is None:
+            raise RuntimeError("codex app-server stdin unavailable")
+        proc.stdin.write(
+            (json.dumps(message, separators=(",", ":")) + "\n").encode()
+        )
+        await proc.stdin.drain()
+
+    async def response_for(request_id: int) -> Any:
+        if proc.stdout is None:
+            raise RuntimeError("codex app-server stdout unavailable")
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                raise RuntimeError("codex app-server closed before responding")
+            try:
+                message = json.loads(line)
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(message, dict):
+                continue
+            if message.get("id") != request_id or "method" in message:
+                continue
+            if "error" in message:
+                raise _rpc_error(message["error"])
+            return message.get("result")
+
+    try:
+        await send({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "clientInfo": {"name": "cc-remote", "version": __version__},
+            },
+        })
+        await asyncio.wait_for(response_for(1), timeout=_RPC_TIMEOUT)
+        await send({"jsonrpc": "2.0", "method": "initialized"})
+
+        pending: dict[int, int] = {}
+        values: list[Any | Exception] = [None] * len(requests)
+        completed: set[int] = set()
+        try:
+            for index, (method, params) in enumerate(requests):
+                request_id = index + 2
+                request: dict[str, Any] = {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": method,
+                }
+                if params is not None:
+                    request["params"] = params
+                await send(request)
+                pending[request_id] = index
+
+            async def collect() -> None:
+                if proc.stdout is None:
+                    raise RuntimeError("codex app-server stdout unavailable")
+                while pending:
+                    line = await proc.stdout.readline()
+                    if not line:
+                        raise RuntimeError(
+                            "codex app-server closed before responding"
+                        )
+                    try:
+                        message = json.loads(line)
+                    except (TypeError, ValueError):
+                        continue
+                    if not isinstance(message, dict) or "method" in message:
+                        continue
+                    request_id = message.get("id")
+                    if request_id not in pending:
+                        continue
+                    index = pending.pop(request_id)
+                    values[index] = (
+                        _rpc_error(message["error"])
+                        if "error" in message
+                        else message.get("result")
+                    )
+                    completed.add(index)
+
+            await asyncio.wait_for(collect(), timeout=_RPC_TIMEOUT)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            for index in range(len(values)):
+                if index in completed:
+                    continue
+                unknown = CodexRpcOutcomeUnknown(
+                    "codex app-server closed before the request outcome was known"
+                )
+                unknown.__cause__ = exc
+                values[index] = unknown
+        return values
+    finally:
+        await _stop_process(proc)

--- a/cc_remote/wrapper/engine_capabilities.py
+++ b/cc_remote/wrapper/engine_capabilities.py
@@ -24,7 +24,11 @@ from urllib.parse import urlsplit
 from cc_remote.claude_paths import claude_config_dir
 from cc_remote.wrapper.child_env import sanitized_child_env
 from cc_remote.wrapper.claude_runtime import resolve_claude_cli
-from cc_remote.wrapper.codex_rpc import CodexRpcOutcomeUnknown, codex_rpc
+from cc_remote.wrapper.codex_rpc import (
+    CodexRpcOutcomeUnknown,
+    codex_rpc,
+    codex_rpc_batch,
+)
 
 _COMPONENT_TIMEOUT = 8.0
 _MAX_ITEMS = 500
@@ -114,6 +118,19 @@ async def _codex_component(method: str, params: dict[str, Any], cwd: str):
         codex_rpc(method, params, cwd=cwd), timeout=_COMPONENT_TIMEOUT)
 
 
+async def _codex_components(
+    requests: list[tuple[str, dict[str, Any]]],
+    cwd: str,
+) -> list[Any | Exception]:
+    try:
+        return await asyncio.wait_for(
+            codex_rpc_batch(requests, cwd=cwd),
+            timeout=_COMPONENT_TIMEOUT,
+        )
+    except Exception as exc:
+        return [exc for _request in requests]
+
+
 async def codex_capabilities(cwd: str, space: str) -> tuple[list[dict], list[str], list[str]]:
     requests = {
         "skills": ("skills/list", {"cwds": [cwd], "forceReload": False}),
@@ -122,10 +139,7 @@ async def codex_capabilities(cwd: str, space: str) -> tuple[list[dict], list[str
         "apps": ("app/list", {"limit": _MAX_ITEMS}),
         "mcp": ("mcpServerStatus/list", {}),
     }
-    results = await asyncio.gather(*(
-        _codex_component(method, params, cwd)
-        for method, params in requests.values()
-    ), return_exceptions=True)
+    results = await _codex_components(list(requests.values()), cwd)
     values = dict(zip(requests, results))
     items: list[dict] = []
     errors: list[str] = []

--- a/cc_remote/wrapper/machine.py
+++ b/cc_remote/wrapper/machine.py
@@ -6403,9 +6403,14 @@ class WrapperMachine:
         engine = cmd.engine
         space = getattr(cmd, "space", "code")
         target_cwd = getattr(cmd, "cwd", None)
-        focused = self._focused_ctx()
-        if focused is not None and focused.engine == engine and focused.space == space:
-            target_cwd = focused.cwd
+        if not target_cwd:
+            focused = self._focused_ctx()
+            if (
+                focused is not None
+                and focused.engine == engine
+                and focused.space == space
+            ):
+                target_cwd = focused.cwd
         if not target_cwd:
             target_cwd = self.cfg.cc_cwd
         client_id = getattr(cmd, "client_id", None)
@@ -6431,14 +6436,16 @@ class WrapperMachine:
 
     def _engine_capability_cwd(self, cmd) -> str:
         target_cwd = getattr(cmd, "cwd", None)
+        if target_cwd:
+            return target_cwd
         focused = self._focused_ctx()
         if (
             focused is not None
             and focused.engine == cmd.engine
             and focused.space == getattr(cmd, "space", "code")
         ):
-            target_cwd = focused.cwd
-        return target_cwd or self.cfg.cc_cwd
+            return focused.cwd
+        return self.cfg.cc_cwd
 
     async def _send_capability_mutation_error(self, cmd, exc: Exception):
         if isinstance(exc, ValueError):

--- a/tests/test_codex_rpc.py
+++ b/tests/test_codex_rpc.py
@@ -102,6 +102,62 @@ def test_codex_rpc_initializes_sends_exact_shape_and_reaps(monkeypatch, tmp_path
     asyncio.run(run())
 
 
+def test_codex_rpc_batch_uses_one_process_and_preserves_partial_results(
+    monkeypatch, tmp_path,
+):
+    async def run():
+        process = _FakeProcess([
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+            {"jsonrpc": "2.0", "method": "account/updated", "params": {}},
+            {"jsonrpc": "2.0", "id": 4, "result": {"third": True}},
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "error": {"code": -32602, "message": "unsupported"},
+            },
+            {"jsonrpc": "2.0", "id": 3, "result": {"second": True}},
+        ])
+        spawn_count = 0
+
+        async def create_subprocess_exec(*_args, **_kwargs):
+            nonlocal spawn_count
+            spawn_count += 1
+            return process
+
+        monkeypatch.setattr(
+            codex_rpc_module, "_resolve_codex_bin", lambda: "/bin/codex"
+        )
+        monkeypatch.setattr(codex_rpc_module, "_codex_env", lambda _path: {})
+        monkeypatch.setattr(
+            codex_rpc_module.asyncio,
+            "create_subprocess_exec",
+            create_subprocess_exec,
+        )
+
+        results = await codex_rpc_module.codex_rpc_batch([
+            ("skills/list", {"cwds": [str(tmp_path)]}),
+            ("hooks/list", {"cwds": [str(tmp_path)]}),
+            ("mcpServerStatus/list", None),
+        ], cwd=str(tmp_path))
+
+        assert spawn_count == 1
+        assert isinstance(results[0], codex_rpc_module.CodexRpcRejected)
+        assert results[1:] == [{"second": True}, {"third": True}]
+        messages = [json.loads(line) for line in process.stdin.writes]
+        assert [message.get("method") for message in messages] == [
+            "initialize",
+            "initialized",
+            "skills/list",
+            "hooks/list",
+            "mcpServerStatus/list",
+        ]
+        assert [message.get("id") for message in messages[2:]] == [2, 3, 4]
+        assert process.stdin.closed is True
+        assert process.terminated is True and process.killed is False
+
+    asyncio.run(run())
+
+
 def test_codex_rpc_distinguishes_rejection_from_unknown_post_submit_outcome(
     monkeypatch, tmp_path,
 ):

--- a/tests/test_engine_capabilities.py
+++ b/tests/test_engine_capabilities.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -327,7 +328,8 @@ def test_codex_skill_toggle_uses_native_config_write(monkeypatch, tmp_path):
 
 def test_codex_capabilities_include_native_hooks_as_read_only(monkeypatch, tmp_path):
     async def run():
-        async def component(method, _params, _cwd):
+        async def components(requests, cwd):
+            assert cwd == str(tmp_path)
             responses = {
                 "skills/list": {"data": []},
                 "hooks/list": {"data": [{"hooks": [{
@@ -340,9 +342,11 @@ def test_codex_capabilities_include_native_hooks_as_read_only(monkeypatch, tmp_p
                 "app/list": {"data": []},
                 "mcpServerStatus/list": {"data": []},
             }
-            return responses[method]
+            return [responses[method] for method, _params in requests]
 
-        monkeypatch.setattr(capabilities_module, "_codex_component", component)
+        monkeypatch.setattr(
+            capabilities_module, "_codex_components", components
+        )
         items, errors, _notes = await capabilities_module.codex_capabilities(
             str(tmp_path), "code"
         )
@@ -472,6 +476,11 @@ def test_machine_forwards_configured_cli_to_capability_listing(
     async def run():
         machine, _ = _mk_machine()
         machine.cfg.claude_bin = "/configured/claude"
+        machine._focused_ctx = lambda: SimpleNamespace(
+            engine="claude",
+            space="code",
+            cwd="/different/focused/project",
+        )
         seen = []
 
         async def discover(engine, cwd, space, claude_bin):
@@ -496,6 +505,11 @@ def test_machine_forwards_work_space_to_plugin_backend(monkeypatch, tmp_path):
     async def run():
         machine, transport = _mk_machine()
         machine.cfg.claude_bin = "/configured/claude"
+        machine._focused_ctx = lambda: SimpleNamespace(
+            engine="claude",
+            space="work",
+            cwd="/different/focused/project",
+        )
         seen = []
 
         async def reject(engine, plugin_id, action, cwd, *, space, claude_bin):

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   testMatch: "history-browser.spec.ts",
   fullyParallel: false,
   workers: 1,
+  retries: process.env.CI ? 2 : 0,
   reporter: "line",
   use: {
     baseURL: "http://127.0.0.1:4174",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -148,11 +148,24 @@ import {
   type CompletionBadgeKind,
   type CompletionReceipts,
 } from "./completion-badges";
+import {
+  cacheSkillCatalog,
+  skillCatalogFresh,
+  skillCatalogKey,
+  type SkillCatalogCacheEntry,
+} from "./skill-catalog-cache";
 
 const THEME_KEY = "cc_remote_theme";
 const ENGINE_KEY = "cc_remote_engine";  // which backend the NEXT new session uses
 const SPACE_KEY = "cc_remote_space";
 const MACHINE_KEY = "cc_remote_machine";
+
+interface SkillCatalogRequest {
+  key: string;
+  engine: Engine;
+  space: Space;
+  cwd: string;
+}
 
 // The sidebar is an overlay on mobile (<980px, matches index.css) but a
 // persistent grid column on desktop. So auto-close it after picking a session
@@ -193,6 +206,8 @@ export default function App() {
   const [capabilitiesLoading, setCapabilitiesLoading] = useState(false);
   const [deviceSheetOpen, setDeviceSheetOpen] = useState(false);
   const [capabilitiesBySurface, setCapabilitiesBySurface] = useState<Record<string, EngineCapabilities>>({});
+  const [skillCatalogs, setSkillCatalogs] =
+    useState<Record<string, SkillCatalogCacheEntry>>({});
   const [notificationMode, setNotificationMode] = useState<NotificationMode>(
     () => readNotificationMode(localStorage));
   const [pushBinding, setPushBinding] = useState<PushBindingSnapshot>({
@@ -255,6 +270,18 @@ export default function App() {
   const rightViewRef = useRef(rightView);
   rightViewRef.current = rightView;
   const wsRef = useRef<RelayWs | null>(null);
+  const skillCatalogsRef =
+    useRef<Record<string, SkillCatalogCacheEntry>>({});
+  const skillCatalogReadsRef = useRef<{
+    active: SkillCatalogRequest | null;
+    queued: Map<string, SkillCatalogRequest>;
+  }>({ active: null, queued: new Map() });
+  const focusedSkillScopeRef = useRef<{
+    key: string;
+    engine: Engine;
+    space: Space;
+    cwd: string;
+  } | null>(null);
   const historyRequestsRef = useRef(new HistoryRequestCoordinator());
   const historyDetailRequestsRef = useRef(new HistoryDetailRequestCoordinator(
     (context) => {
@@ -400,6 +427,9 @@ export default function App() {
     authoritativeSurfaceListsRef.current.clear();
     notificationListRequestRef.current = null;
     sessionActivityPendingRef.current.clear();
+    skillCatalogsRef.current = {};
+    skillCatalogReadsRef.current = { active: null, queued: new Map() };
+    setSkillCatalogs({});
     historyRequestsRef.current.clear();
     clearHistoryDetailRequests();
     historyPageScopesRef.current.clear();
@@ -451,11 +481,21 @@ export default function App() {
   const rt = state.runtimes[focusedSid ?? ""] ?? createRuntime();
   const historyView = displayHistoryProjection(
     state.historyRecovery, focusedSid, rt, state.historyBrowse);
-  const focusedEngine = (state.sessions.find(
-    (session) => session.session_id === focusedSid)?.engine ?? engine) as "claude" | "codex";
+  const focusedSession = state.sessions.find(
+    (session) => session.session_id === focusedSid);
+  const focusedEngine = (focusedSession?.engine ?? engine) as "claude" | "codex";
+  const capabilityCwd = focusedSession?.cwd || currentCwd;
   const focusedComposerDraftKey = composerDraftKey(
     machineId, space, focusedEngine, focusedSid ?? "",
   );
+  const focusedSkillCatalogKey = skillCatalogKey(
+    machineId, focusedEngine, space, capabilityCwd);
+  focusedSkillScopeRef.current = {
+    key: focusedSkillCatalogKey,
+    engine: focusedEngine,
+    space,
+    cwd: capabilityCwd,
+  };
   const activeBtwDraftKey = composerDraftKey(
     machineId, space,
     (activeBtw?.engine === "codex" ? "codex" : "claude"),
@@ -498,6 +538,64 @@ export default function App() {
   }, [visibleParentSid, activeBtwSid, rightView, state.artifact]);
 
   const goalUi = focusedSid ? goalUiBySid[focusedSid] : undefined;
+  const storeSkillCatalog = useCallback((
+    key: string,
+    items: EngineCapabilityItem[],
+  ) => {
+    const next = cacheSkillCatalog(
+      skillCatalogsRef.current, key, items);
+    skillCatalogsRef.current = next;
+    setSkillCatalogs(next);
+  }, []);
+  const requestSkillCatalog = useCallback((
+    request: SkillCatalogRequest,
+    force = false,
+  ) => {
+    const cached = skillCatalogsRef.current[request.key];
+    if (!force && skillCatalogFresh(cached)) return false;
+    const reads = skillCatalogReadsRef.current;
+    if (reads.active) {
+      if (reads.active.key !== request.key) {
+        reads.queued.set(request.key, request);
+      }
+      return false;
+    }
+    const ws = wsRef.current;
+    if (!ws) return false;
+    reads.active = request;
+    ws.sendGetEngineCapabilities(
+      request.engine, request.space, request.cwd);
+    return true;
+  }, []);
+  const acceptSkillCatalog = useCallback((msg: EngineCapabilities) => {
+    const reads = skillCatalogReadsRef.current;
+    const active = reads.active;
+    if (active && active.engine === msg.engine && active.space === msg.space) {
+      storeSkillCatalog(
+        active.key, msg.items.filter((item) => item.kind === "skill"));
+      reads.active = null;
+      const next = reads.queued.values().next().value as
+        SkillCatalogRequest | undefined;
+      if (next) {
+        reads.queued.delete(next.key);
+        const ws = wsRef.current;
+        if (ws) {
+          reads.active = next;
+          ws.sendGetEngineCapabilities(next.engine, next.space, next.cwd);
+        }
+      }
+      return;
+    }
+    // Capability mutations also return a fresh full catalog. Adopt it for the
+    // currently focused cwd when no explicit read owns the response.
+    const focused = focusedSkillScopeRef.current;
+    if (!active && focused
+        && msg.engine === focused.engine && msg.space === focused.space) {
+      storeSkillCatalog(
+        focused.key,
+        msg.items.filter((item) => item.kind === "skill"));
+    }
+  }, [storeSkillCatalog]);
   const loadMessageImage = useCallback((sid: string, path: string): boolean => {
     const ws = wsRef.current;
     if (!ws || stateRef.current.focusedSid !== sid) return false;
@@ -1685,6 +1783,7 @@ export default function App() {
             }));
           }
           if (msg.type === "engine_capabilities") {
+            acceptSkillCatalog(msg);
             setCapabilitiesBySurface((current) => ({
               ...current, [`${msg.space}:${msg.engine}`]: msg,
             }));
@@ -1743,6 +1842,16 @@ export default function App() {
           }
           dispatch({ type: "event", event: msg, ownership });
           if (msg.type === "wrapper_reconnected") {
+            skillCatalogsRef.current = {};
+            setSkillCatalogs({});
+            skillCatalogReadsRef.current = {
+              active: null,
+              queued: new Map(),
+            };
+            const focusedSkills = focusedSkillScopeRef.current;
+            if (focusedSkills?.engine === "codex" && focusedSkills.cwd) {
+              requestSkillCatalog(focusedSkills, true);
+            }
             ws.sendListSessions(engineRef.current, spaceRef.current);
             if (spaceRef.current === "work") {
               ws.sendGetWorkDashboard(engineRef.current);
@@ -1774,6 +1883,12 @@ export default function App() {
         },
         onConnState: (s, detail) => {
           dispatch({ type: "conn", connState: s, detail });
+          if (s !== "connected") {
+            skillCatalogReadsRef.current = {
+              active: null,
+              queued: new Map(),
+            };
+          }
           if (s === "connected") {
             recoverableReads.clear();
             historyRequestsRef.current.beginConnection();
@@ -1888,12 +2003,14 @@ export default function App() {
       draining.clear();
     };
   }, [
+    acceptSkillCatalog,
     authed,
     clearHistoryDetailRequests,
     installBrowseHistoryPage,
     invalidateHistoryPageScopes,
     machineId,
     requestHistory,
+    requestSkillCatalog,
     setBtwOpeningFor,
   ]);
 
@@ -1950,6 +2067,32 @@ export default function App() {
     const selectedSpace: Space = selected.space === "work" ? "work" : "code";
     lastFocusBySurfaceRef.current[`${selectedSpace}:${selectedEngine}`] = focusedSid;
   }, [focusedSid, state.newChat, state.sessions, engine]);
+
+  // Warm the cwd-scoped Codex Skill catalog when a session becomes usable.
+  // Composer completion then reads memory synchronously; an expired entry stays
+  // visible while this refresh runs in the background.
+  useEffect(() => {
+    if (!authed || !focusedSid || focusedEngine !== "codex" || state.newChat
+        || !capabilityCwd || state.connState !== "connected"
+        || !state.wrapperOnline) return;
+    requestSkillCatalog({
+      key: focusedSkillCatalogKey,
+      engine: focusedEngine,
+      space,
+      cwd: capabilityCwd,
+    });
+  }, [
+    authed,
+    capabilityCwd,
+    focusedEngine,
+    focusedSid,
+    focusedSkillCatalogKey,
+    requestSkillCatalog,
+    space,
+    state.connState,
+    state.newChat,
+    state.wrapperOnline,
+  ]);
 
   // Drain every resident session, not just the one currently visible. A queued
   // background turn must resume when that runtime becomes idle even if the user
@@ -3034,8 +3177,21 @@ export default function App() {
             setCapabilitiesKind(kind);
             setCapabilitiesOpen(true);
             setCapabilitiesLoading(true);
-            wsRef.current?.sendGetEngineCapabilities(
-              focusedEngine, space, state.newChat?.cwd ?? currentCwd);
+            requestSkillCatalog({
+              key: focusedSkillCatalogKey,
+              engine: focusedEngine,
+              space,
+              cwd: capabilityCwd,
+            }, true);
+          }}
+          skills={skillCatalogs[focusedSkillCatalogKey]?.items}
+          onRequestSkills={() => {
+            requestSkillCatalog({
+              key: focusedSkillCatalogKey,
+              engine: focusedEngine,
+              space,
+              cwd: capabilityCwd,
+            });
           }}
           workArtifactCount={space === "work" ? currentWorkArtifacts.length : 0}
           onOpenArtifacts={() => {
@@ -3167,8 +3323,12 @@ export default function App() {
         onKindChange={setCapabilitiesKind}
         onRefresh={() => {
           setCapabilitiesLoading(true);
-          wsRef.current?.sendGetEngineCapabilities(
-            focusedEngine, space, state.newChat?.cwd ?? currentCwd);
+          requestSkillCatalog({
+            key: focusedSkillCatalogKey,
+            engine: focusedEngine,
+            space,
+            cwd: capabilityCwd,
+          }, true);
         }}
         onManagePlugin={(item, action) => {
           const verb = action === "install" ? "安装" : "卸载";

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -7,11 +7,20 @@ import {
   type ClipboardEvent,
   type SetStateAction,
 } from "react";
-import type { State, QueryImg, QueryFile, ContextReport, CollaborationModeName, SessionControl, EngineCapabilityKind } from "../protocol";
+import type {
+  State, QueryImg, QueryFile, ContextReport,
+  CollaborationModeName, SessionControl, EngineCapabilityKind,
+  EngineCapabilityItem,
+} from "../protocol";
 import { presentLegacyExternalControl, presentSessionControl } from "../session-control-ui";
 import type { ConnState } from "../ws";
 import { Icon } from "../icons";
-import { clientSlashesFor, CODEX_PROMPTS, isKnownCodeOnlySlash, slashToken, matchCommands, parseSlash, modelsFor, effortsFor, permsFor, type Catalog } from "../data";
+import {
+  clientSlashesFor, CODEX_PROMPTS, isKnownCodeOnlySlash, slashToken,
+  matchCommands, matchSkills, parseSlash, skillToken,
+  modelsFor, effortsFor, permsFor,
+  type Catalog,
+} from "../data";
 import { CommandSheet } from "./CommandSheet";
 import { attachmentBytes, pickFiles } from "../img";
 import type { PendingQuery } from "../reducer";
@@ -79,6 +88,8 @@ interface Props {
   ) => void;
   onCompact?: () => void;
   onOpenExtensions?: (kind: EngineCapabilityKind | "all") => void;
+  skills?: EngineCapabilityItem[];
+  onRequestSkills?: () => void;
   workArtifactCount?: number;
   onOpenArtifacts?: () => void;
   contextReport: ContextReport | null;
@@ -135,6 +146,7 @@ export function Composer(p: Props) {
   const buttonSendTimerRef = useRef<number | null>(null);
   const photoRef = useRef<HTMLInputElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  const requestedSkillScopeRef = useRef<string | null>(null);
   const pickFilesRef = useRef<(files: FileList | File[] | null) => Promise<void>>(
     async () => {});
 
@@ -259,14 +271,40 @@ export function Composer(p: Props) {
     growTa();
   };
 
-  // Command palette = live suggestions derived from the input. Visible while the
-  // user is typing a command name (after "/", before a space) that prefix-matches
-  // at least one command. Typing past a match (/pet) hides it; deleting back
-  // (/pe) shows it again — no separate input, no modal scrim over the composer.
+  // Command/Skill palette = live suggestions derived from the input. A slash
+  // matches cc-remote/native commands; "$" matches the Codex app-server's real
+  // enabled Skill catalog. Both stop suggesting once arguments begin.
   const cmdToken = slashToken(input);
   const cmdMatches = cmdToken !== null
     ? matchCommands(cmdToken, p.engine, p.surface ?? "code") : [];
-  const cmdOpen = cmdMatches.length > 0;
+  const currentSkillToken = p.engine === "codex" ? skillToken(input) : null;
+  const skillMatches = currentSkillToken !== null && p.skills
+    ? matchSkills(currentSkillToken, p.skills) : [];
+  const skillLoading = currentSkillToken !== null && p.skills === undefined;
+  const skillOpen = currentSkillToken !== null
+    && (skillLoading || currentSkillToken === "" || skillMatches.length > 0);
+  const suggestionOpen = cmdMatches.length > 0 || skillOpen;
+  const requestSkills = p.onRequestSkills;
+  const skillRequestScope =
+    `${p.draftKey}:${p.surface ?? "code"}:${p.engine ?? "claude"}`;
+
+  // Skills are cwd-sensitive. Refresh once per focused draft when "$" is first
+  // used; App clears the surface cache before asking the wrapper, so stale
+  // suggestions from a previously focused repository disappear immediately.
+  useEffect(() => {
+    if (currentSkillToken === null) {
+      requestedSkillScopeRef.current = null;
+      return;
+    }
+    if (!requestSkills) return;
+    if (requestedSkillScopeRef.current === skillRequestScope) return;
+    requestedSkillScopeRef.current = skillRequestScope;
+    requestSkills();
+  }, [
+    currentSkillToken,
+    requestSkills,
+    skillRequestScope,
+  ]);
 
   const onPickFiles = async (fl: FileList | File[] | null) => {
     if (importing) { flash("附件正在导入，请稍候"); return; }
@@ -479,6 +517,11 @@ export function Composer(p: Props) {
     focusTa(); growTa();
   };
 
+  const pickSkill = (name: string) => {
+    setInput("$" + name + " ");
+    focusTa(); growTa();
+  };
+
   const send = (value = taRef.current?.value ?? input) => {
     if (locked || importing) return;
     const raw = value.trim();
@@ -577,7 +620,9 @@ export function Composer(p: Props) {
       }}
       onPaste={onPaste}
       onKeyDown={(e) => {
-        if (e.key === "Escape" && cmdOpen) { setInput(""); resetTaHeight(); return; }
+        if (e.key === "Escape" && suggestionOpen) {
+          setInput(""); resetTaHeight(); return;
+        }
         if (!imeSubmitRef.current.shouldSubmitKey({
           key: e.key,
           shiftKey: e.shiftKey,
@@ -585,8 +630,14 @@ export function Composer(p: Props) {
           keyCode: e.nativeEvent.keyCode,
         })) return;
         e.preventDefault();
-        if (cmdOpen && cmdToken) { pickCommand(cmdMatches[0].slash); return; }
+        if (cmdMatches.length > 0 && cmdToken) {
+          pickCommand(cmdMatches[0].slash); return;
+        }
+        if (skillMatches.length > 0 && currentSkillToken !== null) {
+          pickSkill(skillMatches[0].name); return;
+        }
         if (cmdToken === "") return;
+        if (currentSkillToken === "") return;
         send(e.currentTarget.value);
       }}
     />
@@ -607,10 +658,12 @@ export function Composer(p: Props) {
   return (
     <div className={workSurface ? "composer work-composer" : "composer"}>
       <div className={workSurface ? "composer-in work-composer-in" : "composer-in"}>
-        {cmdOpen && (
-          <div className="cmd-pop" role="listbox" aria-label="命令"
+        {suggestionOpen && (
+          <div className="cmd-pop" role="listbox" aria-label={
+            currentSkillToken !== null ? "Skills" : "命令"
+          }
             data-lock-horizontal-swipe="true">
-            {cmdMatches.map((c) => (
+            {currentSkillToken === null ? cmdMatches.map((c) => (
               <button key={c.slash} type="button" className="cmd" onClick={() => pickCommand(c.slash)}>
                 <span className="cmd-ic"><Icon name={c.ic} size={17} /></span>
                 <span className="cmd-tx">
@@ -619,7 +672,21 @@ export function Composer(p: Props) {
                 </span>
                 <span className="cmd-kbd">↵</span>
               </button>
-            ))}
+            )) : skillLoading ? (
+              <div className="cmd-empty">正在读取当前目录的 Skills…</div>
+            ) : skillMatches.length > 0 ? skillMatches.map((skill) => (
+              <button key={skill.name.toLocaleLowerCase()} type="button"
+                className="cmd" onClick={() => pickSkill(skill.name)}>
+                <span className="cmd-ic"><Icon name="spark" size={17} /></span>
+                <span className="cmd-tx">
+                  <span className="cmd-nm"><span className="slash">${skill.name}</span></span>
+                  <span className="cmd-ds">{skill.description || "调用此 Skill"}</span>
+                </span>
+                <span className="cmd-kbd">↵</span>
+              </button>
+            )) : (
+              <div className="cmd-empty">当前目录没有已启用的 Skills</div>
+            )}
           </div>
         )}
         {notice && <div className="composer-notice">{notice}</div>}
@@ -750,7 +817,9 @@ export function Composer(p: Props) {
             <button className="cmdbtn" onClick={() => photoRef.current?.click()}
               aria-label="添加照片" title="添加照片"
               disabled={locked || importing}><Icon name="plus" size={19} /></button>
-            {inputControl("发消息…  输入 / 唤起命令")}
+            {inputControl(p.engine === "codex"
+              ? "发消息…  输入 / 唤起命令，$ 调用 Skill"
+              : "发消息…  输入 / 唤起命令")}
             {sendControl}
           </div>
           <div className="hint">
@@ -768,7 +837,9 @@ export function Composer(p: Props) {
               : (perm ? perm.short : "Mode loading")} · {stateZh[p.state]}
             {!deferredClaudeControls && <span className="hint-mode-ch">▾</span>}
           </button>
-          <span className="hint-kbds"><kbd>Enter</kbd> 发送 · <kbd>Shift+Tab</kbd> 切模式 · <kbd>/</kbd> 命令</span>
+          <span className="hint-kbds"><kbd>Enter</kbd> 发送 · <kbd>Shift+Tab</kbd> 切模式 · <kbd>/</kbd> 命令{
+            p.engine === "codex" && <> · <kbd>$</kbd> Skills</>
+          }</span>
           <div className="hint-right" ref={ctxWrapRef}>
             {deferredClaudeControls && (
               <span className="hint-control-scope"

--- a/web/src/data.ts
+++ b/web/src/data.ts
@@ -5,7 +5,9 @@
 // handled in Composer.send) and cc skills (forwarded verbatim to cc). Model/perm
 // chips drive set_model / set_permission_mode on the wrapper.
 
-import type { CatalogModel } from "./protocol";
+import type {
+  CatalogModel, EngineCapabilityItem,
+} from "./protocol";
 
 export interface CmdGroup { g: string }
 export interface Cmd { slash: string; name: string; ds: string; ic: string }
@@ -295,6 +297,34 @@ export function slashToken(input: string): string | null {
   const after = input.slice(1);
   if (/\s/.test(after)) return null; // a space => choosing args, not the command
   return after;
+}
+
+// Codex explicitly invokes a Skill with "$skill-name". Keep this separate from
+// slash parsing: "$" is forwarded as prompt text after selection, while slash
+// commands may be handled locally by cc-remote.
+export function skillToken(input: string): string | null {
+  if (!input.startsWith("$")) return null;
+  const after = input.slice(1);
+  if (/\s/.test(after)) return null;
+  return after;
+}
+
+/** Enabled Skills whose trigger starts with `token`, deduplicated by trigger.
+ * The app-server catalog is authoritative; disabled Skills must not be offered
+ * as invokable even though extension management still lists them. */
+export function matchSkills(
+  token: string,
+  items: EngineCapabilityItem[],
+): EngineCapabilityItem[] {
+  const prefix = token.toLowerCase();
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (item.kind !== "skill" || item.enabled === false) return false;
+    const name = item.name.toLowerCase();
+    if (!name.startsWith(prefix) || seen.has(name)) return false;
+    seen.add(name);
+    return true;
+  }).sort((a, b) => a.name.localeCompare(b.name));
 }
 
 // Commands whose slash starts with `token` (case-insensitive, prefix match).

--- a/web/src/skill-catalog-cache.ts
+++ b/web/src/skill-catalog-cache.ts
@@ -1,0 +1,37 @@
+import type { Engine, EngineCapabilityItem, Space } from "./protocol";
+
+export const SKILL_CATALOG_TTL_MS = 5 * 60_000;
+export const MAX_SKILL_CATALOGS = 32;
+
+export interface SkillCatalogCacheEntry {
+  items: EngineCapabilityItem[];
+  fetchedAt: number;
+}
+
+export const skillCatalogKey = (
+  machineId: string,
+  engine: Engine,
+  space: Space,
+  cwd: string,
+): string => [machineId, engine, space, cwd || "."].join("\u0000");
+
+export const skillCatalogFresh = (
+  entry: SkillCatalogCacheEntry | undefined,
+  now = Date.now(),
+): boolean => !!entry && now - entry.fetchedAt < SKILL_CATALOG_TTL_MS;
+
+export function cacheSkillCatalog(
+  current: Record<string, SkillCatalogCacheEntry>,
+  key: string,
+  items: EngineCapabilityItem[],
+  fetchedAt = Date.now(),
+): Record<string, SkillCatalogCacheEntry> {
+  const next = { ...current, [key]: { items, fetchedAt } };
+  const keys = Object.keys(next);
+  if (keys.length <= MAX_SKILL_CATALOGS) return next;
+  keys.sort((a, b) => next[a].fetchedAt - next[b].fetchedAt);
+  for (const oldKey of keys.slice(0, keys.length - MAX_SKILL_CATALOGS)) {
+    delete next[oldKey];
+  }
+  return next;
+}

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -67,10 +67,12 @@ import {
   commandsFor,
   isKnownCodeOnlySlash,
   matchCommands,
+  matchSkills,
   matchModelId,
   MODELS,
   modelsFor,
   permsFor,
+  skillToken,
 } from "../src/data.ts";
 import {
   createMobileViewportSync,
@@ -113,6 +115,13 @@ import {
 import { workContextMetrics } from "../src/work-context.ts";
 import { processBlocks } from "../src/process-blocks.ts";
 import { PointerTapGuard } from "../src/pointer-tap.ts";
+import {
+  cacheSkillCatalog,
+  MAX_SKILL_CATALOGS,
+  skillCatalogFresh,
+  skillCatalogKey,
+  SKILL_CATALOG_TTL_MS,
+} from "../src/skill-catalog-cache.ts";
 import {
   constrainImageTransform,
   panImageTransform,
@@ -329,6 +338,47 @@ for (const engine of ["claude", "codex"] as const) {
 }
 assert.equal(clientSlashesFor("claude").has("hook"), false,
   "Claude singular /hook remains native; Remote management uses /hooks");
+assert.equal(skillToken("$"), "");
+assert.equal(skillToken("$cavecrew"), "cavecrew");
+assert.equal(skillToken("$cavecrew explain this"), null,
+  "Skill suggestions must close as soon as prompt arguments begin");
+assert.equal(skillToken("use $cavecrew"), null,
+  "only a leading $ is an explicit Codex Skill invocation");
+const skillCatalog = [
+  { kind: "skill", id: "1", name: "cavecrew", enabled: true,
+    description: "Delegate work" },
+  { kind: "skill", id: "2", name: "Caveman", enabled: true },
+  { kind: "skill", id: "3", name: "cavecrew", enabled: true },
+  { kind: "skill", id: "4", name: "disabled-skill", enabled: false },
+  { kind: "plugin", id: "5", name: "cave-plugin", installed: true },
+] satisfies import("../src/protocol.ts").EngineCapabilityItem[];
+assert.deepEqual(matchSkills("cave", skillCatalog).map((item) => item.name),
+  ["cavecrew", "Caveman"],
+  "Skill completion must prefix-match case-insensitively and deduplicate triggers");
+assert.deepEqual(matchSkills("", skillCatalog).map((item) => item.name),
+  ["cavecrew", "Caveman"],
+  "only enabled Skills may be offered for explicit invocation");
+const repoSkillKey = skillCatalogKey(
+  "machine-a", "codex", "code", "/repo/a");
+assert.notEqual(repoSkillKey, skillCatalogKey(
+  "machine-a", "codex", "code", "/repo/b"),
+  "Skill catalogs from different repositories must never share a cache entry");
+assert.notEqual(repoSkillKey, skillCatalogKey(
+  "machine-b", "codex", "code", "/repo/a"),
+  "Skill catalogs must remain inside the machine authorization boundary");
+const freshSkillEntry = { items: skillCatalog, fetchedAt: 1_000 };
+assert.equal(skillCatalogFresh(freshSkillEntry, 1_000 + SKILL_CATALOG_TTL_MS - 1),
+  true);
+assert.equal(skillCatalogFresh(freshSkillEntry, 1_000 + SKILL_CATALOG_TTL_MS),
+  false, "an expired Skill catalog must refresh without hiding its stale items");
+let boundedSkillCache = {};
+for (let index = 0; index <= MAX_SKILL_CATALOGS; index += 1) {
+  boundedSkillCache = cacheSkillCatalog(
+    boundedSkillCache, `scope-${index}`, skillCatalog, index);
+}
+assert.equal(Object.keys(boundedSkillCache).length, MAX_SKILL_CATALOGS);
+assert.equal("scope-0" in boundedSkillCache, false,
+  "the bounded cache must evict the oldest cwd catalog first");
 const recentProject = { session_id: "project-new", cwd: "/home/nancy/project",
   last_modified: "300" };
 const oldHome = { session_id: "home-old", cwd: "/home/nancy", last_modified: "100" };
@@ -6300,6 +6350,22 @@ assert.match(composerSource, /不是\$\{externalClaudeOwner\}当前强度/,
 assert.doesNotMatch(composerSource, /终端占用/,
   "shared control must never be presented as exclusive terminal occupancy");
 assert.match(composerSource, /presentLegacyExternalControl/);
+assert.match(composerSource, /p\.engine === "codex"[\s\S]*?<kbd>\$<\/kbd> Skills/,
+  "desktop Codex controls must advertise the $ Skill completion trigger");
+assert.match(composerSource, /skillMatches\[0\]\.name/,
+  "Enter must complete the first matching Skill instead of sending a partial trigger");
+assert.match(composerSource, /正在读取当前目录的 Skills/,
+  "the Skill palette must stay visible while native discovery is in flight");
+assert.match(appSource, /skills=\{skillCatalogs\[focusedSkillCatalogKey\]\?\.items\}/,
+  "the composer must paint a cwd-scoped Skill cache synchronously");
+assert.match(appSource, /Warm the cwd-scoped Codex Skill catalog[\s\S]*requestSkillCatalog/,
+  "focused Codex sessions must prefetch Skills before the user types $");
+assert.match(appSource,
+  /msg\.type === "wrapper_reconnected"[\s\S]*skillCatalogsRef\.current = \{\}[\s\S]*requestSkillCatalog\(focusedSkills, true\)/,
+  "a wrapper generation change must invalidate and rewarm native Skill catalogs");
+assert.doesNotMatch(appSource,
+  /onRequestSkills=\{\(\) => \{[\s\S]{0,500}delete next\[/,
+  "opening $ completion must never clear a usable Skill cache");
 assert.doesNotMatch(composerSource, /control-bar/,
   "terminal state no longer consumes a permanent row above the composer");
 const workDashboardSource = readFileSync(


### PR DESCRIPTION
## Summary

- show Codex Skill suggestions when the composer token starts with `$`
- cache per-session Skill catalogs instead of rescanning on every keystroke
- add desktop keyboard guidance while preserving the compact mobile layout

## Motivation

Slash commands already have immediate discovery in the composer, but Codex
Skills did not. Reading the catalog on every `$` input also made the first
interaction noticeably slow. This adds the same discoverability with a
session-aware cache that is invalidated on reconnect and capability changes.

## Dependencies

- Direct dependency: #8 provides the shared CI-only Playwright retry configuration.
- No other PR dependencies; the Skill-suggestion feature is functionally independent of #8.
- Required merge order: #8 → #12.

## Testing

- full `act pull_request` workflow: Web, Python, and Deploy jobs passed
- catalog caching, reconnect invalidation, matching, and composer regression tests
- Web build, reliability suite, Oxlint, and `git diff --check`
