### PR TITLE
fix(web): improve text selection scrolling and copying

### DIFF
--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -678,6 +678,21 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
     });
   }, [captureHistoryBoundary, commitTextSelection]);
 
+  const releaseTextSelectionViewportAnchor = useCallback(() => {
+    const active = textSelectionRef.current;
+    if (!active || active.dragging
+        || (active.releaseAnchorTurnId == null
+          && active.releaseAnchorOffset == null)) return;
+    // The release boundary only protects the viewport from late measurements
+    // while the reader is stationary. Once a new scroll gesture starts, keep
+    // the selected turns mounted but stop correcting back to the old viewport.
+    commitTextSelection({
+      ...active,
+      releaseAnchorTurnId: null,
+      releaseAnchorOffset: null,
+    });
+  }, [commitTextSelection]);
+
   const clearTextSelection = useCallback(() => {
     textSelectionCandidateRef.current = null;
     const active = textSelectionRef.current;
@@ -1186,6 +1201,7 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
     // A real wheel/touch/key/pointer action transfers ownership back to the
     // reader. Late detail responses and ResizeObserver callbacks must not pull
     // the viewport back to the edge captured before that gesture.
+    releaseTextSelectionViewportAnchor();
     cancelDetailAnchorFnRef.current?.();
     setMeasurementBoundary(null);
     userScrollIntentRef.current = true;

--- a/web/tests/history-browser.spec.ts
+++ b/web/tests/history-browser.spec.ts
@@ -1615,6 +1615,47 @@ test("desktop text selection keeps its original virtual turn while edge-dragging
   expect(await page.locator(".turn").count()).toBeLessThan(40);
 });
 
+test("desktop wheel scrolling remains available after text selection", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "webkit",
+    "the configured WebKit project is a touch phone; this is a desktop mouse path");
+  await page.goto("/tests/history-browser.html?large=120");
+  const viewport = page.locator(".thread");
+  await viewport.evaluate((node) => {
+    node.scrollTop = node.scrollHeight * (41 / 120);
+  });
+  const text = page.locator('[data-turn-id="m42"] p').first();
+  await text.scrollIntoViewIfNeeded();
+  const box = await text.boundingBox();
+  if (!box) throw new Error("selection fixture has no geometry");
+
+  await page.mouse.move(box.x + 4, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(
+    Math.min(box.x + box.width - 4, box.x + 180),
+    box.y + box.height / 2,
+    { steps: 12 },
+  );
+  await page.mouse.up();
+  await expect(viewport).toHaveAttribute(
+    "data-text-selection-retained", "true",
+  );
+  expect((await nativeSelectionSnapshot(page)).text.length).toBeGreaterThan(0);
+  const beforeScrollTop = await viewport.evaluate((node) => node.scrollTop);
+
+  await page.mouse.wheel(0, 640);
+  await expect.poll(
+    () => viewport.evaluate((node) => node.scrollTop),
+  ).toBeGreaterThan(beforeScrollTop + 200);
+  const afterScroll = await nativeSelectionSnapshot(page);
+  expect(afterScroll.anchorConnected).toBe(true);
+  expect(afterScroll.text.length).toBeGreaterThan(0);
+  await expect(viewport).toHaveAttribute(
+    "data-text-selection-retained", "true",
+  );
+});
+
 test("a late cached-newer page cannot evict an active text selection", async ({
   page,
 }, testInfo) => {


### PR DESCRIPTION
## Summary

- keep wheel scrolling responsive after a desktop text selection is released
- preserve the native selection and its virtualized turns without replaying the old viewport anchor
- constrain coarse-pointer selection to the paragraph, list item, code block, table cell, or message bubble where the long press begins
- exclude non-content message chrome from touch selection

## Problem

A released desktop selection retained a measurement anchor indefinitely. The next wheel gesture moved the scroll container, but the layout correction immediately restored the old offset, making the conversation appear unable to scroll.

On phones, native selection handles could also cross semantic content boundaries too easily and capture adjacent messages and UI text when the user only wanted a short excerpt.

## Implementation

- release only the stationary viewport anchor when new reader scroll intent begins
- continue retaining selected virtual turns so the browser selection remains connected and copyable
- add a coarse-pointer selection boundary built on the native Selection API
- clamp both forward and reverse handle movement to the semantic block where selection started
- retain the existing whole-message copy actions for intentional full-response copying

## Dependencies

None. This branch is based directly on current `master`.

## Testing

- `.venv/bin/python -m pytest` — 1312 passed, 1 skipped
- `uvx --from ruff==0.15.13 ruff check cc_remote tests deploy`
- `npm --prefix web run build`
- `npm --prefix web run test:reliability`
- `npm --prefix web run test:history-browser` — 94 passed, 12 platform-defined skips
- `npm --prefix web run lint`
- `bash -n` for deployment scripts
- `shellcheck -x` for deployment scripts
- `git diff --check`
