### PR TITLE
fix(web): align session status controls and context meter

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   testMatch: "history-browser.spec.ts",
   fullyParallel: false,
   workers: 1,
+  retries: process.env.CI ? 2 : 0,
   reporter: "line",
   use: {
     baseURL: "http://127.0.0.1:4174",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2180,6 +2180,26 @@ export default function App() {
   }, [loadHistoryTurnDetail, state.historyBrowse, state.runtimes,
     state.focusedSid]);
 
+  // Prime the ring as soon as the focused session is usable. Previously the
+  // first read only happened when the user opened the popover or a turn ended,
+  // so a freshly loaded/restored session misleadingly painted an empty ring.
+  // wrapperOnline deliberately gates reconnects until snapshot/replay proves
+  // that the replacement wrapper has finished restoring resident sessions.
+  useEffect(() => {
+    if (!authed || !focusedSid || state.newChat
+        || state.connState !== "connected" || !state.wrapperOnline) return;
+    if (stateRef.current.runtimes[focusedSid]?.contextRequestId) return;
+    const requestId = wsRef.current?.sendGetContext();
+    if (requestId) {
+      dispatch({ type: "begin_context_request", sid: focusedSid, requestId });
+    }
+  }, [
+    authed,
+    focusedSid,
+    state.connState,
+    state.newChat,
+    state.wrapperOnline,
+  ]);
   if (!authReady) {
     return <div className="login" aria-busy="true">正在连接中继…</div>;
   }

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -555,7 +555,6 @@ export function Composer(p: Props) {
     : null;
   const stateZh: Record<State, string> = { idle: "空闲", running: "运行中", interrupting: "打断中", draining: "收尾中" };
   const modeCls = perm?.id === "plan" ? " plan" : perm?.danger ? " danger" : "";
-  const hintBusy = p.state !== "idle";
 
   const inputControl = (placeholder: string) => (
     <textarea
@@ -756,7 +755,7 @@ export function Composer(p: Props) {
           <div className="hint">
           <button
             type="button"
-            className={"hint-mode" + modeCls + (hintBusy ? " busy" : "")}
+            className={"hint-mode" + modeCls}
             onClick={() => setSheetKind("perms")}
             disabled={locked}
             title={deferredClaudeControls
@@ -765,7 +764,7 @@ export function Composer(p: Props) {
           >
             {deferredClaudeControls
               ? externalClaudeOwner
-              : (perm ? perm.short : "Mode loading")} · {stateZh[p.state]}
+              : (perm ? perm.short : "Mode loading")}
             {!deferredClaudeControls && <span className="hint-mode-ch">▾</span>}
           </button>
           <span className="hint-kbds"><kbd>Enter</kbd> 发送 · <kbd>Shift+Tab</kbd> 切模式 · <kbd>/</kbd> 命令</span>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1061,10 +1061,15 @@ html.panel-resizing,html.panel-resizing *{ cursor:col-resize !important; user-se
 .hint-mode .hint-mode-ch{ font-size:9px; opacity:.6; }
 .hint-mode.plan{ color:var(--accent-ink); }
 .hint-mode.danger{ color:var(--danger); }
-.hint-mode.busy{ color:var(--warn); }
 .hint-kbds{ white-space:nowrap; flex:1; text-align:center; overflow:hidden; text-overflow:ellipsis; }
-/* narrow screens: drop the keyboard hint (shortcuts are desktop-only), keep mode + controls */
-@media (max-width:640px){ .hint-kbds{ display:none; } .hint-right{ gap:12px; } }
+/* Narrow screens: hide desktop shortcuts and distribute every live control
+   across the remaining row width. Desktop keeps the original split layout. */
+@media (max-width:640px){
+  .hint{ gap:clamp(6px,2vw,12px); }
+  .hint-kbds{ display:none; }
+  .hint-right{ min-width:0; margin-left:0; flex:1; justify-content:space-between;
+    gap:clamp(4px,1.4vw,10px); }
+}
 
 /* COMMAND SHEET */
 .scrim{ position:fixed; inset:0; z-index:40; background:rgba(30,22,12,.34);

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -6247,6 +6247,9 @@ assert.match(appSource, /legacyExternal=\{!rt\.control && !!rt\.external\}/,
   "rolling-deploy compatibility keeps legacy external ownership actionable");
 assert.match(appSource, /sessionControlLocksInput\(rt\.control\)/,
   "Shift+Tab must not mutate controls while the authoritative session is read-only");
+assert.match(appSource,
+  /state\.connState !== "connected" \|\| !state\.wrapperOnline\) return;[\s\S]{0,300}sendGetContext\(\)[\s\S]{0,200}begin_context_request/,
+  "a focused session must prime its context ring after initial sync and reconnect");
 assert.doesNotMatch(appSource, /className="work-artifacts-btn"/);
 assert.doesNotMatch(appSource, /className="work-head-manage"/);
 assert.doesNotMatch(appSource, /sendSetWorkGrant|目录授权/);

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -6302,6 +6302,15 @@ assert.doesNotMatch(composerSource, /终端占用/,
 assert.match(composerSource, /presentLegacyExternalControl/);
 assert.doesNotMatch(composerSource, /control-bar/,
   "terminal state no longer consumes a permanent row above the composer");
+assert.doesNotMatch(composerSource, /hint-mode[^]*stateZh\[p\.state\]/,
+  "the composer permission chip must not repeat the header runtime state");
+const permissionControlIndex = composerSource.indexOf('className={"hint-mode"');
+const runtimeControlsIndex = composerSource.indexOf('className="hint-right"');
+const shortcutHintIndex = composerSource.indexOf('className="hint-kbds"');
+assert.ok(permissionControlIndex >= 0
+    && permissionControlIndex < shortcutHintIndex
+    && shortcutHintIndex < runtimeControlsIndex,
+  "desktop composer must keep its original split control layout");
 const workDashboardSource = readFileSync(
   resolve(process.cwd(), "src/components/WorkDashboardSheet.tsx"), "utf8");
 assert.match(workDashboardSource, /<DateTimePicker value=\{scheduleAt\}/,
@@ -6313,6 +6322,13 @@ const dateTimePickerSource = readFileSync(
 assert.match(dateTimePickerSource, /createPortal\(<>.*document\.body\)/s,
   "the date-time popover must escape the scrollable Work manager container");
 const appCssSource = readFileSync(resolve(process.cwd(), "src/index.css"), "utf8");
+assert.doesNotMatch(appCssSource, /\.hint-mode\.busy/,
+  "the composer permission chip must not duplicate runtime state by color");
+assert.match(appCssSource, /\.hint-right\{[^}]*margin-left:auto/,
+  "desktop composer controls must retain the original right alignment");
+assert.match(appCssSource,
+  /@media \(max-width:640px\)\{[\s\S]*?\.hint-kbds\{ display:none; \}[\s\S]*?\.hint-right\{[^}]*margin-left:0;[^}]*flex:1;[^}]*justify-content:space-between;/,
+  "mobile composer controls must distribute across the available row width");
 assert.match(appCssSource, /\.capabilities-sheet>header\{[^}]*flex:none/s,
   "the Extensions header must not collapse under a long capability list");
 assert.match(appCssSource, /\.capabilities-tabs\{[^}]*flex:none/s,


### PR DESCRIPTION
## Summary

- remove the duplicate idle/running label from the composer footer
- let the remaining controls reflow naturally on narrow screens
- prime the context-usage ring immediately when a session gains focus

## Motivation

The global session header already reports idle/running state. Repeating it in
the composer consumed scarce mobile width and left a large gap after removal.
Separately, the context ring could remain blank until the user interacted with
the focused session. The two commits make the compact session-status surface
consistent on desktop and mobile.

## Dependencies

- Stacked on #8 for the shared CI-only Playwright retry configuration.
- The UI changes are otherwise functionally independent of #8.

## Testing

- full `act pull_request` workflow: Web, Python, and Deploy jobs passed
- composer layout, session focus, and context-report regression tests
- Chromium and WebKit history-browser coverage
- Oxlint and `git diff --check`
