### PR TITLE
fix(v3): preserve history and improve capability UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,9 @@ local `claude` or `codex` session through a WebSocket relay. Two independent lin
   transport, never the caller's Origin. Uvicorn trusts forwarded transport
   metadata only from loopback Caddy. Never put tokens in URLs or protocol
   message bodies; logging redacts token/password fields.
-- **Protocol version gate**: `PROTOCOL_VERSION` in both `protocol.py` and
-  `web/src/protocol.ts`. `deserialize` hard-rejects a version mismatch, and
+- **Protocol version gate**: current wire protocol v26 is declared by
+  `PROTOCOL_VERSION` in both `protocol.py` and `web/src/protocol.ts`.
+  `deserialize` hard-rejects a version mismatch, and
   `_Base` is `extra="forbid"`, so ANY protocol change must be deployed to all
   three tiers together (wrapper + relay + web) and the relay restarted — the
   relay imports `protocol.py` and drops frames it can't parse.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   disconnected, and restores the authoritative queue when a client reconnects.
   Queue chips retain only bounded previews; opening one fetches its full prompt
   privately and edits it atomically in the wrapper without dropping attachments.
+- Upgrade the coordinated Wrapper/Relay/Web wire gate to protocol v26 and give
+  Codex `$` completion a lightweight Skills-only inventory path. Slow Apps or
+  MCP discovery can no longer hide an already returned Skill catalog, while
+  the full Extensions sheet retains the complete native inventory.
 - Add official Codex named permission profiles as a control separate from the
   approval policy. The compact permissions sheet can select Read Only,
   Workspace, Full Access, or cwd-aware custom profiles without adding another

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -8,6 +8,9 @@
   允许排队消息和打断后的替换消息在所有 Web/PWA 客户端休眠或断线时，仍于当前
   回合结束后立即继续执行；客户端重连时会恢复 wrapper 的权威队列状态。队列标签
   只保留有界摘要，点击后私有按需读取完整指令，并可在 wrapper 中原子编辑而不丢附件。
+- Wrapper、Relay 与 Web 的协同 wire gate 升级到 protocol v26，并为 Codex
+  的 `$` 补全增加轻量 Skills-only 目录。缓慢的 Apps 或 MCP 枚举不再隐藏已经
+  返回的 Skills；完整 Extensions 面板仍保留原生全量目录。
 - 新增 Codex 官方 named permission profile 控制，并与审批策略分开管理。紧凑的
   权限面板可选择 Read Only、Workspace、Full Access 及按 cwd 生效的自定义
   profile，不增加输入框底栏控件；protocol v24 在 Wrapper、Relay 与 Web

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,9 @@ local `claude` or `codex` session through a WebSocket relay. Two independent lin
   `useLayoutEffect` is deliberately dependency-free — late virtualizer/image
   measurements settle without a React render, and constraining it to its read
   set reintroduces a full-viewport jump on touch release.
-- **Protocol version gate**: `PROTOCOL_VERSION` in both `protocol.py` and
-  `web/src/protocol.ts`. `deserialize` hard-rejects a version mismatch, and
+- **Protocol version gate**: current wire protocol v26 is declared by
+  `PROTOCOL_VERSION` in both `protocol.py` and `web/src/protocol.ts`.
+  `deserialize` hard-rejects a version mismatch, and
   `_Base` is `extra="forbid"`, so ANY protocol change must be deployed to all
   three tiers together (wrapper + relay + web) and the relay restarted — the
   relay imports `protocol.py` and drops frames it can't parse.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 自托管 · 双引擎 · 多会话 · 实时过程 · 响应式 Web
 
-**当前版本：v3.0.0** · Wire protocol v25
+**当前版本：v3.0.0** · Wire protocol v26
 
 [English](README_en.md) ·
 [5 分钟上手](#本地快速开始一台机器5-分钟) ·
@@ -58,7 +58,7 @@ v3 把 cc-remote 从“能在网页控制 CLI”推进为一个本地优先、�
 | **原生 App / CLI 协同** | Claude CLI/Desktop/Agent View 与 Codex shared daemon/App/CLI 使用各自的所有权模型。v3 对齐 running、只读、打断、steer、compact、turn binding 和终止状态，避免兄弟会话误锁、历史回合串到尾部或留下“假思考中”。 |
 | **多设备隔离** | Device Center 提供一次性配对、独立可撤销的机器凭据和在线状态；relay 按用户允许的 `machine_id` 路由。设备、Code / Work、引擎、连接 generation 和会话归属分别隔离，延迟帧不能污染当前视图。 |
 | **移动端与文件体验** | 历史到顶继续拉取时保留滚动锚点；图片按需加载，支持灯箱、再次点击收起和双指缩放；Markdown、源码、HTML、PDF 与 Office 预览仍在本机安全边界内完成。PWA 图标、窄屏弹层、错误提示和过程时间线也统一收敛。 |
-| **可回滚发布** | 产品版本统一为 v3.0.0，wire protocol 为 v24。构建和部署同时校验产品版本与协议版本；VPS 使用不可变 release、独立 venv、原子 `current` 切换和失败回滚，避免直接覆盖正在运行的目录。 |
+| **可回滚发布** | 产品版本统一为 v3.0.0，wire protocol 为 v26。构建和部署同时校验产品版本与协议版本；VPS 使用不可变 release、独立 venv、原子 `current` 切换和失败回滚，避免直接覆盖正在运行的目录。 |
 
 > **信任边界没有改变：**模型账号、API key、会话源文件和工具执行仍留在
 > wrapper 所在机器；VPS relay 不保存对话或 Artifact。浏览历史只读取本地
@@ -401,12 +401,12 @@ npm --prefix web run build   # 产出 web/dist/
 
 > 现在网页**不再把 token 烤进 JS**：登录改为向中继 POST 口令换取短期会话 token。所以构建不需要任何 `VITE_*` 变量。
 
-> **升级到协议 v25**：线协议会严格拒绝版本不一致。请在同一次维护窗口部署
+> **升级到协议 v26**：线协议会严格拒绝版本不一致。请在同一次维护窗口部署
 > `cc_remote/` 和新的 `web/dist/`，然后依次重启 relay、wrapper；不要新旧版本滚动混跑。
 > 升级期间已有 WebSocket 会短暂重连，relay 重启也会要求浏览器重新登录。已打开的
 > 旧版页面必须做一次**硬刷新**（重新加载新的带 hash 静态资源），仅重新登录不够。
-> 手工发布时先停本机 wrapper，再停服更新 relay + web，最后启动 v25 relay 和
-> v25 wrapper；这样旧 wrapper 不会占住同一 `machine_id` 的连接槽。
+> 手工发布时先停本机 wrapper，再停服更新 relay + web，最后启动 v26 relay 和
+> v26 wrapper；这样旧 wrapper 不会占住同一 `machine_id` 的连接槽。
 
 ### 3）上传 staging，由原子 release 安装器发布
 
@@ -460,7 +460,7 @@ sudo bash ~/cc-remote-upload/deploy/setup-vps.sh \
 脚本会：装 `python3-venv` + Caddy、建 `ccremote` 系统用户、创建不可变 release
 和 release-local venv、合并 Caddy 配置、原子切换 `current`，再重启 relay。若新
 relay 重启或健康检查失败，`current`、Caddyfile、systemd unit 会作为一个事务全部
-恢复，并验证旧 release 的 `/healthz`。成功后再启动 v25 wrapper。
+恢复，并验证旧 release 的 `/healthz`。成功后再启动 v26 wrapper。
 
 验证：
 

--- a/README_en.md
+++ b/README_en.md
@@ -4,7 +4,7 @@
 
 Self-hosted · Dual-engine · Multi-session · Live process · Responsive Web
 
-**Current release: v3.0.0** · Wire protocol v25
+**Current release: v3.0.0** · Wire protocol v26
 
 [中文](README.md) ·
 [5-minute quick start](#quick-start-local-one-machine-5-min) ·
@@ -62,7 +62,7 @@ with the previous public release, the major changes are:
 | **Native App / CLI coordination** | Claude CLI/Desktop/Agent View and Codex shared daemon/App/CLI retain engine-specific ownership models. v3 reconciles running, read-only, interrupt, steer, compact, turn binding, and terminal state so sibling sessions do not lock each other, old turns do not move to the tail, and interrupted work does not leave ghost activity. |
 | **Multi-device isolation** | Device Center adds single-use pairing, independently revocable machine credentials, and presence. The relay routes only an account's allowed `machine_id` values. Device, Code / Work, engine, connection generation, and session ownership are isolated so delayed frames cannot mutate the active view. |
 | **Mobile and artifact UX** | Loading older history preserves the scroll anchor. Images load on demand and support a lightbox, tap-to-close, and pinch zoom. Markdown, source, HTML, PDF, and Office previews remain within the local security boundary. PWA icons, narrow-screen sheets, error presentation, and process timelines are also aligned. |
-| **Rollback-safe releases** | The product version is v3.0.0 and the wire protocol is v24. Builds and deployments validate both values. The VPS uses immutable releases, release-local virtual environments, an atomic `current` switch, and rollback instead of overwriting a live directory. |
+| **Rollback-safe releases** | The product version is v3.0.0 and the wire protocol is v26. Builds and deployments validate both values. The VPS uses immutable releases, release-local virtual environments, an atomic `current` switch, and rollback instead of overwriting a live directory. |
 
 > **The trust boundary has not changed:** model accounts, API keys, session
 > sources, and tool execution stay on the wrapper machine. The VPS relay stores
@@ -469,14 +469,14 @@ npm --prefix web run build   # produces web/dist/
 
 > The web client no longer bakes any token into the JS: login POSTs the password to the relay for a short-lived session token. So the build needs no `VITE_*` variables.
 
-> **Upgrading to protocol v25:** the wire gate rejects mixed versions. Deploy
+> **Upgrading to protocol v26:** the wire gate rejects mixed versions. Deploy
 > `cc_remote/` and the new `web/dist/` in one maintenance window, then restart the
 > relay and wrapper; do not run a rolling mixture. Existing sockets reconnect
 > briefly, and a relay restart intentionally requires browsers to log in again.
 > Any already-open older page also needs one **hard refresh** to load the new hashed
 > assets; logging in again inside the old JavaScript bundle isn't sufficient.
 > For a manual release, stop the local wrapper first, stop and update relay + web,
-> then start the v25 relay and v25 wrapper so the old wrapper cannot occupy the
+> then start the v26 relay and v26 wrapper so the old wrapper cannot occupy the
 > slot for the same `machine_id`.
 
 ### 3) Upload staging, then publish it as an atomic release
@@ -534,7 +534,7 @@ The script installs `python3-venv` + Caddy, creates the `ccremote` service user,
 builds an immutable release and its venv, merges Caddy configuration, atomically
 switches `current`, and restarts the relay. If restart/readiness fails, `current`,
 the Caddyfile, and the systemd unit roll back as one transaction and the previous
-release's `/healthz` is verified. Start the v25 wrapper after success.
+release's `/healthz` is verified. Start the v26 wrapper after success.
 
 Verify:
 

--- a/cc_remote/protocol.py
+++ b/cc_remote/protocol.py
@@ -28,7 +28,7 @@ from cc_remote.attachments import (
     MAX_SINGLE_ATTACHMENT_BYTES,
 )
 
-PROTOCOL_VERSION = 25
+PROTOCOL_VERSION = 26
 
 State = Literal["idle", "running", "interrupting", "draining"]
 Engine = Literal["claude", "codex"]
@@ -1389,6 +1389,7 @@ class GetEngineCapabilities(_Command):
     space: Space = "code"
     client_id: Optional[WireId] = None
     cwd: Optional[str] = Field(default=None, max_length=4096)
+    skills_only: bool = False
 
 
 class ManageEnginePlugin(_Command):
@@ -1459,9 +1460,12 @@ class EngineCapabilities(_Base):
     type: Literal["engine_capabilities"] = "engine_capabilities"
     engine: Engine
     space: Space
+    request_id: Optional[WireId] = None
+    cwd: str = Field(max_length=4096)
     items: list[EngineCapabilityItem] = Field(max_length=2000)
     errors: list[str] = Field(default_factory=list, max_length=32)
     notes: list[str] = Field(default_factory=list, max_length=32)
+    skills_only: bool = False
 
 
 class SetPerm(_Command):

--- a/cc_remote/wrapper/codex_rpc.py
+++ b/cc_remote/wrapper/codex_rpc.py
@@ -145,6 +145,8 @@ async def codex_rpc(
 async def codex_rpc_batch(
     requests: list[tuple[str, Optional[dict[str, Any]]]],
     cwd: Optional[str] = None,
+    *,
+    timeout: float = _RPC_TIMEOUT,
 ) -> list[Any | Exception]:
     """Issue a read-only request batch through one initialized app-server.
 
@@ -152,7 +154,8 @@ async def codex_rpc_batch(
     JSON-RPC rejection is returned as ``CodexRpcRejected`` so inventory callers
     can preserve successful components. Process/initialization failures before
     submission still raise; transport failures after submission become
-    per-request ``CodexRpcOutcomeUnknown`` values.
+    per-request ``CodexRpcOutcomeUnknown`` values. The shared deadline preserves
+    responses received before a slower component times out.
     """
     if not isinstance(requests, list):
         raise TypeError("codex RPC batch must be a list")
@@ -161,21 +164,33 @@ async def codex_rpc_batch(
             raise ValueError("codex RPC method must be a non-empty string")
         if params is not None and not isinstance(params, dict):
             raise TypeError("codex RPC params must be a dict or None")
+    if not isinstance(timeout, (int, float)) or timeout <= 0:
+        raise ValueError("codex RPC timeout must be positive")
     if not requests:
         return []
 
-    bin_path = await asyncio.to_thread(_resolve_codex_bin)
+    deadline = asyncio.get_running_loop().time() + timeout
+
+    def remaining() -> float:
+        return max(0.0, deadline - asyncio.get_running_loop().time())
+
+    bin_path = await asyncio.wait_for(
+        asyncio.to_thread(_resolve_codex_bin), timeout=remaining(),
+    )
     workdir = os.path.realpath(os.path.expanduser(cwd or "~"))
-    proc = await asyncio.create_subprocess_exec(
-        bin_path,
-        "app-server",
-        "--stdio",
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.DEVNULL,
-        cwd=workdir,
-        env=_codex_env(bin_path),
-        limit=_STREAM_LIMIT,
+    proc = await asyncio.wait_for(
+        asyncio.create_subprocess_exec(
+            bin_path,
+            "app-server",
+            "--stdio",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+            cwd=workdir,
+            env=_codex_env(bin_path),
+            limit=_STREAM_LIMIT,
+        ),
+        timeout=remaining(),
     )
 
     async def send(message: dict[str, Any]) -> None:
@@ -184,7 +199,7 @@ async def codex_rpc_batch(
         proc.stdin.write(
             (json.dumps(message, separators=(",", ":")) + "\n").encode()
         )
-        await proc.stdin.drain()
+        await asyncio.wait_for(proc.stdin.drain(), timeout=remaining())
 
     async def response_for(request_id: int) -> Any:
         if proc.stdout is None:
@@ -214,7 +229,7 @@ async def codex_rpc_batch(
                 "clientInfo": {"name": "cc-remote", "version": __version__},
             },
         })
-        await asyncio.wait_for(response_for(1), timeout=_RPC_TIMEOUT)
+        await asyncio.wait_for(response_for(1), timeout=remaining())
         await send({"jsonrpc": "2.0", "method": "initialized"})
 
         pending: dict[int, int] = {}
@@ -259,7 +274,7 @@ async def codex_rpc_batch(
                     )
                     completed.add(index)
 
-            await asyncio.wait_for(collect(), timeout=_RPC_TIMEOUT)
+            await asyncio.wait_for(collect(), timeout=remaining())
         except asyncio.CancelledError:
             raise
         except Exception as exc:

--- a/cc_remote/wrapper/engine_capabilities.py
+++ b/cc_remote/wrapper/engine_capabilities.py
@@ -123,15 +123,19 @@ async def _codex_components(
     cwd: str,
 ) -> list[Any | Exception]:
     try:
-        return await asyncio.wait_for(
-            codex_rpc_batch(requests, cwd=cwd),
-            timeout=_COMPONENT_TIMEOUT,
+        return await codex_rpc_batch(
+            requests, cwd=cwd, timeout=_COMPONENT_TIMEOUT,
         )
     except Exception as exc:
         return [exc for _request in requests]
 
 
-async def codex_capabilities(cwd: str, space: str) -> tuple[list[dict], list[str], list[str]]:
+async def codex_capabilities(
+    cwd: str,
+    space: str,
+    *,
+    skills_only: bool = False,
+) -> tuple[list[dict], list[str], list[str]]:
     requests = {
         "skills": ("skills/list", {"cwds": [cwd], "forceReload": False}),
         "hooks": ("hooks/list", {"cwds": [cwd]}),
@@ -139,6 +143,8 @@ async def codex_capabilities(cwd: str, space: str) -> tuple[list[dict], list[str
         "apps": ("app/list", {"limit": _MAX_ITEMS}),
         "mcp": ("mcpServerStatus/list", {}),
     }
+    if skills_only:
+        requests = {"skills": requests["skills"]}
     results = await _codex_components(list(requests.values()), cwd)
     values = dict(zip(requests, results))
     items: list[dict] = []
@@ -180,7 +186,7 @@ async def codex_capabilities(cwd: str, space: str) -> tuple[list[dict], list[str
                     "actions": actions,
                 })
 
-    raw_hooks = values["hooks"]
+    raw_hooks = values.get("hooks")
     if isinstance(raw_hooks, Exception):
         errors.append("hooks: app-server request failed")
     elif isinstance(raw_hooks, dict):
@@ -217,7 +223,7 @@ async def codex_capabilities(cwd: str, space: str) -> tuple[list[dict], list[str
                 if warning and len(notes) < 32:
                     notes.append(f"Hook: {warning}")
 
-    raw_plugins = values["plugins"]
+    raw_plugins = values.get("plugins")
     if isinstance(raw_plugins, Exception):
         errors.append("plugins: app-server request failed")
     elif isinstance(raw_plugins, dict):
@@ -247,7 +253,7 @@ async def codex_capabilities(cwd: str, space: str) -> tuple[list[dict], list[str
                     ]),
                 })
 
-    raw_apps = values["apps"]
+    raw_apps = values.get("apps")
     if isinstance(raw_apps, Exception):
         errors.append("apps: app-server request failed")
     elif isinstance(raw_apps, dict):
@@ -267,7 +273,7 @@ async def codex_capabilities(cwd: str, space: str) -> tuple[list[dict], list[str
                 "install_url": _public_url(app.get("installUrl")),
             })
 
-    raw_mcp = values["mcp"]
+    raw_mcp = values.get("mcp")
     if isinstance(raw_mcp, Exception):
         errors.append("mcp: app-server request failed")
     elif isinstance(raw_mcp, dict):
@@ -888,13 +894,19 @@ async def manage_engine_plugin(
 
 
 async def claude_capabilities(
-    cwd: str, space: str, claude_bin: str = ""
+    cwd: str,
+    space: str,
+    claude_bin: str = "",
+    *,
+    skills_only: bool = False,
 ) -> tuple[list[dict], list[str], list[str]]:
     if space == "work":
         return [], [], [
             "Claude Work 为防止 Code 配置泄漏，明确禁用了用户/项目技能、插件、Hook 与 MCP。"
         ]
     items = await asyncio.to_thread(_claude_skills, cwd)
+    if skills_only:
+        return items[:2000], [], []
     items.extend(await asyncio.to_thread(_claude_hooks, cwd))
     errors: list[str] = []
     try:
@@ -906,11 +918,20 @@ async def claude_capabilities(
 
 
 async def engine_capabilities(
-    engine: str, cwd: str, space: str, claude_bin: str = ""
+    engine: str,
+    cwd: str,
+    space: str,
+    claude_bin: str = "",
+    *,
+    skills_only: bool = False,
 ):
     target = os.path.realpath(os.path.expanduser(cwd))
     if not os.path.isdir(target):
         raise ValueError("capability cwd does not exist")
     if engine == "codex":
-        return await codex_capabilities(target, space)
-    return await claude_capabilities(target, space, claude_bin)
+        return await codex_capabilities(
+            target, space, skills_only=skills_only,
+        )
+    return await claude_capabilities(
+        target, space, claude_bin, skills_only=skills_only,
+    )

--- a/cc_remote/wrapper/machine.py
+++ b/cc_remote/wrapper/machine.py
@@ -7765,7 +7765,11 @@ class WrapperMachine:
         client_id = getattr(cmd, "client_id", None)
         try:
             items, errors, notes = await engine_capabilities(
-                engine, target_cwd, space, self.cfg.claude_bin
+                engine,
+                target_cwd,
+                space,
+                self.cfg.claude_bin,
+                skills_only=getattr(cmd, "skills_only", False),
             )
         except Exception:
             log.exception(
@@ -7775,9 +7779,12 @@ class WrapperMachine:
         result = EngineCapabilities(
             engine=engine,
             space=space,
+            request_id=getattr(cmd, "cmd_id", None),
+            cwd=target_cwd,
             items=items,
             errors=errors,
             notes=notes,
+            skills_only=getattr(cmd, "skills_only", False),
             to=client_id,
         )
         await self.transport.send(result)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -60,11 +60,11 @@ machine). The **full step-by-step guide is in the main [README](../README.md#生
   template. The runtime reads the current user's mode-0600 device JSON instead
   of embedding control credentials in the plist.
 
-Protocol v25 is a coordinated upgrade: publish freshly built Relay/Web and
+Protocol v26 is a coordinated upgrade: publish freshly built Relay/Web and
 Wrapper artifacts from the same tagged commit. The strict protocol gate is
 intentional and mixed protocol versions will not communicate. `setup-vps.sh`
 rejects a missing or mismatched web build manifest. Stop the wrapper first;
-activate the v25 relay/web release; then start the v25 wrapper.
+activate the v26 relay/web release; then start the v26 wrapper.
 
 ## Native terminal coordination
 

--- a/tests/test_atomic_new_session.py
+++ b/tests/test_atomic_new_session.py
@@ -9,7 +9,6 @@ from pydantic import ValidationError
 from cc_remote.wrapper import machine as machine_module
 from cc_remote.protocol import (
     ERR_INVALID_CWD,
-    PROTOCOL_VERSION,
     NewSession,
     SessionFocus,
     TurnBinding,
@@ -22,8 +21,7 @@ from tests.test_multisession import _mk_ctx, _mk_machine
 _PNG_1X1 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
 
 
-def test_protocol_v25_new_session_query_and_turn_binding_roundtrip():
-    assert PROTOCOL_VERSION == 25
+def test_new_session_query_and_turn_binding_roundtrip():
     msg = NewSession(
         request_id="req-1",
         cwd="/tmp/project",

--- a/tests/test_codex_rpc.py
+++ b/tests/test_codex_rpc.py
@@ -34,6 +34,20 @@ class _FakeStdout:
         return self.lines.pop(0) if self.lines else b""
 
 
+class _BlockingFakeStdout(_FakeStdout):
+    async def readline(self) -> bytes:
+        if self.lines:
+            return self.lines.pop(0)
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+
+class _BackpressuredFakeStdin(_FakeStdin):
+    async def drain(self) -> None:
+        if len(self.writes) >= 3:
+            await asyncio.Event().wait()
+
+
 class _FakeProcess:
     def __init__(self, messages):
         self.stdin = _FakeStdin()
@@ -153,6 +167,78 @@ def test_codex_rpc_batch_uses_one_process_and_preserves_partial_results(
             "mcpServerStatus/list",
         ]
         assert [message.get("id") for message in messages[2:]] == [2, 3, 4]
+        assert process.stdin.closed is True
+        assert process.terminated is True and process.killed is False
+
+    asyncio.run(run())
+
+
+def test_codex_rpc_batch_timeout_preserves_completed_results(
+    monkeypatch, tmp_path,
+):
+    async def run():
+        process = _FakeProcess([])
+        process.stdout = _BlockingFakeStdout([
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+            {"jsonrpc": "2.0", "id": 2, "result": {"skills": True}},
+        ])
+
+        async def create_subprocess_exec(*_args, **_kwargs):
+            return process
+
+        monkeypatch.setattr(
+            codex_rpc_module, "_resolve_codex_bin", lambda: "/bin/codex"
+        )
+        monkeypatch.setattr(codex_rpc_module, "_codex_env", lambda _path: {})
+        monkeypatch.setattr(
+            codex_rpc_module.asyncio,
+            "create_subprocess_exec",
+            create_subprocess_exec,
+        )
+
+        results = await codex_rpc_module.codex_rpc_batch([
+            ("skills/list", {"cwds": [str(tmp_path)]}),
+            ("mcpServerStatus/list", None),
+        ], cwd=str(tmp_path), timeout=0.1)
+
+        assert results[0] == {"skills": True}
+        assert isinstance(results[1], codex_rpc_module.CodexRpcOutcomeUnknown)
+        assert process.stdin.closed is True
+        assert process.terminated is True and process.killed is False
+
+    asyncio.run(run())
+
+
+def test_codex_rpc_batch_deadline_covers_request_backpressure(
+    monkeypatch, tmp_path,
+):
+    async def run():
+        process = _FakeProcess([
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+        ])
+        process.stdin = _BackpressuredFakeStdin()
+
+        async def create_subprocess_exec(*_args, **_kwargs):
+            return process
+
+        monkeypatch.setattr(
+            codex_rpc_module, "_resolve_codex_bin", lambda: "/bin/codex"
+        )
+        monkeypatch.setattr(codex_rpc_module, "_codex_env", lambda _path: {})
+        monkeypatch.setattr(
+            codex_rpc_module.asyncio,
+            "create_subprocess_exec",
+            create_subprocess_exec,
+        )
+
+        results = await asyncio.wait_for(
+            codex_rpc_module.codex_rpc_batch([
+                ("skills/list", {"cwds": [str(tmp_path)]}),
+            ], cwd=str(tmp_path), timeout=0.1),
+            timeout=0.5,
+        )
+
+        assert isinstance(results[0], codex_rpc_module.CodexRpcOutcomeUnknown)
         assert process.stdin.closed is True
         assert process.terminated is True and process.killed is False
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -546,7 +546,7 @@ def test_setup_protocol_gate_has_no_release_specific_literal():
     assert not re.search(r'"protocol"[^\n]*[0-9]+', source)
 
 
-def test_release_docs_and_examples_describe_one_atomic_v25_layout():
+def test_release_docs_and_examples_describe_one_atomic_v26_layout():
     deploy_readme = (ROOT / "deploy" / "README.md").read_text()
     readme = (ROOT / "README.md").read_text()
     readme_en = (ROOT / "README_en.md").read_text()
@@ -559,10 +559,10 @@ def test_release_docs_and_examples_describe_one_atomic_v25_layout():
     relay_env = (ROOT / "deploy" / "env.relay.example").read_text()
     unit = (ROOT / "deploy" / "cc-remote-relay.service").read_text()
 
-    assert "Protocol v25" in deploy_readme
+    assert "Protocol v26" in deploy_readme
     assert "v14" not in deploy_readme
     for document in (deploy_readme, readme, readme_en):
-        assert "v25" in document
+        assert "v26" in document
         assert "v16" not in document
         assert "v18" not in document
         assert "sudo rsync -a --delete" not in document
@@ -577,7 +577,7 @@ def test_release_docs_and_examples_describe_one_atomic_v25_layout():
     assert "WorkingDirectory=/opt/cc-remote/current" in unit
     assert "ExecStart=/opt/cc-remote/current/.venv/bin/python" in unit
     assert "claude-agent-sdk==0.2.128" in claude
-    assert "protocol v25" in claude
+    assert "protocol v26" in claude
     assert "0.2.110" not in claude
     assert "protocol v10" not in claude
 

--- a/tests/test_engine_capabilities.py
+++ b/tests/test_engine_capabilities.py
@@ -361,6 +361,107 @@ def test_codex_capabilities_include_native_hooks_as_read_only(monkeypatch, tmp_p
     asyncio.run(run())
 
 
+def test_codex_capabilities_keep_skills_when_another_component_times_out(
+    monkeypatch, tmp_path,
+):
+    async def run():
+        skill_path = tmp_path / ".codex" / "skills" / "example" / "SKILL.md"
+
+        async def batch(requests, cwd, *, timeout):
+            assert cwd == str(tmp_path)
+            assert timeout == capabilities_module._COMPONENT_TIMEOUT
+            responses = {
+                "skills/list": {"data": [{"skills": [{
+                    "name": "example",
+                    "path": str(skill_path),
+                    "scope": "repo",
+                    "enabled": True,
+                }]}]},
+                "hooks/list": RuntimeError("timed out"),
+                "plugin/list": RuntimeError("timed out"),
+                "app/list": RuntimeError("timed out"),
+                "mcpServerStatus/list": RuntimeError("timed out"),
+            }
+            return [responses[method] for method, _params in requests]
+
+        monkeypatch.setattr(capabilities_module, "codex_rpc_batch", batch)
+        items, errors, _notes = await capabilities_module.codex_capabilities(
+            str(tmp_path), "code"
+        )
+
+        assert [item["name"] for item in items if item["kind"] == "skill"] == [
+            "example"
+        ]
+        assert errors == [
+            "hooks: app-server request failed",
+            "plugins: app-server request failed",
+            "apps: app-server request failed",
+            "mcp: app-server request failed",
+        ]
+
+    asyncio.run(run())
+
+
+def test_codex_skills_only_skips_unrelated_component_requests(
+    monkeypatch, tmp_path,
+):
+    async def run():
+        skill_path = tmp_path / ".codex" / "skills" / "example" / "SKILL.md"
+        seen = []
+
+        async def components(requests, cwd):
+            seen.extend(requests)
+            assert cwd == str(tmp_path)
+            return [{"data": [{"skills": [{
+                "name": "example",
+                "path": str(skill_path),
+                "scope": "repo",
+                "enabled": True,
+            }]}]}]
+
+        monkeypatch.setattr(capabilities_module, "_codex_components", components)
+        items, errors, notes = await capabilities_module.codex_capabilities(
+            str(tmp_path), "code", skills_only=True
+        )
+
+        assert [method for method, _params in seen] == ["skills/list"]
+        assert [item["name"] for item in items] == ["example"]
+        assert errors == []
+        assert notes == []
+
+    asyncio.run(run())
+
+
+def test_claude_skills_only_does_not_spawn_plugin_cli(monkeypatch, tmp_path):
+    async def run():
+        monkeypatch.setattr(capabilities_module, "_claude_skills", lambda _cwd: [{
+            "kind": "skill",
+            "id": "skill:example",
+            "name": "example",
+            "enabled": True,
+            "scope": "user",
+            "actions": ["remove"],
+        }])
+        monkeypatch.setattr(
+            capabilities_module,
+            "resolve_claude_cli",
+            lambda _configured: pytest.fail(
+                "skills-only discovery must not resolve the plugin CLI"
+            ),
+        )
+
+        items, errors, notes = await capabilities_module.engine_capabilities(
+            "claude", str(tmp_path), "code", "/configured/claude",
+            skills_only=True,
+        )
+
+        assert [item["name"] for item in items] == ["example"]
+        assert errors == []
+        assert notes == []
+
+    asyncio.run(run())
+
+
 @pytest.mark.parametrize("kind", ["skill", "hook"])
 def test_work_rejects_extension_mutations(kind, tmp_path):
     async def run():
@@ -474,7 +575,7 @@ def test_machine_forwards_configured_cli_to_capability_listing(
     monkeypatch, tmp_path
 ):
     async def run():
-        machine, _ = _mk_machine()
+        machine, transport = _mk_machine()
         machine.cfg.claude_bin = "/configured/claude"
         machine._focused_ctx = lambda: SimpleNamespace(
             engine="claude",
@@ -483,20 +584,26 @@ def test_machine_forwards_configured_cli_to_capability_listing(
         )
         seen = []
 
-        async def discover(engine, cwd, space, claude_bin):
-            seen.append((engine, cwd, space, claude_bin))
+        async def discover(
+            engine, cwd, space, claude_bin, *, skills_only=False,
+        ):
+            seen.append((engine, cwd, space, claude_bin, skills_only))
             return [], [], []
 
         monkeypatch.setattr(machine_module, "engine_capabilities", discover)
         await machine._handle_get_engine_capabilities(
             GetEngineCapabilities(
-                engine="claude", cwd=str(tmp_path), client_id="client-1"
+                engine="claude", cwd=str(tmp_path), client_id="client-1",
+                cmd_id="capabilities-1", skills_only=True,
             )
         )
 
         assert seen == [
-            ("claude", str(tmp_path), "code", "/configured/claude")
+            ("claude", str(tmp_path), "code", "/configured/claude", True)
         ]
+        assert transport.sent[-1].request_id == "capabilities-1"
+        assert transport.sent[-1].cwd == str(tmp_path)
+        assert transport.sent[-1].skills_only is True
 
     asyncio.run(run())
 

--- a/tests/test_product_version.py
+++ b/tests/test_product_version.py
@@ -45,7 +45,7 @@ def test_release_docs_distinguish_product_and_wire_protocol_versions():
     assert "## What changed in v3" in readme_en
     for document in (readme, readme_en, changelog):
         assert "v3.0.0" in document
-        assert "protocol v25" in document.lower()
+        assert "protocol v26" in document.lower()
 
 
 def test_readmes_use_safe_markdown_for_navigation_and_images():

--- a/tests/test_protocol_input_bounds.py
+++ b/tests/test_protocol_input_bounds.py
@@ -16,6 +16,7 @@ from cc_remote.protocol import (
     ForkSessionWorktree,
     GetDiff,
     GetFilePreview,
+    GetEngineCapabilities,
     GetModels,
     GetPreviewAsset,
     ManageEngineHook,
@@ -188,6 +189,9 @@ def test_known_dynamic_control_values_remain_supported():
     assert SetCollaborationMode(mode="default").mode == "default"
     assert SetPerm(mode="on-request").mode == "on-request"
     assert GetModels(engine="cc", cwd="/tmp/project").cwd == "/tmp/project"
+    assert GetEngineCapabilities(
+        engine="codex", skills_only=True
+    ).skills_only is True
     assert ForkSessionWorktree(
         session_id="sid-1", request_id="request-1", name="feature",
     ).name == "feature"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,11 +11,14 @@
       "dependencies": {
         "@tanstack/react-virtual": "3.14.8",
         "dompurify": "^3.4.12",
+        "katex": "0.16.47",
         "mermaid": "11.16.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-markdown": "^10.1.0",
+        "rehype-katex": "7.0.1",
         "remark-gfm": "^4.0.1",
+        "remark-math": "6.0.0",
         "shiki": "^4.3.1"
       },
       "devDependencies": {
@@ -1176,6 +1179,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmmirror.com/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -1954,6 +1963,18 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-toolkit": {
       "version": "1.50.0",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
@@ -2032,6 +2053,101 @@
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -2082,6 +2198,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -2089,6 +2221,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmmirror.com/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2684,6 +2833,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -3022,6 +3190,25 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -3527,6 +3714,18 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmmirror.com/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -3727,6 +3926,25 @@
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmmirror.com/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -3738,6 +3956,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -4043,6 +4277,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -4063,6 +4311,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4132,6 +4394,20 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4228,6 +4504,16 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/zwitch": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,11 +21,14 @@
   "dependencies": {
     "@tanstack/react-virtual": "3.14.8",
     "dompurify": "^3.4.12",
+    "katex": "0.16.47",
     "mermaid": "11.16.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",
+    "rehype-katex": "7.0.1",
     "remark-gfm": "^4.0.1",
+    "remark-math": "6.0.0",
     "shiki": "^4.3.1"
   },
   "devDependencies": {

--- a/web/public/cc-remote-build.json
+++ b/web/public/cc-remote-build.json
@@ -1,1 +1,1 @@
-{"version":"3.0.0","protocol":25}
+{"version":"3.0.0","protocol":26}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1577,6 +1577,7 @@ export default function App() {
                     type: "turn_detail_requested", sid: detailTarget.sid,
                     turnId: detailTarget.turnId,
                     before: detailTarget.before,
+                    autoLoad: detailTarget.autoLoad,
                   });
                 }
               });
@@ -2373,6 +2374,7 @@ export default function App() {
 
   const loadHistoryTurnDetail = useCallback((
     displayTurnId: string, before?: string | null,
+    autoLoad = true,
   ): boolean => {
     const current = stateRef.current;
     const sid = current.focusedSid;
@@ -2405,6 +2407,7 @@ export default function App() {
           revision: runtime.historyRevision,
           turnId,
           before,
+          autoLoad,
         };
     if (!historyDetailRequestsRef.current.begin(context)) return false;
     const sent = wsRef.current?.sendGetTurnDetail(
@@ -2425,10 +2428,26 @@ export default function App() {
         before,
       });
     } else {
-      dispatch({ type: "turn_detail_requested", sid, turnId, before });
+      dispatch({
+        type: "turn_detail_requested", sid, turnId, before, autoLoad,
+      });
     }
     return true;
   }, [focusedEngine, historyPageScopeFor, space]);
+  useEffect(() => {
+    const current = stateRef.current;
+    const sid = current.focusedSid;
+    const runtime = sid ? current.runtimes[sid] : null;
+    if (!sid || !runtime || current.historyBrowse?.sid === sid) return;
+    // Restore only the newest affected row and only its newest detail page.
+    // Older rows retain their instant cached projection until the user opens
+    // them, avoiding a refresh-triggered multi-megabyte pagination cascade.
+    const target = [...runtime.turns].reverse().find((turn) =>
+      turn.detailRestorePending === true && turn.detailLoading !== true);
+    if (!target) return;
+    loadHistoryTurnDetail(target.id, undefined, false);
+  }, [loadHistoryTurnDetail, state.historyBrowse, state.runtimes,
+    state.focusedSid]);
   useEffect(() => {
     const current = stateRef.current;
     const sid = current.focusedSid;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -160,22 +160,18 @@ import {
 } from "./completion-badges";
 import {
   cacheSkillCatalog,
+  SkillCatalogRequestCoordinator,
   skillCatalogFresh,
   skillCatalogKey,
+  skillCatalogRefreshSucceeded,
   type SkillCatalogCacheEntry,
+  type SkillCatalogRequest,
 } from "./skill-catalog-cache";
 
 const THEME_KEY = "cc_remote_theme";
 const ENGINE_KEY = "cc_remote_engine";  // which backend the NEXT new session uses
 const SPACE_KEY = "cc_remote_space";
 const MACHINE_KEY = "cc_remote_machine";
-
-interface SkillCatalogRequest {
-  key: string;
-  engine: Engine;
-  space: Space;
-  cwd: string;
-}
 
 interface QueuedQueryEditorState extends QueuedQueryEditor {
   detailRequestId: string | null;
@@ -223,7 +219,8 @@ export default function App() {
   const [capabilitiesKind, setCapabilitiesKind] = useState<EngineCapabilityKind | "all">("all");
   const [capabilitiesLoading, setCapabilitiesLoading] = useState(false);
   const [deviceSheetOpen, setDeviceSheetOpen] = useState(false);
-  const [capabilitiesBySurface, setCapabilitiesBySurface] = useState<Record<string, EngineCapabilities>>({});
+  const [capabilitiesByScope, setCapabilitiesByScope] =
+    useState<Record<string, EngineCapabilities>>({});
   const [skillCatalogs, setSkillCatalogs] =
     useState<Record<string, SkillCatalogCacheEntry>>({});
   const [notificationMode, setNotificationMode] = useState<NotificationMode>(
@@ -295,15 +292,24 @@ export default function App() {
   const wsRef = useRef<RelayWs | null>(null);
   const skillCatalogsRef =
     useRef<Record<string, SkillCatalogCacheEntry>>({});
-  const skillCatalogReadsRef = useRef<{
-    active: SkillCatalogRequest | null;
-    queued: Map<string, SkillCatalogRequest>;
-  }>({ active: null, queued: new Map() });
+  const skillCatalogRequestsRef =
+    useRef<SkillCatalogRequestCoordinator | null>(null);
+  if (skillCatalogRequestsRef.current === null) {
+    skillCatalogRequestsRef.current = new SkillCatalogRequestCoordinator(
+      (request) => wsRef.current?.sendGetEngineCapabilities(
+        request.engine,
+        request.space,
+        request.cwd,
+        request.skillsOnly,
+      ) ?? null,
+    );
+  }
   const focusedSkillScopeRef = useRef<{
     key: string;
     engine: Engine;
     space: Space;
     cwd: string;
+    skillsOnly: boolean;
   } | null>(null);
   const historyRequestsRef = useRef(new HistoryRequestCoordinator());
   const historyDetailRequestsRef = useRef(new HistoryDetailRequestCoordinator(
@@ -452,8 +458,9 @@ export default function App() {
     notificationListRequestRef.current = null;
     sessionActivityPendingRef.current.clear();
     skillCatalogsRef.current = {};
-    skillCatalogReadsRef.current = { active: null, queued: new Map() };
+    skillCatalogRequestsRef.current?.reset();
     setSkillCatalogs({});
+    setCapabilitiesByScope({});
     deferredStatusRefreshRef.current.clear();
     historyRequestsRef.current.clear();
     clearHistoryDetailRequests();
@@ -520,6 +527,7 @@ export default function App() {
     engine: focusedEngine,
     space,
     cwd: capabilityCwd,
+    skillsOnly: true,
   };
   const activeBtwDraftKey = composerDraftKey(
     machineId, space,
@@ -592,50 +600,40 @@ export default function App() {
     force = false,
   ) => {
     const cached = skillCatalogsRef.current[request.key];
-    if (!force && skillCatalogFresh(cached)) return false;
-    const reads = skillCatalogReadsRef.current;
-    if (reads.active) {
-      if (reads.active.key !== request.key) {
-        reads.queued.set(request.key, request);
-      }
-      return false;
-    }
-    const ws = wsRef.current;
-    if (!ws) return false;
-    reads.active = request;
-    ws.sendGetEngineCapabilities(
-      request.engine, request.space, request.cwd);
-    return true;
+    if (request.skillsOnly && !force && skillCatalogFresh(cached)) return false;
+    return skillCatalogRequestsRef.current?.request(request) ?? false;
   }, []);
   const acceptSkillCatalog = useCallback((msg: EngineCapabilities) => {
-    const reads = skillCatalogReadsRef.current;
-    const active = reads.active;
-    if (active && active.engine === msg.engine && active.space === msg.space) {
+    const coordinator = skillCatalogRequestsRef.current;
+    if (!coordinator) return;
+    const accepted = coordinator.accept(msg);
+    if (!accepted) return;
+    const matchedScope = accepted.request;
+    if (!accepted.superseded && skillCatalogRefreshSucceeded(msg)) {
       storeSkillCatalog(
-        active.key, msg.items.filter((item) => item.kind === "skill"));
-      reads.active = null;
-      const next = reads.queued.values().next().value as
-        SkillCatalogRequest | undefined;
-      if (next) {
-        reads.queued.delete(next.key);
-        const ws = wsRef.current;
-        if (ws) {
-          reads.active = next;
-          ws.sendGetEngineCapabilities(next.engine, next.space, next.cwd);
-        }
-      }
-      return;
-    }
-    // Capability mutations also return a fresh full catalog. Adopt it for the
-    // currently focused cwd when no explicit read owns the response.
-    const focused = focusedSkillScopeRef.current;
-    if (!active && focused
-        && msg.engine === focused.engine && msg.space === focused.space) {
-      storeSkillCatalog(
-        focused.key,
+        matchedScope.key,
         msg.items.filter((item) => item.kind === "skill"));
     }
+    if (!accepted.superseded && !msg.skills_only) {
+      setCapabilitiesByScope((current) => ({
+        ...current,
+        [matchedScope.key]: msg,
+      }));
+    }
+    if (focusedSkillScopeRef.current?.key === matchedScope.key
+        && !coordinator.hasPendingMutation(matchedScope.key)
+        && !coordinator.hasPendingRead(matchedScope.key, false)) {
+      setCapabilitiesLoading(false);
+    }
   }, [storeSkillCatalog]);
+  const trackCapabilityMutation = useCallback((
+    requestId: string | null | undefined,
+    request: SkillCatalogRequest,
+  ) => {
+    if (!skillCatalogRequestsRef.current?.trackMutation(requestId, request)) {
+      setCapabilitiesLoading(false);
+    }
+  }, []);
   const loadMessageImage = useCallback((sid: string, path: string): boolean => {
     const ws = wsRef.current;
     if (!ws || stateRef.current.focusedSid !== sid) return false;
@@ -1896,12 +1894,6 @@ export default function App() {
           }
           if (msg.type === "engine_capabilities") {
             acceptSkillCatalog(msg);
-            setCapabilitiesBySurface((current) => ({
-              ...current, [`${msg.space}:${msg.engine}`]: msg,
-            }));
-            if (msg.space === spaceRef.current && msg.engine === engineRef.current) {
-              setCapabilitiesLoading(false);
-            }
           }
           if (msg.type === "turn_end" && msg.sid && msg.notification_context
               && document.hidden
@@ -1995,10 +1987,7 @@ export default function App() {
           if (msg.type === "wrapper_reconnected") {
             skillCatalogsRef.current = {};
             setSkillCatalogs({});
-            skillCatalogReadsRef.current = {
-              active: null,
-              queued: new Map(),
-            };
+            skillCatalogRequestsRef.current?.resetReads();
             const focusedSkills = focusedSkillScopeRef.current;
             if (focusedSkills?.engine === "codex" && focusedSkills.cwd) {
               requestSkillCatalog(focusedSkills, true);
@@ -2035,10 +2024,7 @@ export default function App() {
         onConnState: (s, detail) => {
           dispatch({ type: "conn", connState: s, detail });
           if (s !== "connected") {
-            skillCatalogReadsRef.current = {
-              active: null,
-              queued: new Map(),
-            };
+            skillCatalogRequestsRef.current?.resetReads();
           }
           if (s === "connected") {
             recoverableReads.clear();
@@ -2073,6 +2059,10 @@ export default function App() {
           historyInvalidationGenerationsRef.current.clear();
           historyCacheEpochRef.current.clear();
           historySessionListsRef.current = {};
+          skillCatalogsRef.current = {};
+          skillCatalogRequestsRef.current?.reset();
+          setSkillCatalogs({});
+          setCapabilitiesByScope({});
           inlineImageAssetsRef.current.clear();
           historyImageAssetsRef.current.clear();
           bumpInlineImageRevision();
@@ -2230,6 +2220,7 @@ export default function App() {
       engine: focusedEngine,
       space,
       cwd: capabilityCwd,
+      skillsOnly: true,
     });
   }, [
     authed,
@@ -2241,6 +2232,32 @@ export default function App() {
     space,
     state.connState,
     state.newChat,
+    state.wrapperOnline,
+  ]);
+
+  // An open Extensions sheet follows the focused authorization scope. Switching
+  // device, engine, space, or cwd must fetch that scope instead of retaining a
+  // report from the previously visible session.
+  useEffect(() => {
+    if (!capabilitiesOpen || !authed || state.connState !== "connected"
+        || !state.wrapperOnline) return;
+    setCapabilitiesLoading(true);
+    requestSkillCatalog({
+      key: focusedSkillCatalogKey,
+      engine: focusedEngine,
+      space,
+      cwd: capabilityCwd,
+      skillsOnly: false,
+    }, true);
+  }, [
+    authed,
+    capabilitiesOpen,
+    capabilityCwd,
+    focusedEngine,
+    focusedSkillCatalogKey,
+    requestSkillCatalog,
+    space,
+    state.connState,
     state.wrapperOnline,
   ]);
 
@@ -3611,6 +3628,7 @@ export default function App() {
               engine: focusedEngine,
               space,
               cwd: capabilityCwd,
+              skillsOnly: false,
             }, true);
           }}
           skills={skillCatalogs[focusedSkillCatalogKey]?.items}
@@ -3620,6 +3638,7 @@ export default function App() {
               engine: focusedEngine,
               space,
               cwd: capabilityCwd,
+              skillsOnly: true,
             });
           }}
           workArtifactCount={space === "work" ? currentWorkArtifacts.length : 0}
@@ -3760,7 +3779,7 @@ export default function App() {
         engine={focusedEngine}
         activeKind={capabilitiesKind}
         readOnly={space === "work"}
-        report={capabilitiesBySurface[`${space}:${focusedEngine}`] ?? null}
+        report={capabilitiesByScope[focusedSkillCatalogKey] ?? null}
         loading={capabilitiesLoading}
         onKindChange={setCapabilitiesKind}
         onRefresh={() => {
@@ -3770,42 +3789,63 @@ export default function App() {
             engine: focusedEngine,
             space,
             cwd: capabilityCwd,
+            skillsOnly: false,
           }, true);
         }}
         onManagePlugin={(item, action) => {
           const verb = action === "install" ? "安装" : "卸载";
           if (!window.confirm(`${verb}插件「${item.name}」将修改本机 ${focusedEngine === "codex" ? "Codex" : "Claude"} 配置，确定继续吗？`)) return;
           setCapabilitiesLoading(true);
-          wsRef.current?.sendManageEnginePlugin(
+          const requestId = wsRef.current?.sendManageEnginePlugin(
             focusedEngine, space, action, item.id,
-            state.newChat?.cwd ?? currentCwd);
+            capabilityCwd);
+          trackCapabilityMutation(requestId, {
+            key: focusedSkillCatalogKey, engine: focusedEngine, space,
+            cwd: capabilityCwd, skillsOnly: false,
+          });
         }}
         onManageSkill={(item: EngineCapabilityItem, action) => {
           const labels = { enable: "启用", disable: "停用", remove: "删除" } as const;
           if (!window.confirm(`${labels[action]} Skill「${item.name}」？${action === "remove" ? "删除会移动到本机可恢复回收目录。" : ""}`)) return;
           setCapabilitiesLoading(true);
-          wsRef.current?.sendManageEngineSkill(
+          const requestId = wsRef.current?.sendManageEngineSkill(
             focusedEngine, space, action, { skillId: item.id },
-            state.newChat?.cwd ?? currentCwd);
+            capabilityCwd);
+          trackCapabilityMutation(requestId, {
+            key: focusedSkillCatalogKey, engine: focusedEngine, space,
+            cwd: capabilityCwd, skillsOnly: false,
+          });
         }}
         onCreateSkill={(draft: SkillDraft) => {
           setCapabilitiesLoading(true);
-          wsRef.current?.sendManageEngineSkill(
+          const requestId = wsRef.current?.sendManageEngineSkill(
             focusedEngine, space, "create", draft,
-            state.newChat?.cwd ?? currentCwd);
+            capabilityCwd);
+          trackCapabilityMutation(requestId, {
+            key: focusedSkillCatalogKey, engine: focusedEngine, space,
+            cwd: capabilityCwd, skillsOnly: false,
+          });
         }}
         onRemoveHook={(item: EngineCapabilityItem) => {
           if (!window.confirm(`删除 Hook「${item.name}」？配置文件中的其他内容会原样保留。`)) return;
           setCapabilitiesLoading(true);
-          wsRef.current?.sendManageEngineHook(
+          const requestId = wsRef.current?.sendManageEngineHook(
             focusedEngine, space, "remove", { hookId: item.id },
-            state.newChat?.cwd ?? currentCwd);
+            capabilityCwd);
+          trackCapabilityMutation(requestId, {
+            key: focusedSkillCatalogKey, engine: focusedEngine, space,
+            cwd: capabilityCwd, skillsOnly: false,
+          });
         }}
         onCreateHook={(draft: HookDraft) => {
           setCapabilitiesLoading(true);
-          wsRef.current?.sendManageEngineHook(
+          const requestId = wsRef.current?.sendManageEngineHook(
             focusedEngine, space, "create", draft,
-            state.newChat?.cwd ?? currentCwd);
+            capabilityCwd);
+          trackCapabilityMutation(requestId, {
+            key: focusedSkillCatalogKey, engine: focusedEngine, space,
+            cwd: capabilityCwd, skillsOnly: false,
+          });
         }}
         onClose={() => setCapabilitiesOpen(false)} />
       <DeviceSheet open={deviceSheetOpen}

--- a/web/src/cache.ts
+++ b/web/src/cache.ts
@@ -9,6 +9,9 @@
 import {
   isSessionControl, sessionControlTargetsSid, type SessionControl,
 } from "./protocol.ts";
+import type {
+  Block, ProcessBlock, TextBlock, ToolBlock, Turn,
+} from "./domain/conversation.ts";
 
 const DB_NAME = "cc_remote_cache";
 const STORE = "sessions";
@@ -24,10 +27,17 @@ const SCHEMA = 1;
 // cannot fall back to an unrevisioned terminal lock. v9 discards projections
 // written by the old open-turn History merge, which could persist duplicate
 // assistant blocks after switching away from and back to a running session.
-const CACHE_VER = 9;
+// v10 separates the instant timeline skeleton from heavyweight detail so one
+// image or tool output can no longer evict an otherwise valid completed turn.
+const CACHE_VER = 10;
 const MAX_CACHE_SESSIONS = 64;
 const MAX_CACHE_TURNS = 100;
 const MAX_CACHE_BYTES = 2 * 1024 * 1024;
+const CACHE_PROMPT_CHARS = 128 * 1024;
+const CACHE_FINAL_TEXT_CHARS = 512 * 1024;
+const CACHE_PROCESS_TEXT_CHARS = 256 * 1024;
+const CACHE_PROCESS_DETAIL_CHARS = 512 * 1024;
+const CACHE_IMAGE_CHARS = 384 * 1024;
 
 interface ReplayRecord {
   sid: string;
@@ -43,38 +53,308 @@ function retainNewest(records: ReplayRecord[], record: ReplayRecord): void {
   if (records.length > MAX_CACHE_SESSIONS) records.length = MAX_CACHE_SESSIONS;
 }
 
-/** Bound the structured clone written for one session. Large image turns are
- * intentionally omitted from the instant-paint cache; authoritative history is
- * fetched on focus, while the replay cursor remains stored separately. */
-export function boundCachedTurns(turns: unknown[]): unknown[] {
-  const candidates = turns.slice(-MAX_CACHE_TURNS).map((turn) => {
-    if (!turn || typeof turn !== "object" || Array.isArray(turn)) return turn;
-    const record = turn as Record<string, unknown>;
-    if (!Array.isArray(record.files)) return turn;
-    // QueryFile.data is needed only until the command is put on the wire.  The
-    // transcript protocol intentionally echoes metadata only, so make the
-    // best-effort local cache obey the same rule even if an optimistic turn from
-    // an older caller still contains the original body.
+function clipCacheString(value: string | null | undefined, limit: number):
+    string | null | undefined {
+  if (value == null || value.length <= limit) return value;
+  if (limit <= 1) return "…".slice(0, limit);
+  const marker = "…";
+  const content = limit - marker.length;
+  const head = Math.ceil(content / 2);
+  return value.slice(0, head) + marker + value.slice(-(content - head));
+}
+
+function compactCacheValue(
+  value: unknown,
+  limit: number,
+  depth = 0,
+): unknown {
+  if (value == null || typeof value === "boolean"
+      || typeof value === "number") return value;
+  if (typeof value === "string") return clipCacheString(value, limit);
+  if (depth >= 2) return "…";
+  if (Array.isArray(value)) {
+    return value.slice(0, 16).map((item) =>
+      compactCacheValue(item, Math.max(64, Math.floor(limit / 16)), depth + 1));
+  }
+  if (typeof value !== "object") return String(value);
+  const result: Record<string, unknown> = {};
+  const entries = Object.entries(value as Record<string, unknown>).slice(0, 32);
+  const itemLimit = Math.max(64, Math.floor(limit / Math.max(1, entries.length)));
+  for (const [key, item] of entries) {
+    result[clipCacheString(key, 256) ?? key] =
+      compactCacheValue(item, itemLimit, depth + 1);
+  }
+  if (Object.keys(value as object).length > entries.length) {
+    result._truncated = true;
+  }
+  return result;
+}
+
+function compactToolBlock(
+  block: ToolBlock,
+  detailBudget: { remaining: number },
+): ToolBlock {
+  const take = (value: string | null | undefined, limit: number) => {
+    const available = Math.max(0, Math.min(limit, detailBudget.remaining));
+    const clipped = clipCacheString(value, available);
+    detailBudget.remaining -= clipped?.length ?? 0;
+    return clipped;
+  };
+  const inputLimit = Math.min(8 * 1024, detailBudget.remaining);
+  const input = compactCacheValue(block.input, inputLimit);
+  detailBudget.remaining -= JSON.stringify(input)?.length ?? 0;
+  return {
+    ...block,
+    input: input && typeof input === "object" && !Array.isArray(input)
+      ? input as Record<string, unknown> : {},
+    title: clipCacheString(block.title, 1024),
+    server: clipCacheString(block.server, 1024) ?? undefined,
+    progress: take(block.progress, 8 * 1024) ?? undefined,
+    output: take(block.output, 16 * 1024) ?? undefined,
+    diff: take(block.diff, 32 * 1024) ?? undefined,
+    result: block.result ? {
+      ...block.result,
+      content: take(block.result.content, 16 * 1024) ?? "",
+      summary: take(block.result.summary, 8 * 1024),
+      diff: take(block.result.diff, 32 * 1024),
+    } : undefined,
+  };
+}
+
+function compactProcessBlock(
+  block: ProcessBlock,
+  detailBudget: { remaining: number },
+): ProcessBlock {
+  const take = (value: string | null | undefined, limit: number) => {
+    const available = Math.max(0, Math.min(limit, detailBudget.remaining));
+    const clipped = clipCacheString(value, available);
+    detailBudget.remaining -= clipped?.length ?? 0;
+    return clipped;
+  };
+  const inputLimit = Math.min(8 * 1024, detailBudget.remaining);
+  const input = compactCacheValue(block.input, inputLimit);
+  detailBudget.remaining -= JSON.stringify(input)?.length ?? 0;
+  return {
+    ...block,
+    title: clipCacheString(block.title, 1024) || "处理事件",
+    summary: take(block.summary, 8 * 1024),
+    detail: take(block.detail, 16 * 1024),
+    input: input && typeof input === "object" && !Array.isArray(input)
+      ? input as Record<string, unknown> : null,
+    output: take(block.output, 16 * 1024),
+    diff: take(block.diff, 32 * 1024),
+    progress: take(block.progress, 8 * 1024),
+    server: clipCacheString(block.server, 1024),
+    tool: clipCacheString(block.tool, 1024),
+    command: take(block.command, 16 * 1024),
+    cwd: take(block.cwd, 4 * 1024),
+    explanation: take(block.explanation, 8 * 1024),
+    plan: block.plan?.slice(0, 64).map((entry) => ({
+      ...entry,
+      step: take(entry.step, 2 * 1024) || "（空步骤）",
+    })),
+  };
+}
+
+/** Store the same lightweight local projection a native conversation client
+ * paints on launch: every visible timeline identity survives, while attachment
+ * bytes, raw cursor pages and heavyweight outputs remain in their independently
+ * paged authoritative stores. A single large field can therefore never evict
+ * the whole turn and make the middle of a completed process disappear. */
+function projectTurnForCache(turn: Turn): Turn {
+  const finalBudget = { remaining: CACHE_FINAL_TEXT_CHARS };
+  const processTextBudget = { remaining: CACHE_PROCESS_TEXT_CHARS };
+  const detailBudget = { remaining: CACHE_PROCESS_DETAIL_CHARS };
+  const projectionBlocks = turn.detailProjection?.blocks?.length
+    ? turn.detailProjection.blocks : turn.blocks;
+  const finalBlocks = turn.blocks.filter((block): block is TextBlock =>
+    block.kind === "text" && block.channel === "final");
+  const sourceBlocks = [...projectionBlocks];
+  for (const finalBlock of finalBlocks) {
+    if (!sourceBlocks.some((block) =>
+      block.kind === "text" && block.message_id === finalBlock.message_id)) {
+      sourceBlocks.push(finalBlock);
+    }
+  }
+  const blocks = sourceBlocks.map((block): Block => {
+    if (block.kind === "tool") return compactToolBlock(block, detailBudget);
+    if (block.kind === "process") {
+      return compactProcessBlock(block, detailBudget);
+    }
+    const budget = block.channel === "final" ? finalBudget : processTextBudget;
+    const perBlock = block.channel === "final" ? 256 * 1024 : 16 * 1024;
+    const available = Math.max(0, Math.min(perBlock, budget.remaining));
+    const text = clipCacheString(block.text, available) ?? "";
+    budget.remaining -= text.length;
+    return { ...block, text };
+  });
+  const deferredBlocks = blocks.filter((block) =>
+    block.kind !== "text" || block.channel !== "final").length;
+  const imageChars = turn.images?.reduce(
+    (total, image) => total + image.media_type.length + image.data.length, 0);
+  const images = imageChars != null && imageChars <= CACHE_IMAGE_CHARS
+    ? turn.images?.map((image) => ({ ...image }))
+    : undefined;
+  return {
+    ...turn,
+    prompt: clipCacheString(turn.prompt, CACHE_PROMPT_CHARS) ?? "",
+    error: clipCacheString(turn.error, 32 * 1024) ?? undefined,
+    progress: clipCacheString(turn.progress, 8 * 1024) ?? undefined,
+    blocks,
+    // Keep a small optimistic attachment set for a flicker-free first paint.
+    // Larger bodies stay in the transcript image store and are refilled through
+    // History image references instead of evicting the whole turn.
+    images,
+    imageRefs: turn.imageRefs?.slice(0, 64).map((image) => ({ ...image })),
+    files: turn.files?.slice(0, 64).map((file) => ({
+      filename: clipCacheString(file.filename, 16 * 1024) ?? "",
+      data: "",
+    })),
+    detailEventCount: Math.max(turn.detailEventCount ?? 0, deferredBlocks),
+    detailLoaded: false,
+    detailLoading: false,
+    detailProjection: undefined,
+    detailHasMore: false,
+    detailOldestCursor: null,
+    detailHasNewer: false,
+    detailNewerCursor: null,
+    detailAutoLoad: false,
+    detailRestorePending: false,
+    detailRestoreOpen: false,
+    detailRestoreIncomplete: false,
+  };
+}
+
+function projectTurnSkeletonForCache(turn: Turn): Turn {
+  let finalRemaining = 128 * 1024;
+  let processRemaining = 128 * 1024;
+  const blocks = turn.blocks.map((block): Block => {
+    if (block.kind === "text") {
+      const final = block.channel === "final";
+      const remaining = final ? finalRemaining : processRemaining;
+      const text = clipCacheString(
+        block.text, Math.min(final ? 32 * 1024 : 2 * 1024, remaining)) ?? "";
+      if (final) finalRemaining -= text.length;
+      else processRemaining -= text.length;
+      return {
+        ...block,
+        message_id: clipCacheString(block.message_id, 1024) ?? "",
+        text,
+      };
+    }
+    if (block.kind === "tool") {
+      return {
+        kind: "tool",
+        message_id: clipCacheString(block.message_id, 1024) ?? "",
+        tool_use_id: clipCacheString(block.tool_use_id, 1024) ?? "",
+        tool: clipCacheString(block.tool, 512) ?? "",
+        input: compactCacheValue(block.input, 1024) as Record<string, unknown>,
+        category: block.category,
+        title: clipCacheString(block.title, 512),
+        parent_id: clipCacheString(block.parent_id, 1024),
+        server: clipCacheString(block.server, 512),
+        progress: clipCacheString(block.progress, 1024) ?? undefined,
+        result: block.result ? {
+          content: "",
+          is_error: block.result.is_error,
+          truncated: true,
+          status: block.result.status,
+          summary: clipCacheString(block.result.summary, 1024),
+          exit_code: block.result.exit_code,
+          duration_ms: block.result.duration_ms,
+        } : undefined,
+        done: block.done,
+      };
+    }
     return {
-      ...record,
-      files: record.files.map((file) => {
-        const filename = file && typeof file === "object"
-          && typeof (file as Record<string, unknown>).filename === "string"
-          ? (file as Record<string, unknown>).filename as string
-          : "";
-        return { filename, data: "" };
-      }),
+      kind: "process",
+      item_id: clipCacheString(block.item_id, 1024) ?? "",
+      processKind: block.processKind,
+      phase: block.phase,
+      status: block.status,
+      turn_id: clipCacheString(block.turn_id, 1024),
+      parent_id: clipCacheString(block.parent_id, 1024),
+      title: clipCacheString(block.title, 512) || "处理事件",
+      summary: clipCacheString(block.summary, 1024),
+      progress: clipCacheString(block.progress, 1024),
+      server: clipCacheString(block.server, 512),
+      tool: clipCacheString(block.tool, 512),
+      command: clipCacheString(block.command, 1024),
+      cwd: clipCacheString(block.cwd, 1024),
+      exit_code: block.exit_code,
+      duration_ms: block.duration_ms,
+      truncated: true,
+      plan: block.plan?.slice(0, 32).map((entry) => ({
+        ...entry,
+        step: clipCacheString(entry.step, 512) || "（空步骤）",
+      })),
+      done: block.done,
     };
   });
+  return {
+    ...turn,
+    prompt: clipCacheString(turn.prompt, 16 * 1024) ?? "",
+    error: clipCacheString(turn.error, 8 * 1024) ?? undefined,
+    progress: clipCacheString(turn.progress, 2 * 1024) ?? undefined,
+    blocks,
+    images: undefined,
+    imageRefs: turn.imageRefs?.slice(0, 32).map((image) => ({ ...image })),
+    files: turn.files?.slice(0, 32).map((file) => ({
+      filename: clipCacheString(file.filename, 1024) ?? "",
+      data: "",
+    })),
+  };
+}
+
+function cacheTurn(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const record = value as Record<string, unknown>;
+  if (typeof record.id === "string"
+      && typeof record.prompt === "string"
+      && typeof record.done === "boolean"
+      && Array.isArray(record.blocks)) {
+    return projectTurnForCache(value as Turn);
+  }
+  if (!Array.isArray(record.files)) return value;
+  return {
+    ...record,
+    files: record.files.map((file) => {
+      const filename = file && typeof file === "object"
+        && typeof (file as Record<string, unknown>).filename === "string"
+        ? (file as Record<string, unknown>).filename as string
+        : "";
+      return { filename, data: "" };
+    }),
+  };
+}
+
+/** Bound the structured clone written for one session. */
+export function boundCachedTurns(turns: unknown[]): unknown[] {
+  const candidates = turns.slice(-MAX_CACHE_TURNS);
   const kept: unknown[] = [];
   let bytes = 2; // []
   for (let i = candidates.length - 1; i >= 0; i--) {
+    // Project lazily newest-first. A large current turn usually fills most of
+    // the instant-paint budget, so walking and cloning every older page on each
+    // 400 ms streaming flush would create avoidable main-thread work.
+    let candidate = cacheTurn(candidates[i]);
     let encoded: string | undefined;
-    try { encoded = JSON.stringify(candidates[i]); } catch { continue; }
+    try { encoded = JSON.stringify(candidate); } catch { continue; }
     if (encoded === undefined) continue;
-    const size = new TextEncoder().encode(encoded).byteLength + 1;
+    let size = new TextEncoder().encode(encoded).byteLength + 1;
+    if (size > MAX_CACHE_BYTES && candidate
+        && typeof candidate === "object" && !Array.isArray(candidate)
+        && typeof (candidate as Partial<Turn>).id === "string"
+        && typeof (candidate as Partial<Turn>).prompt === "string"
+        && typeof (candidate as Partial<Turn>).done === "boolean"
+        && Array.isArray((candidate as Partial<Turn>).blocks)) {
+      candidate = projectTurnSkeletonForCache(candidate as Turn);
+      try { encoded = JSON.stringify(candidate); } catch { continue; }
+      if (encoded === undefined) continue;
+      size = new TextEncoder().encode(encoded).byteLength + 1;
+    }
     if (size > MAX_CACHE_BYTES || bytes + size > MAX_CACHE_BYTES) continue;
-    kept.unshift(candidates[i]);
+    kept.unshift(candidate);
     bytes += size;
   }
   return kept;

--- a/web/src/components/ArtifactPanel.tsx
+++ b/web/src/components/ArtifactPanel.tsx
@@ -2,7 +2,6 @@ import { isValidElement, useCallback, useEffect, useMemo, useRef, useState,
   type ComponentPropsWithoutRef, type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
-import remarkGfm from "remark-gfm";
 import type { Artifact, PreviewAssetState } from "../reducer";
 import { Icon } from "../icons";
 import { PanelTabs } from "./PanelTabs";
@@ -12,6 +11,12 @@ import { parseLocalFileTarget } from "../file-link";
 import { buildSandboxDocument } from "../html-preview";
 import { clampPanelWidth } from "../responsive-layout";
 import { isMermaidFenceClass } from "../mermaid";
+import {
+  isMathFenceClass,
+  normalizeMathDelimiters,
+  STREAMING_REMARK_PLUGINS,
+  useMarkdownMathPlugins,
+} from "../markdown-math";
 import { MermaidBlock } from "./MermaidBlock";
 
 const EMPTY_GIT_DIFF_SECTIONS: GitDiffSection[] = [];
@@ -39,13 +44,18 @@ function markdownFenceClassName(children: ReactNode): string | undefined {
 }
 
 function MarkdownPreviewPre({ children }: ComponentPropsWithoutRef<"pre">) {
-  if (isMermaidFenceClass(markdownFenceClassName(children))) return <>{children}</>;
+  const className = markdownFenceClassName(children);
+  if (isMermaidFenceClass(className)
+      || isMathFenceClass(className)) return <>{children}</>;
   return <pre>{children}</pre>;
 }
 
 function MarkdownPreviewCode({
   className, children,
 }: ComponentPropsWithoutRef<"code">) {
+  if (isMathFenceClass(className)) {
+    return <code className={className}>{children}</code>;
+  }
   if (isMermaidFenceClass(className)) {
     return <MermaidBlock source={markdownNodeText(children).replace(/\n$/, "")} />;
   }
@@ -279,6 +289,10 @@ export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
     draft: artifact.content || "",
     baseline: artifact.content || "",
   };
+  const mathPlugins = useMarkdownMathPlugins(
+    editor.draft,
+    artifact.kind === "md" && mode === "preview",
+  );
   const dirty = artifact.kind === "md" && editor.draft !== editor.baseline;
   const sections = artifact.kind === "gitdiff"
     ? (artifact.sections || EMPTY_GIT_DIFF_SECTIONS) : EMPTY_GIT_DIFF_SECTIONS;
@@ -608,7 +622,13 @@ export function ArtifactPanel({ artifact, active, hasBtw, onTab, onClose,
                     baseline: editor.baseline,
                   })} />
               : <div className="prose markdown-preview"><ReactMarkdown
-                  remarkPlugins={[remarkGfm]} components={markdownComponents}>{editor.draft}</ReactMarkdown></div>}
+                  remarkPlugins={
+                    mathPlugins?.remarkPlugins ?? STREAMING_REMARK_PLUGINS}
+                  rehypePlugins={mathPlugins?.rehypePlugins}
+                  components={markdownComponents}>
+                  {mathPlugins
+                    ? normalizeMathDelimiters(editor.draft) : editor.draft}
+                </ReactMarkdown></div>}
           </>
         ) : null}
       </div>

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -2008,7 +2008,10 @@ export function ChatView({ sid, turns, engine = "claude", loading, hasMore,
                 onLoadImage={onLoadImage}
                 onInteractionStart={beginProcessInteraction}
                 onInteractionEnd={endProcessInteraction}
-                openOverride={processDisclosureOpen[`${processOpenKey}\u0000outer`]}
+                openOverride={
+                  processDisclosureOpen[`${processOpenKey}\u0000outer`]
+                  ?? (t.detailRestoreOpen ? true : undefined)
+                }
                 onOpenChange={(open) => rememberProcessDisclosure(
                   `${processOpenKey}\u0000outer`, open,
                 )}

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -863,8 +863,8 @@ export function Composer(p: Props) {
               aria-label="添加照片" title="添加照片"
               disabled={locked || importing}><Icon name="plus" size={19} /></button>
             {inputControl(p.engine === "codex"
-              ? "发消息…  输入 / 唤起命令，$ 调用 Skill"
-              : "发消息…  输入 / 唤起命令")}
+              ? "输入 / 命令，$ Skill"
+              : "输入 / 命令")}
             {sendControl}
           </div>
           <div className="hint">
@@ -919,7 +919,7 @@ export function Composer(p: Props) {
                 onClick={() => p.onSetServiceTier?.("toggle")}
                 disabled={locked}
                 title="Fast 服务档位:快 / 标准(下条消息生效)"
-              >{p.fast == null ? "档位读取中" : p.fast ? "⚡ 快" : "标准"}</button>
+              >{p.fast == null ? "档位读取中" : p.fast ? "快速" : "标准"}</button>
             )}
             {p.engine === "codex" && (
               <UsageMeter

--- a/web/src/components/MessageBlock.tsx
+++ b/web/src/components/MessageBlock.tsx
@@ -1,7 +1,6 @@
 import { createContext, isValidElement, useContext, useEffect, useMemo, useRef,
   useState, type ComponentPropsWithoutRef, type ReactNode } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { parseLocalFileTarget } from "../file-link";
 import { Icon } from "../icons";
 import {
@@ -9,6 +8,12 @@ import {
   type InlineImageAsset,
 } from "../inline-image-assets";
 import { isMermaidFenceClass } from "../mermaid";
+import {
+  isMathFenceClass,
+  normalizeMathDelimiters,
+  STREAMING_REMARK_PLUGINS,
+  useMarkdownMathPlugins,
+} from "../markdown-math";
 import { MermaidBlock } from "./MermaidBlock";
 
 const CODEX_DIRECTIVE_LABELS: Record<string, string> = {
@@ -227,7 +232,9 @@ function fenceClassName(children: ReactNode): string | undefined {
 
 function MarkdownPre({ children }: ComponentPropsWithoutRef<"pre">) {
   const { done } = useContext(MessageMarkdownContext);
-  if (done && isMermaidFenceClass(fenceClassName(children))) return <>{children}</>;
+  const className = fenceClassName(children);
+  if (done && (isMermaidFenceClass(className)
+      || isMathFenceClass(className))) return <>{children}</>;
   return <CopyableCodeBlock>{children}</CopyableCodeBlock>;
 }
 
@@ -235,6 +242,9 @@ function MarkdownCode({
   className, children,
 }: ComponentPropsWithoutRef<"code">) {
   const { done } = useContext(MessageMarkdownContext);
+  if (done && isMathFenceClass(className)) {
+    return <code className={className}>{children}</code>;
+  }
   if (done && isMermaidFenceClass(className)) {
     return <MermaidBlock source={nodeText(children).replace(/\n$/, "")} />;
   }
@@ -249,8 +259,6 @@ const MESSAGE_MARKDOWN_COMPONENTS: Components = Object.freeze({
   img: MarkdownImage,
   a: MarkdownLink,
 });
-const MESSAGE_REMARK_PLUGINS = [remarkGfm];
-
 // Streams markdown with a ~50ms throttle: re-parsing react-markdown on every
 // token delta is wasteful, so we hold a "shown" buffer that catches up on a
 // timer while streaming, and snaps to the full text when the block is done.
@@ -288,7 +296,10 @@ export function MessageBlock({ text, done, onOpenFile, imageAssets,
   const markdownContext = useMemo<MessageMarkdownContextValue>(() => ({
     done, imageAssets, onLoadImage, onOpenFile, onPreviewImage,
   }), [done, imageAssets, onLoadImage, onOpenFile, onPreviewImage]);
-  const parts = useMemo(() => splitCodexDirectives(shown), [shown]);
+  const mathPlugins = useMarkdownMathPlugins(shown, done);
+  const parts = useMemo(() => splitCodexDirectives(
+    mathPlugins ? normalizeMathDelimiters(shown) : shown,
+  ), [mathPlugins, shown]);
 
   if (!shown) return null;
   return (
@@ -296,7 +307,9 @@ export function MessageBlock({ text, done, onOpenFile, imageAssets,
       <div className="prose">
         {parts.map((part, index) => part.kind === "markdown"
           ? <ReactMarkdown key={`markdown-${index}`}
-              remarkPlugins={MESSAGE_REMARK_PLUGINS}
+              remarkPlugins={
+                mathPlugins?.remarkPlugins ?? STREAMING_REMARK_PLUGINS}
+              rehypePlugins={mathPlugins?.rehypePlugins}
               components={MESSAGE_MARKDOWN_COMPONENTS}>{part.text}</ReactMarkdown>
           : <div key={`directive-${index}`} className="codex-directive-status"
               data-directive={part.name}>

--- a/web/src/domain/conversation.ts
+++ b/web/src/domain/conversation.ts
@@ -131,4 +131,13 @@ export interface Turn {
   detailProjection?: TurnDetailProjection;
   /** Initial disclosure click keeps fetching older pages until EOF or cap. */
   detailAutoLoad?: boolean;
+  /** Same-revision IndexedDB process is painted provisionally while one
+   * authoritative newest-page detail read replaces it after refresh. */
+  detailRestorePending?: boolean;
+  /** Reopen only the newest compact cached process after a full page refresh;
+   * a user's subsequent disclosure choice overrides this hint. */
+  detailRestoreOpen?: boolean;
+  /** The automatic refresh repair installed only the newest server page; an
+   * explicit disclosure may still request the remaining older pages. */
+  detailRestoreIncomplete?: boolean;
 }

--- a/web/src/history-merge.ts
+++ b/web/src/history-merge.ts
@@ -138,7 +138,7 @@ function mergeBlocks(history: Block[], live: Block[], preserveLiveOpen: boolean)
   return out;
 }
 
-function sameTurn(history: Turn, live: Turn): boolean {
+function sameTurnIdentity(history: Turn, live: Turn): boolean {
   if (history.id === live.id) return true;
   if (history.clientMsgId && (
     history.clientMsgId === live.id
@@ -150,7 +150,11 @@ function sameTurn(history: Turn, live: Turn): boolean {
   // assistant item id; TurnEnd still supplies the same authoritative branch id.
   if (history.forkPointId && live.forkPointId
       && history.forkPointId === live.forkPointId) return true;
-  if (history.forkPointId === live.id || live.forkPointId === history.id) return true;
+  return history.forkPointId === live.id || live.forkPointId === history.id;
+}
+
+function sameTurn(history: Turn, live: Turn): boolean {
+  if (sameTurnIdentity(history, live)) return true;
   if (!history.prompt || !live.prompt || history.prompt !== live.prompt) return false;
   // Different ids are an optimistic-client id vs transcript id only when their
   // authoritative UserMsg times are nearly identical. Prompt text alone is not
@@ -237,16 +241,57 @@ export function restoreCachedTurnDetails(
   summaries: Turn[],
   cachedTurns: readonly Turn[],
 ): Turn[] {
+  const matches = new Array<number>(summaries.length).fill(-1);
+  const usedCached = new Set<number>();
+
+  // Reserve every authoritative identity before considering the timestamp
+  // compatibility fallback. Otherwise a nearby repeated prompt can consume a
+  // cache row which belongs exactly to another summary.
+  for (let summaryIndex = 0; summaryIndex < summaries.length; summaryIndex += 1) {
+    const cachedIndex = cachedTurns.findIndex((candidate, index) =>
+      !usedCached.has(index)
+      && sameTurnIdentity(summaries[summaryIndex], candidate));
+    if (cachedIndex < 0) continue;
+    matches[summaryIndex] = cachedIndex;
+    usedCached.add(cachedIndex);
+  }
+
+  // Older optimistic caches may legitimately have a different id. Keep that
+  // compatibility one-to-one and choose the closest timestamp so repeated
+  // prompts cannot all reuse the first eligible cache row.
+  for (let summaryIndex = 0; summaryIndex < summaries.length; summaryIndex += 1) {
+    if (matches[summaryIndex] >= 0) continue;
+    const summary = summaries[summaryIndex];
+    let bestIndex = -1;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (let cachedIndex = 0; cachedIndex < cachedTurns.length;
+      cachedIndex += 1) {
+      if (usedCached.has(cachedIndex)) continue;
+      const candidate = cachedTurns[cachedIndex];
+      if (!sameTurn(summary, candidate)) continue;
+      const distance = Math.abs((summary.ts ?? 0) - (candidate.ts ?? 0));
+      if (distance >= bestDistance) continue;
+      bestIndex = cachedIndex;
+      bestDistance = distance;
+    }
+    if (bestIndex < 0) continue;
+    matches[summaryIndex] = bestIndex;
+    usedCached.add(bestIndex);
+  }
+
   let revealNewest = true;
-  const restored = [...summaries].reverse().map((summary) => {
-    const cached = cachedTurns.find((candidate) => sameTurn(summary, candidate));
-    if (!cached) return summary;
+  const restored = [...summaries];
+  for (let summaryIndex = restored.length - 1; summaryIndex >= 0;
+    summaryIndex -= 1) {
+    const cachedIndex = matches[summaryIndex];
+    if (cachedIndex < 0) continue;
+    const summary = restored[summaryIndex];
     const installed = installCachedDetailRestore(
-      summary, cached, revealNewest);
+      summary, cachedTurns[cachedIndex], revealNewest);
     if (installed !== summary) revealNewest = false;
-    return installed;
-  });
-  return restored.reverse();
+    restored[summaryIndex] = installed;
+  }
+  return restored;
 }
 
 function mergeTurn(history: Turn, live: Turn, preserveLiveOpen = false): Turn {

--- a/web/src/history-merge.ts
+++ b/web/src/history-merge.ts
@@ -163,6 +163,92 @@ export function historyContainsTurn(history: Turn[], live: Turn): boolean {
   return history.some((turn) => sameTurn(turn, live));
 }
 
+function cloneDetailBlock(block: Block): Block {
+  if (block.kind === "process") {
+    return {
+      ...block,
+      input: block.input ? { ...block.input } : block.input,
+      plan: block.plan?.map((entry) => ({ ...entry })),
+    };
+  }
+  if (block.kind === "tool") {
+    return {
+      ...block,
+      input: { ...block.input },
+      result: block.result ? { ...block.result } : block.result,
+    };
+  }
+  return { ...block };
+}
+
+/** Paint only heavyweight blocks from a same-revision/generation browser
+ * cache over an authoritative summary row.
+ *
+ * The summary remains authoritative for prompt/final/lifecycle. Cached process
+ * is deliberately marked provisional and owns no source segments; the next
+ * accepted TurnDetail page replaces it rather than merging stale events into
+ * the transcript projection.
+ */
+function installCachedDetailRestore(
+  summary: Turn,
+  cached: Turn,
+  reveal: boolean,
+): Turn {
+  if (!summary.done || !cached.done || summary.detailLoaded
+      || summary.detailProjection
+      || (summary.detailEventCount ?? 0) <= 0) return summary;
+  const source = cached.detailProjection?.blocks ?? cached.blocks;
+  const blocks = source.filter((block) => !isFinalTextBlock(block))
+    .map(cloneDetailBlock);
+  if (blocks.length === 0) return summary;
+  return {
+    ...summary,
+    detailLoaded: false,
+    detailLoading: false,
+    detailProjection: {
+      // Empty segments distinguish instant-paint cache from authoritative
+      // cursor pages. installTurnDetailProjectionPage then replaces this
+      // visible block list with the first accepted server page.
+      segments: [],
+      blocks,
+      capped: cached.detailProjection?.capped ?? false,
+      hasMore: false,
+      oldestCursor: null,
+      hasNewer: false,
+      newerCursor: null,
+    },
+    detailHasMore: false,
+    detailOldestCursor: null,
+    detailHasNewer: false,
+    detailNewerCursor: null,
+    detailAutoLoad: false,
+    detailRestorePending: reveal,
+    detailRestoreIncomplete: false,
+    // Automatically recreating thousands of DOM rows would defeat the instant
+    // cache paint. Small latest-turn process is reopened to preserve the live
+    // 1..N reading experience; large projections remain one tap away.
+    detailRestoreOpen: reveal && blocks.length <= 256,
+  };
+}
+
+/** Reconcile cached process with canonical summary identities without
+ * resurrecting a completed row which authoritative History removed. */
+export function restoreCachedTurnDetails(
+  summaries: Turn[],
+  cachedTurns: readonly Turn[],
+): Turn[] {
+  let revealNewest = true;
+  const restored = [...summaries].reverse().map((summary) => {
+    const cached = cachedTurns.find((candidate) => sameTurn(summary, candidate));
+    if (!cached) return summary;
+    const installed = installCachedDetailRestore(
+      summary, cached, revealNewest);
+    if (installed !== summary) revealNewest = false;
+    return installed;
+  });
+  return restored.reverse();
+}
+
 function mergeTurn(history: Turn, live: Turn, preserveLiveOpen = false): Turn {
   const historyImageRefs = history.imageRefs?.length
     ? history.imageRefs : undefined;
@@ -246,7 +332,7 @@ export function mergeAuthoritativeTurnDetail(
     error: summary.error,
     progress: summary.progress,
     detailEventCount: summary.detailEventCount,
-    detailLoaded: true,
+    detailLoaded: detail.detailLoaded ?? true,
     detailLoading: false,
     detailProjection: detail.detailProjection ?? summary.detailProjection,
     detailHasMore: detail.detailProjection
@@ -262,6 +348,11 @@ export function mergeAuthoritativeTurnDetail(
       ? detail.detailProjection.newerCursor
       : detail.detailNewerCursor ?? summary.detailNewerCursor,
     detailAutoLoad: detail.detailAutoLoad ?? summary.detailAutoLoad,
+    detailRestorePending: false,
+    detailRestoreOpen:
+      detail.detailRestoreOpen ?? summary.detailRestoreOpen,
+    detailRestoreIncomplete:
+      detail.detailRestoreIncomplete ?? summary.detailRestoreIncomplete,
   };
 }
 
@@ -341,6 +432,8 @@ export function installAuthoritativeTurnDetailPage(
     ? detailProjection.hasNewer : page.hasNewer;
   const newerCursor = detailProjection
     ? detailProjection.newerCursor : page.newerCursor ?? null;
+  const restoreIncomplete =
+    summary.detailRestoreIncomplete === true && hasMore;
   return {
     ...summary,
     prompt: detail.prompt || summary.prompt,
@@ -360,7 +453,7 @@ export function installAuthoritativeTurnDetailPage(
     error: summary.error,
     progress: summary.progress,
     detailEventCount: summary.detailEventCount,
-    detailLoaded: true,
+    detailLoaded: !restoreIncomplete,
     detailLoading: false,
     detailProjection,
     detailHasMore: hasMore,
@@ -368,6 +461,8 @@ export function installAuthoritativeTurnDetailPage(
     detailHasNewer: hasNewer,
     detailNewerCursor: newerCursor,
     detailAutoLoad: !!summary.detailAutoLoad && hasMore,
+    detailRestorePending: false,
+    detailRestoreIncomplete: restoreIncomplete,
   };
 }
 

--- a/web/src/history-requests.ts
+++ b/web/src/history-requests.ts
@@ -173,6 +173,8 @@ export type HistoryDetailRequestContext =
       revision: string;
       turnId: string;
       before?: string | null;
+      /** Initial user expansion pages to EOF; refresh repair reads one page. */
+      autoLoad?: boolean;
     }
   | {
       target: "browse";

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1030,10 +1030,9 @@ html.panel-resizing,html.panel-resizing *{ cursor:col-resize !important; user-se
 .hint-ctl:disabled{ opacity:.45; cursor:default; color:inherit; }
 .collaboration-chip.plan{ flex:none; color:var(--accent-ink); background:var(--accent-weak);
   border:1px solid var(--accent-line); border-radius:999px; padding:1px 8px; }
-/* codex Fast-mode chip: dim when standard, accent pill when fast is on */
+/* Codex Fast mode keeps a stable text-only footprint in both states. */
 .fast-chip{ flex:none; color:var(--dim); }
-.fast-chip.on{ color:var(--accent); background:var(--accent-weak); border:1px solid var(--accent-line);
-  border-radius:999px; padding:1px 8px; }
+.fast-chip.on{ color:var(--accent); }
 /* context-usage ring */
 .hint-ring{ border:0; background:none; padding:0; display:inline-flex; cursor:pointer; line-height:0; flex:none; }
 .hint-ring svg{ display:block; transition:transform .14s; }
@@ -1053,7 +1052,7 @@ html.panel-resizing,html.panel-resizing *{ cursor:col-resize !important; user-se
   overflow:hidden; background:var(--border); }
 .usage-meter-line i em{ display:block; height:100%; border-radius:inherit;
   background:var(--accent); transition:width .24s var(--ease),background .18s; }
-.usage-meter-line .good{ background:var(--ok); }
+.usage-meter-line .good{ background:color-mix(in srgb,var(--ok) 68%,white); }
 .usage-meter-line .warn{ background:var(--warn); }
 .usage-meter-line .critical{ background:var(--danger); }
 .usage-meter-line .unknown{ background:var(--border-strong); }
@@ -1075,7 +1074,7 @@ html.panel-resizing,html.panel-resizing *{ cursor:col-resize !important; user-se
   border-radius:999px; background:var(--raised); }
 .usage-pop-window>i span{ display:block; height:100%; border-radius:inherit;
   background:var(--accent); transition:width .24s var(--ease),background .18s; }
-.usage-pop-window>i .good{ background:var(--ok); }
+.usage-pop-window>i .good{ background:color-mix(in srgb,var(--ok) 68%,white); }
 .usage-pop-window>i .warn{ background:var(--warn); }
 .usage-pop-window>i .critical{ background:var(--danger); }
 .usage-pop-window>i .unknown{ background:var(--border-strong); }
@@ -1160,21 +1159,29 @@ html.panel-resizing,html.panel-resizing *{ cursor:col-resize !important; user-se
 @media (max-width:640px){
   .hint{ gap:clamp(6px,2vw,12px); }
   .hint-kbds{ display:none; }
-  .hint-right{ min-width:0; margin-left:0; flex:1; justify-content:space-between;
-    gap:clamp(4px,1.4vw,10px); }
+  .hint-right{ min-width:0; margin-left:0; flex:1; justify-content:flex-end;
+    gap:clamp(6px,1.8vw,10px); }
 }
-/* A 320 px phone cannot keep the mode label and every Codex control on one
-   line. Give controls their own row, then let only the two textual selectors
-   shrink; quota bars and the context ring retain usable touch targets. */
+/* Keep the complete control strip on one line even at 320 px. Text selectors
+   shrink with ellipsis while quota and context retain stable touch targets. */
 @media (max-width:420px){
-  .hint{ align-items:flex-start; flex-wrap:wrap; row-gap:4px; column-gap:8px; }
-  .hint-mode{ min-width:0; max-width:100%; overflow:hidden; text-overflow:ellipsis; }
-  .hint-right{ width:100%; min-width:0; margin-left:0; flex:1 0 100%;
-    justify-content:flex-end; gap:6px; }
+  .hint{ align-items:center; flex-wrap:nowrap; gap:11px; }
+  .hint-mode{ min-width:0; max-width:72px; min-height:34px; flex:0 1 auto;
+    overflow:hidden; text-overflow:ellipsis; }
+  .hint-right{ width:auto; min-width:0; margin-left:0; flex:1 1 auto;
+    justify-content:flex-end; gap:11px; }
   .hint-control-scope{ display:none; }
-  .hint-right>.hint-ctl:not(.collaboration-chip):not(.fast-chip){
-    flex:1 1 0; min-width:0; max-width:70px; overflow:hidden; text-overflow:ellipsis;
+  .hint-right>.hint-ctl{
+    min-width:0; min-height:34px; display:inline-flex; align-items:center;
+    justify-content:center; overflow:hidden; text-overflow:ellipsis;
   }
+  .hint-right>.hint-ctl:not(.collaboration-chip):not(.fast-chip){
+    flex:0 1 auto; max-width:none;
+  }
+  .hint-right>.hint-ctl:nth-of-type(2){ min-width:28px; }
+  .hint-right>.collaboration-chip,.hint-right>.fast-chip{ flex:0 1 auto; }
+  .hint-right>.fast-chip{ min-width:20px; }
+  .hint-ring{ width:28px; height:34px; align-items:center; justify-content:center; }
 }
 
 /* COMMAND SHEET */

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -404,6 +404,9 @@ body{
 .message-link-disabled{ color:var(--dim); border-bottom:1px dotted var(--faint); cursor:not-allowed; }
 .prose blockquote{ border-left:3px solid var(--accent-line); margin:8px 0; padding:2px 12px; color:var(--dim); }
 .prose img{ max-width:100%; height:auto; }
+.prose .katex-display{ max-width:100%; margin:10px 0; padding:2px 0;
+  overflow-x:auto; overflow-y:hidden; -webkit-overflow-scrolling:touch; }
+.prose .katex-display>.katex{ white-space:nowrap; }
 .message-image-trigger{ display:inline-block; max-width:100%; margin:5px 0; padding:0; border:0;
   border-radius:10px; background:none; cursor:zoom-in; vertical-align:top; touch-action:manipulation; }
 .message-inline-image{ display:block; max-width:min(100%,680px); max-height:min(62vh,680px);

--- a/web/src/markdown-math-plugins.ts
+++ b/web/src/markdown-math-plugins.ts
@@ -1,0 +1,24 @@
+import "katex/dist/katex.min.css";
+
+import type { Options as ReactMarkdownOptions } from "react-markdown";
+import rehypeKatex from "rehype-katex";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+
+type RemarkPlugins = NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
+type RehypePlugins = NonNullable<ReactMarkdownOptions["rehypePlugins"]>;
+
+export const remarkPlugins: RemarkPlugins = [
+  remarkGfm,
+  [remarkMath, { singleDollarTextMath: true }],
+];
+
+export const rehypePlugins: RehypePlugins = [
+  [rehypeKatex, {
+    trust: false,
+    strict: "warn",
+    maxSize: 10,
+    maxExpand: 1_000,
+    output: "htmlAndMathml",
+  }],
+];

--- a/web/src/markdown-math.ts
+++ b/web/src/markdown-math.ts
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useState } from "react";
+import type { Options as ReactMarkdownOptions } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+type RemarkPlugins = NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
+type RehypePlugins = NonNullable<ReactMarkdownOptions["rehypePlugins"]>;
+
+export const STREAMING_REMARK_PLUGINS: RemarkPlugins = [remarkGfm];
+
+export interface MarkdownMathPlugins {
+  remarkPlugins: RemarkPlugins;
+  rehypePlugins: RehypePlugins;
+}
+
+let loadedPlugins: MarkdownMathPlugins | null = null;
+let loadingPlugins: Promise<MarkdownMathPlugins> | null = null;
+
+/** Load KaTeX only for a completed message which actually contains math.
+ * Keeping this dynamic avoids adding the 259 KiB renderer to every mobile
+ * history first paint. Exported for the zero-browser SSR regression harness. */
+export function preloadMarkdownMathPlugins(): Promise<MarkdownMathPlugins> {
+  if (loadedPlugins) return Promise.resolve(loadedPlugins);
+  if (!loadingPlugins) {
+    loadingPlugins = import("./markdown-math-plugins").then((module) => {
+      loadedPlugins = {
+        remarkPlugins: module.remarkPlugins,
+        rehypePlugins: module.rehypePlugins,
+      };
+      return loadedPlugins;
+    }).catch((error: unknown) => {
+      loadingPlugins = null;
+      throw error;
+    });
+  }
+  return loadingPlugins;
+}
+
+interface Fence {
+  marker: "`" | "~";
+  length: number;
+}
+
+function fenceAtLineStart(line: string): Fence | null {
+  const match = /^(?: {0,3})(`{3,}|~{3,})/.exec(line);
+  if (!match) return null;
+  return {
+    marker: match[1][0] as Fence["marker"],
+    length: match[1].length,
+  };
+}
+
+function closesFence(line: string, fence: Fence): boolean {
+  const match = /^(?: {0,3})(`{3,}|~{3,})[ \t]*$/.exec(line);
+  return !!match
+    && match[1][0] === fence.marker
+    && match[1].length >= fence.length;
+}
+
+function slashIsEscaped(line: string, index: number): boolean {
+  let preceding = 0;
+  for (let cursor = index - 1; cursor >= 0 && line[cursor] === "\\"; cursor--) {
+    preceding += 1;
+  }
+  return preceding % 2 === 1;
+}
+
+/** Normalize MathJax-style bracket delimiters for remark-math.
+ *
+ * Codex and Claude commonly emit `\(...\)` / `\[...\]`, while remark-math
+ * consumes dollar delimiters. The scanner deliberately skips fenced and inline
+ * code so examples and shell snippets remain byte-for-byte readable.
+ */
+export function normalizeMathDelimiters(source: string): string {
+  let fence: Fence | null = null;
+  let inlineTicks = 0;
+  const normalized = source.split("\n").map((line) => {
+    if (fence) {
+      if (closesFence(line, fence)) fence = null;
+      return line;
+    }
+    if (inlineTicks === 0) {
+      const opening = fenceAtLineStart(line);
+      if (opening) {
+        fence = opening;
+        return line;
+      }
+    }
+
+    let output = "";
+    for (let index = 0; index < line.length;) {
+      if (line[index] === "`") {
+        let end = index + 1;
+        while (end < line.length && line[end] === "`") end += 1;
+        const run = end - index;
+        if (inlineTicks === 0) inlineTicks = run;
+        else if (inlineTicks === run) inlineTicks = 0;
+        output += line.slice(index, end);
+        index = end;
+        continue;
+      }
+      if (inlineTicks === 0 && line[index] === "\\"
+          && !slashIsEscaped(line, index)) {
+        const delimiter = line[index + 1];
+        if (delimiter === "(" || delimiter === ")") {
+          output += "$";
+          index += 2;
+          continue;
+        }
+        if (delimiter === "[" || delimiter === "]") {
+          output += "\n$$\n";
+          index += 2;
+          continue;
+        }
+      }
+      output += line[index];
+      index += 1;
+    }
+    return output;
+  });
+  return normalized.join("\n");
+}
+
+export function hasMathDelimiters(source: string): boolean {
+  if (normalizeMathDelimiters(source) !== source) return true;
+  // remark-math performs the authoritative dollar parsing. This cheap hint may
+  // load the chunk for a literal currency sign; the parser still decides
+  // whether it forms a valid delimiter pair.
+  return source.includes("$");
+}
+
+export function useMarkdownMathPlugins(
+  source: string,
+  enabled: boolean,
+): MarkdownMathPlugins | null {
+  const shouldLoad = useMemo(
+    () => enabled && hasMathDelimiters(source),
+    [enabled, source],
+  );
+  const [plugins, setPlugins] = useState<MarkdownMathPlugins | null>(
+    shouldLoad ? loadedPlugins : null,
+  );
+  useEffect(() => {
+    let cancelled = false;
+    if (!shouldLoad) return;
+    void preloadMarkdownMathPlugins().then((loaded) => {
+      if (!cancelled) setPlugins(loaded);
+    }).catch(() => undefined);
+    return () => { cancelled = true; };
+  }, [shouldLoad]);
+  return shouldLoad ? (plugins ?? loadedPlugins) : null;
+}
+
+export function isMathFenceClass(className: string | undefined): boolean {
+  if (!className) return false;
+  const classes = new Set(className.split(/\s+/));
+  return classes.has("language-math")
+    || classes.has("math-display")
+    || classes.has("math-inline");
+}

--- a/web/src/protocol.ts
+++ b/web/src/protocol.ts
@@ -395,14 +395,14 @@ export interface CatalogModel {
 // Effective controls for a NEW no-override session. These are display metadata,
 // not the focused session's controls and not implicit overrides on NewSession.
 export interface Models extends Base { type: "models"; engine: string; models: CatalogModel[]; default_model?: string | null; default_effort?: string | null; cwd?: string | null }
-export interface GetEngineCapabilities extends Base { type: "get_engine_capabilities"; engine: Engine; space?: Space; client_id?: string | null; cwd?: string | null }
+export interface GetEngineCapabilities extends Base { type: "get_engine_capabilities"; engine: Engine; space?: Space; client_id?: string | null; cwd?: string | null; skills_only?: boolean }
 export interface ManageEnginePlugin extends Base { type: "manage_engine_plugin"; engine: Engine; action: "install" | "uninstall"; plugin_id: string; space?: Space; client_id?: string | null; cwd?: string | null }
 export interface ManageEngineSkill extends Base { type: "manage_engine_skill"; engine: Engine; action: "create" | "remove" | "enable" | "disable"; skill_id?: string | null; name?: string | null; description?: string | null; instructions?: string | null; scope?: "user" | "project"; space?: Space; client_id?: string | null; cwd?: string | null }
 export interface ManageEngineHook extends Base { type: "manage_engine_hook"; engine: Engine; action: "create" | "remove"; hook_id?: string | null; event?: string | null; matcher?: string | null; command?: string | null; timeout?: number | null; scope?: "user" | "project"; space?: Space; client_id?: string | null; cwd?: string | null }
 export type EngineCapabilityKind = "skill" | "plugin" | "app" | "mcp" | "hook";
 export type EngineCapabilityAction = "install" | "uninstall" | "enable" | "disable" | "remove";
 export interface EngineCapabilityItem { kind: EngineCapabilityKind; id: string; name: string; description?: string | null; enabled?: boolean | null; installed?: boolean | null; status?: string | null; scope?: string | null; source?: string | null; tool_count?: number | null; resource_count?: number | null; install_url?: string | null; actions?: EngineCapabilityAction[]; event?: string | null; matcher?: string | null; handler_type?: string | null; detail?: string | null }
-export interface EngineCapabilities extends Base { type: "engine_capabilities"; engine: Engine; space: Space; items: EngineCapabilityItem[]; errors?: string[]; notes?: string[] }
+export interface EngineCapabilities extends Base { type: "engine_capabilities"; engine: Engine; space: Space; request_id?: string | null; cwd: string; items: EngineCapabilityItem[]; errors?: string[]; notes?: string[]; skills_only: boolean }
 export interface AskOption { label: string; ds?: string }
 export interface AskUser extends Base { type: "ask_user"; ask_id: string; header?: string | null; question: string; options: AskOption[]; allow_text?: boolean; secret?: boolean; multi_select?: boolean }
 export interface AskUserClosed extends Base { type: "ask_user_closed"; ask_id: string; reason: "answered" | "cancelled" | "timeout" | "superseded" }
@@ -521,7 +521,7 @@ export type ServerEvent =
   | ProcessEvent | TurnPlan | TurnDiff | TurnBinding
   | TurnEnd | ErrorMsg | WrapperDisconnected | WrapperReconnected | Hello;
 
-export const PROTOCOL_VERSION = 25;
+export const PROTOCOL_VERSION = 26;
 
 const CONTROL_MODES = new Set<ControlMode>([
   "remote", "codex_shared", "claude_broker", "external_cli", "agent_view", "desktop",

--- a/web/src/reducer.ts
+++ b/web/src/reducer.ts
@@ -36,6 +36,7 @@ import {
 import {
   historyContainsTurn, installAuthoritativeTurnDetailPage,
   mergeAuthoritativeTurnDetail, mergeInitialHistory,
+  restoreCachedTurnDetails,
 } from "./history-merge";
 import {
   installTurnDetailProjectionPage,
@@ -372,7 +373,7 @@ export type Action =
   | { type: "restore_session_list"; sessions: SessionInfo[] }
   | { type: "set_session_pinned"; sid: string; pinned: boolean }
   | { type: "focus_session"; sid: string }
-  | { type: "turn_detail_requested"; sid: string; turnId: string; before?: string | null }
+  | { type: "turn_detail_requested"; sid: string; turnId: string; before?: string | null; autoLoad?: boolean }
   | { type: "begin_history_browse"; sid: string; scopeKey: string; revision: string; generation?: string | null; viewId: string; basePageKey: string }
   | { type: "install_history_browse_page"; sid: string; scopeKey: string; revision: string; generation?: string | null; viewId: string; windowEpoch: number; before: string; page: HistoryBrowsePage; protectedTurnIds?: string[]; prepared?: { from: HistoryBrowseProjection; to: HistoryBrowseProjection } }
   | { type: "install_history_browse_newer"; sid: string; scopeKey: string; revision: string; generation?: string | null; viewId: string; windowEpoch: number; page: HistoryBrowsePage; protectedTurnIds?: string[]; prepared?: { from: HistoryBrowseProjection; to: HistoryBrowseProjection } }
@@ -1256,7 +1257,11 @@ export function reduce(state: AppState, action: Action): AppState {
               ...turn,
               detailLoading: true,
               detailAutoLoad: action.before == null
-                ? true : turn.detailAutoLoad,
+                ? (action.autoLoad ?? true) : turn.detailAutoLoad,
+              detailRestorePending: false,
+              detailRestoreIncomplete: action.before == null
+                ? action.autoLoad === false
+                : turn.detailRestoreIncomplete,
             }
           : turn);
       }, true);
@@ -1521,17 +1526,36 @@ export function reduce(state: AppState, action: Action): AppState {
         const control = action.control
           && sessionControlTargetsSid(action.control, action.sid)
           ? action.control : null;
-        switchControlGeneration(
-          rt, action.generation ?? control?.generation);
-        if (control) applySessionControl(rt, control);
-        if (rt.turns.length === 0 && action.turns.length) {
-          replaceWithBoundedTurns(rt, action.turns.map((turn) => (
-            !turn.forkPointId && turn.codexTurnId
-              ? { ...turn, forkPointId: turn.codexTurnId }
-              : turn
-          )));
-          rt.historyRevision = action.revision;
-          rt.hydratedCacheTurnIds = action.turns.map((turn) => turn.id);
+        const cacheGeneration =
+          action.generation ?? control?.generation ?? null;
+        if (rt.turns.length === 0) {
+          switchControlGeneration(
+            rt, cacheGeneration);
+          if (control) applySessionControl(rt, control);
+          if (action.turns.length) {
+            replaceWithBoundedTurns(rt, action.turns.map((turn) => (
+              !turn.forkPointId && turn.codexTurnId
+                ? { ...turn, forkPointId: turn.codexTurnId }
+                : turn
+            )));
+            rt.historyRevision = action.revision;
+            rt.historyGeneration = cacheGeneration;
+            rt.hydratedCacheTurnIds = action.turns.map((turn) => turn.id);
+          }
+        } else if (rt.turns.length > 0
+            && action.revision != null
+            && action.revision === rt.historyRevision
+            && (cacheGeneration != null
+              ? cacheGeneration === rt.historyGeneration
+              : rt.historyGeneration == null)) {
+          // IndexedDB and authoritative History race on focus. If History won,
+          // accept only its exact revision/generation cache as temporary
+          // process paint; prompt/final/lifecycle remain server-owned.
+          if (control) {
+            switchControlGeneration(rt, cacheGeneration);
+            applySessionControl(rt, control);
+          }
+          rt.turns = restoreCachedTurnDetails(rt.turns, action.turns);
         }
         rt.loading = false;
       }, true);
@@ -2168,7 +2192,8 @@ function reduceEvent(
       if (e.detail === "summary" && !base.historyInvalidated
           && base.historyRevision === e.revision) {
         const loadedDetail = new Map(base.turns
-          .filter((turn) => turn.detailLoaded)
+          .filter((turn) => turn.detailLoaded
+            || (turn.detailProjection?.segments.length ?? 0) > 0)
           .map((turn) => [turn.id, turn]));
         turns = turns.map((turn) => {
           const detail = loadedDetail.get(turn.id);
@@ -2181,6 +2206,16 @@ function reduceEvent(
           }
           return merged;
         });
+        const cachedScopeMatches = e.generation != null
+          ? base.historyGeneration === e.generation
+          : base.historyGeneration == null;
+        if (cachedScopeMatches && base.hydratedCacheTurnIds.length > 0) {
+          const cachedIds = new Set(base.hydratedCacheTurnIds);
+          turns = restoreCachedTurnDetails(
+            turns,
+            base.turns.filter((turn) => cachedIds.has(turn.id)),
+          );
+        }
       }
       turns = turns.map(withLimitedTurnBlocks);
       const boundedTurns = boundRuntimeTurns(turns);

--- a/web/src/skill-catalog-cache.ts
+++ b/web/src/skill-catalog-cache.ts
@@ -106,7 +106,9 @@ export class SkillCatalogRequestCoordinator {
   private readonly begin: (
     request: SkillCatalogRequest,
   ) => string | null;
-  private active: ActiveSkillCatalogRead | null = null;
+  // Keep each response shape bounded to one request while allowing the
+  // latency-sensitive Skills lane to bypass slow plugin/app/MCP inventory.
+  private readonly active = new Map<boolean, ActiveSkillCatalogRead>();
   private readonly queued = new Map<string, SkillCatalogRequest>();
   private readonly mutations = new Map<string, SkillCatalogMutation>();
   private readonly latestMutationByScope = new Map<string, number>();
@@ -118,10 +120,11 @@ export class SkillCatalogRequestCoordinator {
 
   request(request: SkillCatalogRequest): boolean {
     const readKey = skillCatalogReadKey(request.key, request.skillsOnly);
-    if (this.active) {
+    const active = this.active.get(request.skillsOnly);
+    if (active) {
       const activeKey = skillCatalogReadKey(
-        this.active.key, this.active.skillsOnly);
-      if (activeKey !== readKey || this.active.superseded) {
+        active.key, active.skillsOnly);
+      if (activeKey !== readKey || active.superseded) {
         this.queued.set(readKey, request);
       }
       return false;
@@ -146,18 +149,17 @@ export class SkillCatalogRequestCoordinator {
       generation,
     });
     this.latestMutationByScope.set(request.key, generation);
-    if (this.active?.key === request.key) {
-      this.active.superseded = true;
+    for (const active of this.active.values()) {
+      if (active.key === request.key) active.superseded = true;
     }
     return true;
   }
 
   accept(response: EngineCapabilities): SkillCatalogAcceptance | null {
     let accepted: SkillCatalogAcceptance | null = null;
-    if (this.active
-        && skillCatalogResponseMatches(this.active, response)) {
-      const active = this.active;
-      this.active = null;
+    const active = this.active.get(response.skills_only);
+    if (active && skillCatalogResponseMatches(active, response)) {
+      this.active.delete(response.skills_only);
       accepted = {
         request: active,
         source: "read",
@@ -187,9 +189,10 @@ export class SkillCatalogRequestCoordinator {
 
   hasPendingRead(key: string, skillsOnly: boolean): boolean {
     const readKey = skillCatalogReadKey(key, skillsOnly);
+    const active = this.active.get(skillsOnly);
     return (
-      !!this.active
-        && skillCatalogReadKey(this.active.key, this.active.skillsOnly)
+      !!active
+        && skillCatalogReadKey(active.key, active.skillsOnly)
           === readKey
     ) || this.queued.has(readKey);
   }
@@ -202,7 +205,7 @@ export class SkillCatalogRequestCoordinator {
   }
 
   resetReads(): void {
-    this.active = null;
+    this.active.clear();
     this.queued.clear();
   }
 
@@ -213,22 +216,23 @@ export class SkillCatalogRequestCoordinator {
   }
 
   private beginRead(request: SkillCatalogRequest): boolean {
+    if (this.active.has(request.skillsOnly)) return false;
     const requestId = this.begin(request);
     if (!requestId) return false;
-    this.active = {
+    this.active.set(request.skillsOnly, {
       ...request,
       requestId,
       superseded: false,
-    };
+    });
     return true;
   }
 
   private drain(): void {
-    if (this.active) return;
     for (const [readKey, request] of this.queued) {
+      if (this.active.has(request.skillsOnly)) continue;
       if (this.hasPendingMutation(request.key)) continue;
       this.queued.delete(readKey);
-      if (this.beginRead(request)) return;
+      if (this.beginRead(request)) continue;
       // A failed send has already surfaced a command error. Continue so one
       // bad queued request cannot discard or starve unrelated scopes.
     }

--- a/web/src/skill-catalog-cache.ts
+++ b/web/src/skill-catalog-cache.ts
@@ -1,4 +1,9 @@
-import type { Engine, EngineCapabilityItem, Space } from "./protocol";
+import type {
+  Engine,
+  EngineCapabilities,
+  EngineCapabilityItem,
+  Space,
+} from "./protocol";
 
 export const SKILL_CATALOG_TTL_MS = 5 * 60_000;
 export const MAX_SKILL_CATALOGS = 32;
@@ -8,12 +13,73 @@ export interface SkillCatalogCacheEntry {
   fetchedAt: number;
 }
 
+export interface SkillCatalogRequest {
+  key: string;
+  engine: Engine;
+  space: Space;
+  cwd: string;
+  skillsOnly: boolean;
+}
+
+export interface SkillCatalogReadIdentity extends SkillCatalogRequest {
+  requestId: string;
+}
+
+interface ActiveSkillCatalogRead extends SkillCatalogReadIdentity {
+  superseded: boolean;
+}
+
+interface SkillCatalogMutation extends SkillCatalogReadIdentity {
+  generation: number;
+}
+
+export interface SkillCatalogAcceptance {
+  request: SkillCatalogRequest;
+  source: "read" | "mutation";
+  superseded: boolean;
+}
+
 export const skillCatalogKey = (
   machineId: string,
   engine: Engine,
   space: Space,
   cwd: string,
 ): string => [machineId, engine, space, cwd || "."].join("\u0000");
+
+export const skillCatalogReadKey = (
+  catalogKey: string,
+  skillsOnly: boolean,
+): string => `${catalogKey}\u0000${skillsOnly ? "skills" : "all"}`;
+
+export const skillCatalogResponseMatches = (
+  read: SkillCatalogReadIdentity,
+  response: EngineCapabilities,
+): boolean => (
+  response.request_id === read.requestId
+  && response.engine === read.engine
+  && response.space === read.space
+  // An empty cwd deliberately asks the wrapper for its configured default;
+  // the response carries that resolved path, which the browser cannot know
+  // before the request. Explicit cwd scopes still require exact equality.
+  && (!read.cwd || response.cwd === read.cwd)
+  && response.skills_only === read.skillsOnly
+);
+
+export const skillCatalogMutationResponseMatches = (
+  mutation: SkillCatalogReadIdentity,
+  response: EngineCapabilities,
+): boolean => (
+  !response.skills_only
+  && skillCatalogResponseMatches(mutation, response)
+);
+
+export const skillCatalogRefreshSucceeded = (
+  response: EngineCapabilities,
+): boolean => !(response.errors ?? []).some((error) => (
+  response.skills_only
+  || error === "capability discovery failed"
+  || error.startsWith("skills:")
+));
 
 export const skillCatalogFresh = (
   entry: SkillCatalogCacheEntry | undefined,
@@ -34,4 +100,137 @@ export function cacheSkillCatalog(
     delete next[oldKey];
   }
   return next;
+}
+
+export class SkillCatalogRequestCoordinator {
+  private readonly begin: (
+    request: SkillCatalogRequest,
+  ) => string | null;
+  private active: ActiveSkillCatalogRead | null = null;
+  private readonly queued = new Map<string, SkillCatalogRequest>();
+  private readonly mutations = new Map<string, SkillCatalogMutation>();
+  private readonly latestMutationByScope = new Map<string, number>();
+  private mutationGeneration = 0;
+
+  constructor(begin: (request: SkillCatalogRequest) => string | null) {
+    this.begin = begin;
+  }
+
+  request(request: SkillCatalogRequest): boolean {
+    const readKey = skillCatalogReadKey(request.key, request.skillsOnly);
+    if (this.active) {
+      const activeKey = skillCatalogReadKey(
+        this.active.key, this.active.skillsOnly);
+      if (activeKey !== readKey || this.active.superseded) {
+        this.queued.set(readKey, request);
+      }
+      return false;
+    }
+    if (this.hasPendingMutation(request.key)) {
+      this.queued.set(readKey, request);
+      return false;
+    }
+    return this.beginRead(request);
+  }
+
+  trackMutation(
+    requestId: string | null | undefined,
+    request: SkillCatalogRequest,
+  ): boolean {
+    if (!requestId) return false;
+    const generation = ++this.mutationGeneration;
+    this.mutations.set(requestId, {
+      ...request,
+      requestId,
+      skillsOnly: false,
+      generation,
+    });
+    this.latestMutationByScope.set(request.key, generation);
+    if (this.active?.key === request.key) {
+      this.active.superseded = true;
+    }
+    return true;
+  }
+
+  accept(response: EngineCapabilities): SkillCatalogAcceptance | null {
+    let accepted: SkillCatalogAcceptance | null = null;
+    if (this.active
+        && skillCatalogResponseMatches(this.active, response)) {
+      const active = this.active;
+      this.active = null;
+      accepted = {
+        request: active,
+        source: "read",
+        superseded: active.superseded,
+      };
+    } else if (response.request_id) {
+      const mutation = this.mutations.get(response.request_id);
+      if (mutation
+          && skillCatalogMutationResponseMatches(mutation, response)) {
+        this.mutations.delete(response.request_id);
+        accepted = {
+          request: mutation,
+          source: "mutation",
+          superseded:
+            this.latestMutationByScope.get(mutation.key)
+              !== mutation.generation,
+        };
+        if (!this.hasPendingMutation(mutation.key)) {
+          this.latestMutationByScope.delete(mutation.key);
+        }
+      }
+    }
+    if (!accepted) return null;
+    this.drain();
+    return accepted;
+  }
+
+  hasPendingRead(key: string, skillsOnly: boolean): boolean {
+    const readKey = skillCatalogReadKey(key, skillsOnly);
+    return (
+      !!this.active
+        && skillCatalogReadKey(this.active.key, this.active.skillsOnly)
+          === readKey
+    ) || this.queued.has(readKey);
+  }
+
+  hasPendingMutation(key: string): boolean {
+    for (const mutation of this.mutations.values()) {
+      if (mutation.key === key) return true;
+    }
+    return false;
+  }
+
+  resetReads(): void {
+    this.active = null;
+    this.queued.clear();
+  }
+
+  reset(): void {
+    this.resetReads();
+    this.mutations.clear();
+    this.latestMutationByScope.clear();
+  }
+
+  private beginRead(request: SkillCatalogRequest): boolean {
+    const requestId = this.begin(request);
+    if (!requestId) return false;
+    this.active = {
+      ...request,
+      requestId,
+      superseded: false,
+    };
+    return true;
+  }
+
+  private drain(): void {
+    if (this.active) return;
+    for (const [readKey, request] of this.queued) {
+      if (this.hasPendingMutation(request.key)) continue;
+      this.queued.delete(readKey);
+      if (this.beginRead(request)) return;
+      // A failed send has already surfaced a command error. Continue so one
+      // bad queued request cannot discard or starve unrelated scopes.
+    }
+  }
 }

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -802,24 +802,25 @@ export class RelayWs {
   }
 
   sendGetEngineCapabilities(engine: "claude" | "codex", space: Space,
-                            cwd?: string | null): void {
+                            cwd?: string | null,
+                            skillsOnly = false): string | null {
     const frame: Record<string, unknown> = {
       v: PROTOCOL_VERSION, type: "get_engine_capabilities", engine, space,
-      client_id: this.clientId, ts: nowTs(),
+      client_id: this.clientId, skills_only: skillsOnly, ts: nowTs(),
     };
     if (cwd) frame.cwd = cwd;
-    this.send(frame);
+    return this.sendTracked(frame);
   }
 
   sendManageEnginePlugin(engine: "claude" | "codex", space: Space,
                          action: "install" | "uninstall", pluginId: string,
-                         cwd?: string | null): boolean {
+                         cwd?: string | null): string | null {
     const frame: Record<string, unknown> = {
       v: PROTOCOL_VERSION, type: "manage_engine_plugin", engine, space,
       action, plugin_id: pluginId, client_id: this.clientId, ts: nowTs(),
     };
     if (cwd) frame.cwd = cwd;
-    return this.send(frame);
+    return this.sendTracked(frame);
   }
 
   sendManageEngineSkill(
@@ -830,7 +831,7 @@ export class RelayWs {
       instructions?: string; scope?: "user" | "project";
     },
     cwd?: string | null,
-  ): boolean {
+  ): string | null {
     const frame: Record<string, unknown> = {
       v: PROTOCOL_VERSION, type: "manage_engine_skill", engine, space, action,
       client_id: this.clientId, ts: nowTs(),
@@ -841,7 +842,7 @@ export class RelayWs {
     if (options.instructions !== undefined) frame.instructions = options.instructions;
     if (options.scope) frame.scope = options.scope;
     if (cwd) frame.cwd = cwd;
-    return this.send(frame);
+    return this.sendTracked(frame);
   }
 
   sendManageEngineHook(
@@ -852,7 +853,7 @@ export class RelayWs {
       timeout?: number; scope?: "user" | "project";
     },
     cwd?: string | null,
-  ): boolean {
+  ): string | null {
     const frame: Record<string, unknown> = {
       v: PROTOCOL_VERSION, type: "manage_engine_hook", engine, space, action,
       client_id: this.clientId, ts: nowTs(),
@@ -864,7 +865,7 @@ export class RelayWs {
     if (options.timeout !== undefined) frame.timeout = options.timeout;
     if (options.scope) frame.scope = options.scope;
     if (cwd) frame.cwd = cwd;
-    return this.send(frame);
+    return this.sendTracked(frame);
   }
 
   sendAnswerQuestion(

--- a/web/tests/history-browser.fixture.tsx
+++ b/web/tests/history-browser.fixture.tsx
@@ -1019,18 +1019,24 @@ export function HistoryBrowserFixture() {
       {quotaComposer && (
         <div className="composer" data-testid="quota-composer">
           <div className="composer-in">
+            <div className="inrow">
+              <button className="cmdbtn" type="button" aria-label="add">+</button>
+              <textarea rows={1} aria-label="message"
+                placeholder="输入 / 命令，$ Skill" />
+              <button className="sendbtn" type="button" aria-label="send">↑</button>
+            </div>
             <div className="hint">
               <button className="hint-mode" type="button">
-                Full access · idle <span className="hint-mode-ch">▾</span>
+                Full Access <span className="hint-mode-ch">▾</span>
               </button>
               <span className="hint-kbds">keyboard shortcuts</span>
               <div className="hint-right">
                 <button className="hint-ctl" type="button">
-                  gpt-5.6-codex
+                  GPT-5.6 Sol
                 </button>
                 <button className="hint-ctl" type="button">xhigh</button>
-                <button className="hint-ctl fast-chip" type="button">
-                  standard
+                <button className="hint-ctl fast-chip on" type="button">
+                  快速
                 </button>
                 <UsageMeter
                   open={false}

--- a/web/tests/history-browser.fixture.tsx
+++ b/web/tests/history-browser.fixture.tsx
@@ -356,6 +356,25 @@ function mermaidTurn(invalid = false, source?: string): Turn {
   };
 }
 
+function mathTurn(): Turn {
+  return {
+    id: "math",
+    prompt: "渲染数学公式",
+    blocks: [{
+      kind: "text",
+      message_id: "math-message",
+      channel: "final",
+      text: String.raw`\[ r = \frac{h}{\sin |\alpha|} \]
+
+Inline: \(h = r \sin \alpha\).`,
+      done: true,
+    }],
+    done: true,
+    ts: Date.now(),
+    doneTs: Date.now(),
+  };
+}
+
 interface FixtureSession {
   turns: Turn[];
   cursor: string;
@@ -385,6 +404,7 @@ export function HistoryBrowserFixture() {
   const actualMermaid = params.has("actual-mermaid");
   const invalidMermaid = params.has("invalid-mermaid");
   const mermaidHistory = params.has("mermaid-history");
+  const math = params.has("math");
   const composerAttachment = params.has("composer-attachment");
   const composerResize = params.has("composer-resize");
   const quotaComposer = params.has("quota-composer");
@@ -418,6 +438,7 @@ export function HistoryBrowserFixture() {
         actualMermaid ? ROBOT_CORE_MERMAID_SOURCE : undefined,
       )];
     }
+    if (math) return [mathTurn()];
     if (mermaidHistory) {
       return [
         mermaidTurn(),
@@ -450,7 +471,7 @@ export function HistoryBrowserFixture() {
   }, [
     actualMermaid, compactTools, detailPaging, detailRetainedPreview,
     detailScrollCancel, dualImage,
-    interactiveTimeline,
+    interactiveTimeline, math,
     deepBrowse, invalidMermaid, large, largeCount, mermaid, mermaidHistory,
     timeline,
   ]);
@@ -460,7 +481,7 @@ export function HistoryBrowserFixture() {
       turns: initialA,
       cursor: initialA[0]?.id ?? "",
       hasMore: !compactTools && !detailPaging && !invalidMermaid && !large && !mermaid
-        && !mermaidHistory && !timeline && !deepBrowse,
+        && !mermaidHistory && !math && !timeline && !deepBrowse,
       pagesLoaded: 0,
       hasNewer: deepBrowse,
       newerPagesLoaded: 0,

--- a/web/tests/history-browser.spec.ts
+++ b/web/tests/history-browser.spec.ts
@@ -1971,33 +1971,71 @@ test("composer action growth keeps the live tail visible without stealing histor
   expect(Math.abs(after.offset - before.offset)).toBeLessThan(2);
 });
 
-test("Codex quota controls fit a 320 px composer", async ({ page }) => {
-  await page.setViewportSize({ width: 320, height: 720 });
-  await page.goto("/tests/history-browser.html?quota-composer=1");
+for (const width of [320, 390]) {
+  test(`Codex controls stay on one row in a ${width} px composer`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width, height: 720 });
+    await page.goto("/tests/history-browser.html?quota-composer=1");
 
-  const composer = page.getByTestId("quota-composer");
-  await expect(composer.locator(".usage-meter")).toBeVisible();
-  await expect(composer.locator(".hint-ring")).toBeVisible();
+    const composer = page.getByTestId("quota-composer");
+    const input = composer.getByRole("textbox", { name: "message" });
+    await expect(input).toHaveAttribute(
+      "placeholder", "输入 / 命令，$ Skill");
+    await expect(composer.locator(".fast-chip")).toHaveText("快速");
+    await expect(composer.locator(".fast-chip")).not.toContainText("⚡");
+    await expect(composer.locator(".usage-meter")).toBeVisible();
+    await expect(composer.locator(".hint-ring")).toBeVisible();
+    const inputHeight = await input.evaluate((node) => ({
+      client: node.clientHeight,
+      scroll: node.scrollHeight,
+    }));
+    expect(inputHeight.scroll).toBeLessThanOrEqual(inputHeight.client + 1);
 
-  const layout = await composer.evaluate((node) => {
-    const footer = node.getBoundingClientRect();
-    const right = node.querySelector<HTMLElement>(".hint-right")
-      ?.getBoundingClientRect();
-    return {
-      clientWidth: node.clientWidth,
-      scrollWidth: node.scrollWidth,
-      rightLeft: right?.left ?? -1,
-      rightRight: right?.right ?? -1,
-      rightWidth: right?.width ?? 0,
-      footerLeft: footer.left,
-      footerRight: footer.right,
-    };
+    const layout = await composer.evaluate((node) => {
+      const footer = node.getBoundingClientRect();
+      const controls = [
+        node.querySelector<HTMLElement>(".hint-mode"),
+        ...node.querySelectorAll<HTMLElement>(".hint-right > .hint-ctl"),
+        node.querySelector<HTMLElement>(".usage-meter"),
+        node.querySelector<HTMLElement>(".hint-ring"),
+      ].filter((control): control is HTMLElement => control !== null)
+        .map((control) => {
+          const rect = control.getBoundingClientRect();
+          return {
+            left: rect.left,
+            right: rect.right,
+            width: rect.width,
+            centerY: rect.top + rect.height / 2,
+          };
+        });
+      return {
+        clientWidth: node.clientWidth,
+        scrollWidth: node.scrollWidth,
+        footerLeft: footer.left,
+        footerRight: footer.right,
+        controls,
+      };
+    });
+    expect(layout.controls).toHaveLength(6);
+    expect(layout.scrollWidth).toBeLessThanOrEqual(layout.clientWidth);
+    expect(Math.max(...layout.controls.map((control) => control.centerY))
+      - Math.min(...layout.controls.map((control) => control.centerY)))
+      .toBeLessThanOrEqual(2);
+    const minimumWidths = [48, 48, 28, 20, 44, 28];
+    for (const [index, control] of layout.controls.entries()) {
+      expect(control.width).toBeGreaterThanOrEqual(minimumWidths[index]);
+    }
+    for (const [index, control] of layout.controls.entries()) {
+      expect(control.left).toBeGreaterThanOrEqual(layout.footerLeft);
+      expect(control.right).toBeLessThanOrEqual(layout.footerRight);
+      if (index > 0) {
+        expect(control.left - layout.controls[index - 1].right)
+          .toBeGreaterThanOrEqual(10);
+      }
+    }
   });
-  expect(layout.scrollWidth).toBeLessThanOrEqual(layout.clientWidth);
-  expect(layout.rightLeft).toBeGreaterThanOrEqual(layout.footerLeft);
-  expect(layout.rightRight).toBeLessThanOrEqual(layout.footerRight);
-  expect(layout.rightWidth).toBeGreaterThan(280);
-});
+}
 
 test("queued messages expand to full editable prompts", async ({ page }) => {
   await page.setViewportSize({ width: 320, height: 720 });

--- a/web/tests/history-browser.spec.ts
+++ b/web/tests/history-browser.spec.ts
@@ -655,6 +655,79 @@ test("history page cache upgrades v1 and preserves pages in real IndexedDB", asy
   expect(result.afterInvalidation).toBeNull();
 });
 
+test("instant session cache preserves a heavy turn's complete process skeleton", async ({
+  page,
+}) => {
+  await page.goto("/tests/history-browser.html");
+  const result = await page.evaluate(async () => {
+    const cache = await import("/src/cache.ts");
+    await cache.clearCache();
+    cache.saveSession("heavy-refresh-session", [{
+      id: "heavy-refresh-turn",
+      prompt: "1",
+      done: true,
+      images: [{
+        media_type: "image/png",
+        data: "i".repeat(2 * 1024 * 1024 + 1),
+      }],
+      blocks: [
+        {
+          kind: "text", message_id: "heavy-commentary", text: "2",
+          done: true, channel: "commentary",
+        },
+        {
+          kind: "tool", message_id: "heavy-tool-message-3",
+          tool_use_id: "heavy-tool-3", tool: "Read",
+          input: { file_path: "/tmp/3" },
+          result: {
+            content: "x".repeat(2 * 1024 * 1024 + 1),
+            is_error: false,
+          },
+          done: true,
+        },
+        {
+          kind: "tool", message_id: "heavy-tool-message-4",
+          tool_use_id: "heavy-tool-4", tool: "Bash",
+          input: { command: "echo 4" }, done: true,
+        },
+        {
+          kind: "process", item_id: "heavy-process-5",
+          processKind: "command", phase: "snapshot", status: "succeeded",
+          title: "5", done: true,
+        },
+        {
+          kind: "text", message_id: "heavy-final", text: "6",
+          done: true, channel: "final",
+        },
+      ],
+      detailEventCount: 4,
+    }], 42, "heavy-refresh-r1", "heavy-refresh-g1");
+    await new Promise((resolve) => window.setTimeout(resolve, 700));
+    const loaded = await cache.loadSession("heavy-refresh-session");
+    const turn = loaded?.turns[0] as {
+      images?: unknown[];
+      blocks?: Array<Record<string, unknown>>;
+      detailProjection?: unknown;
+    } | undefined;
+    return {
+      size: new TextEncoder().encode(JSON.stringify(turn)).byteLength,
+      hasImages: Array.isArray(turn?.images),
+      hasDetailProjection: turn?.detailProjection != null,
+      process: turn?.blocks?.map((block) => (
+        block.kind === "text" ? block.text
+          : block.kind === "tool" ? block.tool_use_id
+            : block.title
+      )),
+    };
+  });
+  expect(result.size).toBeLessThan(2 * 1024 * 1024);
+  expect(result.hasImages).toBe(false);
+  expect(result.hasDetailProjection).toBe(false);
+  expect(result.process).toEqual([
+    "2", "heavy-tool-3", "heavy-tool-4", "5", "6",
+  ]);
+});
+
 test("a canonical image reference does not reserve a second hidden image row", async ({
   page,
 }) => {
@@ -782,6 +855,20 @@ test("completed Mermaid fences render isolated sanitized SVGs", async ({
     page.locator(".mermaid-svg > svg").first().getAttribute("id"),
   ).not.toBe(lightId);
   await expect(diagrams.nth(0)).toHaveAttribute("data-mermaid-state", "ready");
+});
+
+test("completed chat formulas lazy-load accessible KaTeX markup", async ({
+  page,
+}) => {
+  await page.goto("/tests/history-browser.html?math=1");
+  await expect(page.locator(".katex-display")).toHaveCount(1);
+  await expect(page.locator(".katex")).toHaveCount(2);
+  await expect(page.locator(".katex-mathml math")).toHaveCount(2);
+  await expect(page.locator('[data-turn-id="math"]')).toContainText(
+    "Inline:",
+  );
+  await expect(page.locator('[data-turn-id="math"] .message-code-copy'))
+    .toHaveCount(0);
 });
 
 test("a completed Mermaid diagram opens the shared pinch-zoom preview", async ({

--- a/web/tests/markdown-preview.test.ts
+++ b/web/tests/markdown-preview.test.ts
@@ -175,6 +175,9 @@ const harness = await createServer({
 });
 try {
   const { initialState, reduce } = await harness.ssrLoadModule("/src/reducer.ts");
+  const { preloadMarkdownMathPlugins } = await harness.ssrLoadModule(
+    "/src/markdown-math.ts");
+  await preloadMarkdownMathPlugins();
   const { ArtifactPanel } = await harness.ssrLoadModule(
     "/src/components/ArtifactPanel.tsx");
   const { buildSandboxDocument } = await harness.ssrLoadModule(
@@ -204,6 +207,63 @@ try {
   assert.match(completedMermaidMarkup, /class="mermaid-source"/);
   assert.match(completedMermaidMarkup, /flowchart LR/);
   assert.match(completedMermaidMarkup, /aria-label="复制 Mermaid 源码"/);
+  const completedDisplayBracketMath = renderToStaticMarkup(
+    createElement(MessageBlock, {
+      text: String.raw`\[ r = \frac{h}{\sin |\alpha|} \]`,
+      done: true,
+    }),
+  );
+  assert.match(completedDisplayBracketMath, /class="katex-display"/,
+    "completed assistant bracket-delimited display math must render with KaTeX");
+  assert.doesNotMatch(completedDisplayBracketMath, /aria-label="复制代码"/,
+    "math output must not be wrapped in the fenced-code copy UI");
+  const completedInlineBracketMath = renderToStaticMarkup(
+    createElement(MessageBlock, {
+      text: String.raw`半径为 \(r = h / \sin \alpha\)。`,
+      done: true,
+    }),
+  );
+  assert.match(completedInlineBracketMath, /class="katex"/,
+    "completed assistant bracket-delimited inline math must render with KaTeX");
+  const completedDollarMath = renderToStaticMarkup(createElement(MessageBlock, {
+    text: String.raw`inline $r=h$
+
+$$
+h=r\sin\alpha
+$$`,
+    done: true,
+  }));
+  assert.match(completedDollarMath, /class="katex"/);
+  assert.match(completedDollarMath, /class="katex-display"/,
+    "both dollar-delimited inline and display math remain supported");
+  const streamingMathMarkup = renderToStaticMarkup(createElement(MessageBlock, {
+    text: String.raw`\[ r = \frac{h}{\sin |\alpha|} \]`,
+    done: false,
+  }));
+  assert.doesNotMatch(streamingMathMarkup, /class="katex/,
+    "streaming formula source stays stable until the message is terminal");
+  assert.match(streamingMathMarkup, /\\frac/,
+    "streaming formula source remains readable instead of repeatedly re-laying out");
+  const literalMathMarkup = renderToStaticMarkup(createElement(MessageBlock, {
+    text: "Inline code: `\\(\\alpha\\)`\n\n"
+      + "```text\n\\[not math\\]\n```",
+    done: true,
+  }));
+  assert.doesNotMatch(literalMathMarkup, /class="katex/,
+    "math delimiters inside inline and fenced code remain literal");
+  assert.match(literalMathMarkup, /aria-label="复制代码"/);
+  const plainBracketMarkup = renderToStaticMarkup(createElement(MessageBlock, {
+    text: "普通数组 [1, 2, 3] 不是数学定界符。",
+    done: true,
+  }));
+  assert.doesNotMatch(plainBracketMarkup, /class="katex/,
+    "ordinary square brackets must never be guessed as display math");
+  const untrustedMathMarkup = renderToStaticMarkup(createElement(MessageBlock, {
+    text: String.raw`$\href{javascript:alert(1)}{unsafe}$`,
+    done: true,
+  }));
+  assert.doesNotMatch(untrustedMathMarkup, /href="javascript:/,
+    "KaTeX trust stays disabled for model-provided commands");
   const codexDirectiveMarkup = renderToStaticMarkup(createElement(MessageBlock, {
     text: "提交完成。\n\n::git-commit{cwd=\"/tmp/private-project\"}",
     done: true,
@@ -463,6 +523,26 @@ try {
   assert.match(mermaidPreviewMarkup, /sequenceDiagram/);
   assert.doesNotMatch(mermaidPreviewMarkup, /<pre><div/,
     "the Mermaid component must not be nested inside an invalid pre element");
+  const mathPreviewMarkup = renderToStaticMarkup(createElement(ArtifactPanel, {
+    artifact: {
+      file: "docs/formula.md",
+      sid: "session-1",
+      requestId: "preview-math",
+      kind: "md",
+      content: String.raw`\[ r = \frac{h}{\sin |\alpha|} \]`,
+      size: 42,
+      mtimeNs: "4",
+      revision: "c".repeat(64),
+      assets: {},
+    },
+    active: "diff",
+    hasBtw: false,
+    onTab: () => {},
+    onClose: () => {},
+  }));
+  assert.match(mathPreviewMarkup, /class="katex-display"/,
+    "artifact Markdown preview and chat messages must share math rendering");
+  assert.doesNotMatch(mathPreviewMarkup, /aria-label="复制代码"/);
 
   const messageMarkup = renderToStaticMarkup(createElement(MessageBlock, {
     text: "[codex_stream.py](/home/nancy/project/codex_stream.py:731)",

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -17,7 +17,10 @@ import {
   queuedQueryWireBytes,
   reduceTargetedRuntime,
 } from "../src/runtime-drain.ts";
-import { mergeInitialHistory } from "../src/history-merge.ts";
+import {
+  mergeInitialHistory,
+  restoreCachedTurnDetails,
+} from "../src/history-merge.ts";
 import {
   HISTORY_INITIAL_PAGE,
   HISTORY_MORE_PAGE,
@@ -693,7 +696,7 @@ assert.match(historyAppSource,
 assert.match(historyAppSource,
   /onLoadHistoryImage=\{historyView\.recovering\s*\? undefined/,
   "display-only recovery turns must not issue history-image reads");
-assert.match(cacheSource, /const CACHE_VER = 9/,
+assert.match(cacheSource, /const CACHE_VER = 10/,
   "open-turn merge repair must invalidate duplicate IndexedDB projections");
 assert.match(cacheSource, /objectStore\(STORE\)\.delete\(sessionId\)/);
 assert.match(cacheSource, /job\.epoch !== sessionEpoch\(job\.sid\)/,
@@ -2196,6 +2199,238 @@ try {
   assert.ok(refreshedSummary.runtimes[summarySid].turns[0]
     .detailProjection?.blocks.some((block: Block) => block.kind === "tool"),
   "a same-revision head refresh must not collapse detail the user opened");
+
+  const refreshSid = "completed-process-refresh";
+  const cachedSixStepTurn: Turn = {
+    id: "refresh-turn",
+    prompt: "1",
+    done: true,
+    blocks: [
+      {
+        kind: "text", message_id: "refresh-commentary", text: "2",
+        done: true, channel: "commentary",
+      },
+      {
+        kind: "tool", message_id: "refresh-tool-message-3",
+        tool_use_id: "refresh-tool-3", tool: "Read",
+        input: { file_path: "/tmp/3" }, done: true,
+      },
+      {
+        kind: "tool", message_id: "refresh-tool-message-4",
+        tool_use_id: "refresh-tool-4", tool: "Bash",
+        input: { command: "echo 4" }, done: true,
+      },
+      {
+        kind: "process", item_id: "refresh-process-5",
+        processKind: "command", phase: "snapshot", status: "succeeded",
+        title: "5", done: true,
+      },
+      {
+        kind: "text", message_id: "refresh-final", text: "6",
+        done: true, channel: "final",
+      },
+    ],
+    detailEventCount: 4,
+  };
+  const refreshSummary = () => event({
+    type: "history", session_id: refreshSid, revision: "refresh-r1",
+    generation: "refresh-g1", build_seq: 1, live_seq: 0,
+    detail: "summary", has_more: false, oldest_id: "refresh-turn",
+    events: [], turns: [{
+      id: "refresh-turn", prompt: "1", done: true,
+      blocks: [{
+        kind: "text", message_id: "refresh-final", text: "6",
+        done: true, channel: "final",
+      }],
+      detailEventCount: 4, detailLoaded: false,
+    }],
+  });
+  const processFingerprint = (turn: Turn): string[] =>
+    (turn.detailProjection?.blocks ?? []).map((block) => {
+      if (block.kind === "text") return block.text;
+      if (block.kind === "tool") return block.tool_use_id;
+      return block.title;
+    });
+  const twoCachedRestores = restoreCachedTurnDetails(
+    [
+      {
+        ...cachedSixStepTurn,
+        id: "refresh-turn-older",
+        prompt: "older",
+        blocks: [cachedSixStepTurn.blocks.at(-1)!],
+      },
+      {
+        ...cachedSixStepTurn,
+        blocks: [cachedSixStepTurn.blocks.at(-1)!],
+      },
+    ],
+    [
+      {
+        ...cachedSixStepTurn,
+        id: "refresh-turn-older",
+        prompt: "older",
+      },
+      cachedSixStepTurn,
+    ],
+  );
+  assert.deepEqual(
+    twoCachedRestores.map((turn) => !!turn.detailRestorePending),
+    [false, true],
+    "refresh automatically validates only the newest affected turn instead of downloading every cached process",
+  );
+
+  let cacheFirstRefresh = reduce({
+    ...initialState, focusedSid: refreshSid,
+    runtimes: { [refreshSid]: createRuntime() },
+  }, {
+    type: "hydrate_cache", sid: refreshSid, turns: [cachedSixStepTurn],
+    revision: "refresh-r1", generation: "refresh-g1",
+  });
+  cacheFirstRefresh = reduce(cacheFirstRefresh, {
+    type: "event", event: refreshSummary(),
+  });
+  assert.deepEqual(
+    processFingerprint(cacheFirstRefresh.runtimes[refreshSid].turns[0]),
+    ["2", "refresh-tool-3", "refresh-tool-4", "5"],
+    "cache-first refresh must keep the completed process visible while authoritative detail reloads",
+  );
+  assert.equal(
+    (cacheFirstRefresh.runtimes[refreshSid].turns[0] as Turn & {
+      detailRestorePending?: boolean;
+    }).detailRestorePending,
+    true,
+    "a same-revision cached process should schedule one authoritative detail restore",
+  );
+  assert.equal(
+    (cacheFirstRefresh.runtimes[refreshSid].turns[0] as Turn & {
+      detailRestoreOpen?: boolean;
+    }).detailRestoreOpen,
+    true,
+    "the newest compact process should stay open across a page refresh",
+  );
+
+  let historyFirstRefresh = reduce({
+    ...initialState, focusedSid: refreshSid,
+    runtimes: { [refreshSid]: createRuntime() },
+  }, {
+    type: "event", event: refreshSummary(),
+  });
+  historyFirstRefresh = reduce(historyFirstRefresh, {
+    type: "hydrate_cache", sid: refreshSid, turns: [cachedSixStepTurn],
+    revision: "refresh-r1", generation: "refresh-g1",
+  });
+  assert.deepEqual(
+    processFingerprint(historyFirstRefresh.runtimes[refreshSid].turns[0]),
+    ["2", "refresh-tool-3", "refresh-tool-4", "5"],
+    "History-first refresh must accept the same validated provisional process instead of racing it away",
+  );
+
+  let mismatchedRefresh = reduce({
+    ...initialState, focusedSid: refreshSid,
+    runtimes: { [refreshSid]: createRuntime() },
+  }, {
+    type: "event", event: refreshSummary(),
+  });
+  mismatchedRefresh = reduce(mismatchedRefresh, {
+    type: "hydrate_cache", sid: refreshSid, turns: [cachedSixStepTurn],
+    revision: "refresh-r1", generation: "stale-generation",
+  });
+  assert.deepEqual(
+    processFingerprint(mismatchedRefresh.runtimes[refreshSid].turns[0]),
+    [],
+    "a process cache from another wrapper generation must never be restored",
+  );
+  const mismatchedRevision = reduce(reduce({
+    ...initialState, focusedSid: refreshSid,
+    runtimes: { [refreshSid]: createRuntime() },
+  }, {
+    type: "event", event: refreshSummary(),
+  }), {
+    type: "hydrate_cache", sid: refreshSid, turns: [cachedSixStepTurn],
+    revision: "stale-revision", generation: "refresh-g1",
+  });
+  assert.deepEqual(
+    processFingerprint(mismatchedRevision.runtimes[refreshSid].turns[0]),
+    [],
+    "a process cache from another history revision must never be restored",
+  );
+
+  const restoreRequested = reduce(cacheFirstRefresh, {
+    type: "turn_detail_requested", sid: refreshSid, turnId: "refresh-turn",
+    autoLoad: false,
+  } as Parameters<typeof reduce>[1]);
+  assert.equal(
+    restoreRequested.runtimes[refreshSid].turns[0].detailAutoLoad,
+    false,
+    "automatic refresh repair fetches one newest detail page instead of paging a giant turn to EOF",
+  );
+  assert.equal(
+    (restoreRequested.runtimes[refreshSid].turns[0] as Turn & {
+      detailRestorePending?: boolean;
+    }).detailRestorePending,
+    false,
+    "an accepted restore request is one-shot",
+  );
+  const restoredDetail = reduce(restoreRequested, {
+    type: "event", event: event({
+      type: "turn_detail", session_id: refreshSid,
+      turn_id: "refresh-turn", revision: "refresh-r1",
+      has_more: true, oldest_cursor: "restore-older",
+      events: [
+        event({ type: "user_msg", sid: refreshSid,
+          msg_id: "refresh-turn", prompt: "1" }),
+        event({ type: "assistant_msg_start", sid: refreshSid,
+          message_id: "restore-commentary", channel: "commentary" }),
+        event({ type: "delta", sid: refreshSid,
+          message_id: "restore-commentary", channel: "commentary",
+          text: "2-server" }),
+        event({ type: "assistant_msg_end", sid: refreshSid,
+          message_id: "restore-commentary", channel: "commentary" }),
+        event({ type: "tool_use", sid: refreshSid,
+          message_id: "restore-tool-message", tool_use_id: "restore-tool-5",
+          tool: "Read", input: { file_path: "/tmp/5" } }),
+        event({ type: "tool_result", sid: refreshSid,
+          tool_use_id: "restore-tool-5", content: "ok", is_error: false }),
+        event({ type: "assistant_msg_start", sid: refreshSid,
+          message_id: "refresh-final", channel: "final" }),
+        event({ type: "delta", sid: refreshSid,
+          message_id: "refresh-final", channel: "final", text: "6" }),
+        event({ type: "assistant_msg_end", sid: refreshSid,
+          message_id: "refresh-final", channel: "final" }),
+        event({ type: "turn_end", sid: refreshSid, turn_id: "refresh-turn",
+          result: { subtype: "success", duration_ms: 1, is_error: false } }),
+      ],
+    }),
+  });
+  assert.deepEqual(
+    processFingerprint(restoredDetail.runtimes[refreshSid].turns[0]),
+    ["2-server", "restore-tool-5"],
+    "the authoritative newest detail page replaces rather than merges provisional cache blocks",
+  );
+  assert.equal(
+    restoredDetail.runtimes[refreshSid].turns[0].detailAutoLoad,
+    false,
+    "refresh repair must not follow has_more into an automatic full-turn download",
+  );
+  assert.equal(
+    restoredDetail.runtimes[refreshSid].turns[0].detailLoaded,
+    false,
+    "a one-page repair with older detail remaining must keep the explicit full-process affordance",
+  );
+  const userExpandedRestore = reduce(restoredDetail, {
+    type: "turn_detail_requested", sid: refreshSid, turnId: "refresh-turn",
+    autoLoad: true,
+  });
+  assert.equal(
+    userExpandedRestore.runtimes[refreshSid].turns[0].detailAutoLoad,
+    true,
+    "the user's later disclosure still upgrades the repair into full pagination",
+  );
+  assert.equal(
+    userExpandedRestore.runtimes[refreshSid].turns[0]
+      .detailRestoreIncomplete,
+    false,
+  );
 
   const managedClaudeSid = "managed-claude-session";
   const managedClaudeIdle = reduce({
@@ -6149,6 +6384,115 @@ const skipsOneOversizedCacheTurn = boundCachedTurns([
   { id: "huge", image: "x".repeat(2 * 1024 * 1024 + 1) },
 ]);
 assert.deepEqual(skipsOneOversizedCacheTurn, [{ id: "small", prompt: "keep" }]);
+const oversizedProcessCache = boundCachedTurns([{
+  id: "oversized-process",
+  prompt: "1",
+  done: true,
+  images: [{
+    media_type: "image/png",
+    data: "i".repeat(2 * 1024 * 1024 + 1),
+  }],
+  blocks: [
+    {
+      kind: "text", message_id: "oversized-commentary", text: "2",
+      done: true, channel: "commentary",
+    },
+    {
+      kind: "tool", message_id: "oversized-tool-message-3",
+      tool_use_id: "oversized-tool-3", tool: "Read",
+      input: { file_path: "/tmp/3" },
+      result: {
+        content: "x".repeat(2 * 1024 * 1024 + 1),
+        is_error: false,
+      },
+      done: true,
+    },
+    {
+      kind: "tool", message_id: "oversized-tool-message-4",
+      tool_use_id: "oversized-tool-4", tool: "Bash",
+      input: { command: "echo 4" }, done: true,
+    },
+    {
+      kind: "process", item_id: "oversized-process-5",
+      processKind: "command", phase: "snapshot", status: "succeeded",
+      title: "5", done: true,
+    },
+    {
+      kind: "text", message_id: "oversized-final", text: "6",
+      done: true, channel: "final",
+    },
+  ],
+  detailProjection: {
+    segments: [{
+      pageKey: "huge-segment",
+      before: null,
+      events: [{
+        type: "delta", sid: "oversized-process",
+        message_id: "huge-event", text: "y".repeat(2 * 1024 * 1024 + 1),
+        channel: "commentary", v: 22, ts: 1,
+      }],
+      hasMore: false,
+      oldestCursor: null,
+      hasNewer: false,
+      newerCursor: null,
+      encodedChars: 2 * 1024 * 1024 + 1,
+    }],
+    blocks: [],
+    capped: false,
+    hasMore: false,
+    oldestCursor: null,
+    hasNewer: false,
+    newerCursor: null,
+  },
+  detailEventCount: 4,
+  detailLoaded: true,
+}] as Turn[]) as Turn[];
+assert.equal(oversizedProcessCache.length, 1,
+  "one heavy attachment/output must not evict the whole visible turn");
+assert.equal(oversizedProcessCache[0].images, undefined,
+  "base64 attachments stay in the lazy history-image path");
+assert.equal(oversizedProcessCache[0].detailProjection, undefined,
+  "raw cursor pages are never copied into the instant-paint cache");
+assert.deepEqual(oversizedProcessCache[0].blocks.map((block) => {
+  if (block.kind === "text") return block.text;
+  if (block.kind === "tool") return block.tool_use_id;
+  return block.title;
+}), ["2", "oversized-tool-3", "oversized-tool-4", "5", "6"],
+"the compact cache keeps every visible 1..6 timeline identity across refresh");
+assert.ok(new TextEncoder().encode(
+  JSON.stringify(oversizedProcessCache[0])).byteLength < 2 * 1024 * 1024,
+"the instant projection must remain bounded independently of heavy detail");
+const smallImageCache = boundCachedTurns([{
+  id: "small-image-turn",
+  prompt: "preview",
+  done: true,
+  images: [{ media_type: "image/png", data: "small-preview" }],
+  blocks: [],
+}] as Turn[]) as Turn[];
+assert.equal(smallImageCache[0].images?.[0]?.data, "small-preview",
+  "small optimistic images remain available during the first paint");
+const extremeTimelineCache = boundCachedTurns([{
+  id: "extreme-timeline-turn",
+  prompt: "keep every visible row",
+  done: true,
+  blocks: Array.from({ length: 256 }, (_, index) => ({
+    kind: "tool" as const,
+    message_id: `message-${"m".repeat(12 * 1024)}-${index}`,
+    tool_use_id: `tool-${"t".repeat(12 * 1024)}-${index}`,
+    tool: "Bash",
+    input: { command: `echo ${index}` },
+    done: true,
+  })),
+}] as Turn[]) as Turn[];
+assert.equal(extremeTimelineCache.length, 1);
+assert.equal(extremeTimelineCache[0].blocks.length, 256,
+  "the hard cache fallback preserves the full bounded timeline skeleton");
+assert.equal(new Set(extremeTimelineCache[0].blocks.map((block) =>
+  block.kind === "tool" ? block.tool_use_id : "")).size, 256,
+"hard clipping must retain the unique suffix of every process identity");
+assert.ok(new TextEncoder().encode(
+  JSON.stringify(extremeTimelineCache[0])).byteLength < 2 * 1024 * 1024,
+"even pathological process identifiers cannot evict the current timeline");
 const stripsFileBodiesFromCache = boundCachedTurns([{
   id: "file-turn",
   prompt: "upload",

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -7257,6 +7257,14 @@ assert.ok(permissionControlIndex >= 0
     && permissionControlIndex < shortcutHintIndex
     && shortcutHintIndex < runtimeControlsIndex,
   "desktop composer must keep its original split control layout");
+assert.doesNotMatch(composerSource, /发消息…/,
+  "the compact composer placeholder must not wrap a redundant send label");
+assert.match(composerSource, /输入 \/ 命令，\$ Skill/,
+  "the Codex placeholder must retain command and Skill discovery");
+assert.match(composerSource, /p\.fast \? "快速" : "标准"/,
+  "the Fast control must use stable text labels");
+assert.doesNotMatch(composerSource, /⚡/,
+  "the Fast control must not add a lightning marker");
 const workDashboardSource = readFileSync(
   resolve(process.cwd(), "src/components/WorkDashboardSheet.tsx"), "utf8");
 assert.match(workDashboardSource, /<DateTimePicker value=\{scheduleAt\}/,
@@ -7273,8 +7281,17 @@ assert.doesNotMatch(appCssSource, /\.hint-mode\.busy/,
 assert.match(appCssSource, /\.hint-right\{[^}]*margin-left:auto/,
   "desktop composer controls must retain the original right alignment");
 assert.match(appCssSource,
-  /@media \(max-width:640px\)\{[\s\S]*?\.hint-kbds\{ display:none; \}[\s\S]*?\.hint-right\{[^}]*margin-left:0;[^}]*flex:1;[^}]*justify-content:space-between;/,
-  "mobile composer controls must distribute across the available row width");
+  /@media \(max-width:640px\)\{[\s\S]*?\.hint-kbds\{ display:none; \}[\s\S]*?\.hint-right\{[^}]*margin-left:0;[^}]*flex:1;[^}]*justify-content:flex-end;/,
+  "mobile composer controls must stay compact at the end of the row");
+assert.match(appCssSource,
+  /@media \(max-width:420px\)\{[\s\S]*?\.hint\{[^}]*flex-wrap:nowrap;[\s\S]*?\.hint-right\{[^}]*width:auto;[^}]*flex:1 1 auto;/,
+  "phone composer controls must remain on one row");
+assert.match(appCssSource,
+  /@media \(max-width:420px\)\{[\s\S]*?\.hint\{[^}]*gap:11px;[\s\S]*?\.hint-right\{[^}]*gap:11px;/,
+  "phone composer controls must retain readable separation");
+assert.match(appCssSource,
+  /\.usage-meter-line \.good\{ background:color-mix\(in srgb,var\(--ok\) 68%,white\); \}/,
+  "healthy compact quota bars must use a softer green");
 assert.match(appCssSource, /\.capabilities-sheet>header\{[^}]*flex:none/s,
   "the Extensions header must not collapse under a long capability list");
 assert.match(appCssSource, /\.capabilities-tabs\{[^}]*flex:none/s,

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -457,6 +457,61 @@ const capabilityResponse = (
   skills_only: skillsOnly,
 });
 
+const parallelLaneStarts: Array<{
+  requestId: string;
+  key: string;
+  skillsOnly: boolean;
+}> = [];
+const parallelLanes = new SkillCatalogRequestCoordinator((request) => {
+  const requestId = `parallel-read-${parallelLaneStarts.length + 1}`;
+  parallelLaneStarts.push({
+    requestId, key: request.key, skillsOnly: request.skillsOnly,
+  });
+  return requestId;
+});
+const parallelFullRequest = capabilityRequest(
+  repoSkillKey, "/repo/a", false);
+const parallelSkillsRequest = capabilityRequest(
+  repoSkillKey, "/repo/a", true);
+assert.equal(parallelLanes.request(parallelFullRequest), true);
+assert.equal(parallelLanes.request(parallelSkillsRequest), true,
+  "a Skills-only read must not wait for a slow full inventory read");
+assert.deepEqual(
+  parallelLaneStarts.map(({ skillsOnly }) => skillsOnly),
+  [false, true],
+  "full and Skills-only reads use independent bounded lanes");
+assert.equal(parallelLanes.accept(
+  capabilityResponse("parallel-read-2", "/repo/a", true))?.request.skillsOnly,
+  true);
+assert.equal(parallelLanes.hasPendingRead(repoSkillKey, false), true,
+  "accepting the fast Skills response must leave full inventory active");
+assert.equal(parallelLanes.hasPendingRead(repoSkillKey, true), false);
+assert.equal(parallelLanes.accept(
+  capabilityResponse("parallel-read-1", "/repo/a", false))?.request.skillsOnly,
+  false);
+
+const parallelMutationStarts: string[] = [];
+const parallelMutation = new SkillCatalogRequestCoordinator((_request) => {
+  const requestId = `parallel-mutation-read-${parallelMutationStarts.length + 1}`;
+  parallelMutationStarts.push(requestId);
+  return requestId;
+});
+assert.equal(parallelMutation.request(parallelFullRequest), true);
+assert.equal(parallelMutation.request(parallelSkillsRequest), true);
+assert.equal(parallelMutation.trackMutation(
+  "parallel-mutation", parallelFullRequest), true);
+assert.equal(parallelMutation.accept(
+  capabilityResponse("parallel-mutation", "/repo/a", false))?.superseded,
+  false);
+assert.equal(parallelMutation.accept(
+  capabilityResponse(
+    "parallel-mutation-read-2", "/repo/a", true))?.superseded,
+  true, "a same-scope mutation must supersede the active Skills lane");
+assert.equal(parallelMutation.accept(
+  capabilityResponse(
+    "parallel-mutation-read-1", "/repo/a", false))?.superseded,
+  true, "a same-scope mutation must supersede the active full lane");
+
 const mutationRaceStarts: Array<{ requestId: string; key: string; skillsOnly: boolean }> = [];
 const mutationRace = new SkillCatalogRequestCoordinator((request) => {
   const requestId = `race-read-${mutationRaceStarts.length + 1}`;
@@ -471,20 +526,22 @@ assert.equal(mutationRace.request(raceSkillsRequest), true);
 assert.equal(mutationRace.trackMutation("race-mutation", raceFullRequest), true);
 assert.equal(mutationRace.request(raceFullRequest), false,
   "a read requested during a same-scope mutation must wait");
+assert.equal(mutationRaceStarts.length, 1,
+  "the queued refresh must not overtake the pending mutation");
 const raceMutationAcceptance = mutationRace.accept(
   capabilityResponse("race-mutation", "/repo/a", false));
 assert.equal(raceMutationAcceptance?.superseded, false);
-assert.equal(mutationRaceStarts.length, 1,
-  "the queued refresh must not overtake the still-active old read");
-const staleReadAcceptance = mutationRace.accept(
-  capabilityResponse("race-read-1", "/repo/a", true));
-assert.equal(staleReadAcceptance?.superseded, true,
-  "a read started before mutation must not roll the catalog back");
 assert.deepEqual(mutationRaceStarts.at(-1), {
   requestId: "race-read-2",
   key: repoSkillKey,
   skillsOnly: false,
-}, "the queued full refresh must continue after mutation and stale-read drain");
+}, "the full lane may refresh after mutation while stale Skills drain");
+const staleReadAcceptance = mutationRace.accept(
+  capabilityResponse("race-read-1", "/repo/a", true));
+assert.equal(staleReadAcceptance?.superseded, true,
+  "a read started before mutation must not roll the catalog back");
+assert.equal(mutationRaceStarts.length, 2,
+  "draining the stale Skills lane must not duplicate the active full refresh");
 
 const blockedMutationStarts: string[] = [];
 const blockedMutation = new SkillCatalogRequestCoordinator((request) => {

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -2447,6 +2447,39 @@ try {
     [false, true],
     "refresh automatically validates only the newest affected turn instead of downloading every cached process",
   );
+  const repeatedPromptSummaries: Turn[] = ["a", "b"].map((suffix, index) => ({
+    id: `repeated-${suffix}`,
+    prompt: "继续",
+    ts: 1_000 + index * 1_000,
+    done: true,
+    blocks: [{
+      kind: "text",
+      message_id: `repeated-${suffix}-final`,
+      text: `final-${suffix}`,
+      done: true,
+      channel: "final",
+    }],
+    detailEventCount: 1,
+  }));
+  const repeatedPromptCaches = repeatedPromptSummaries.map((turn, index) => ({
+    ...turn,
+    blocks: [{
+      kind: "process" as const,
+      item_id: `repeated-${index}-process`,
+      processKind: "command" as const,
+      phase: "snapshot" as const,
+      status: "succeeded" as const,
+      title: `process-${index}`,
+      done: true,
+    }, ...turn.blocks],
+  }));
+  const repeatedPromptRestores = restoreCachedTurnDetails(
+    repeatedPromptSummaries, repeatedPromptCaches);
+  assert.deepEqual(
+    repeatedPromptRestores.map(processFingerprint),
+    [["process-0"], ["process-1"]],
+    "nearby repeated prompts must restore each turn's own cached process exactly once",
+  );
 
   let cacheFirstRefresh = reduce({
     ...initialState, focusedSid: refreshSid,

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -84,7 +84,12 @@ import {
   type MobileViewportEvent,
   type ViewportReading,
 } from "../src/use-mobile-viewport.ts";
-import type { History, ServerEvent, SessionControl } from "../src/protocol.ts";
+import type {
+  EngineCapabilities,
+  History,
+  ServerEvent,
+  SessionControl,
+} from "../src/protocol.ts";
 import type { Block, Turn } from "../src/reducer.ts";
 import { clampPanelWidth, resolveSidebarSwipe } from "../src/responsive-layout.ts";
 import {
@@ -122,8 +127,12 @@ import { PointerTapGuard } from "../src/pointer-tap.ts";
 import {
   cacheSkillCatalog,
   MAX_SKILL_CATALOGS,
+  SkillCatalogRequestCoordinator,
   skillCatalogFresh,
   skillCatalogKey,
+  skillCatalogRefreshSucceeded,
+  skillCatalogReadKey,
+  skillCatalogResponseMatches,
   SKILL_CATALOG_TTL_MS,
 } from "../src/skill-catalog-cache.ts";
 import {
@@ -375,6 +384,166 @@ assert.notEqual(repoSkillKey, skillCatalogKey(
 assert.notEqual(repoSkillKey, skillCatalogKey(
   "machine-b", "codex", "code", "/repo/a"),
   "Skill catalogs must remain inside the machine authorization boundary");
+assert.notEqual(
+  skillCatalogReadKey(repoSkillKey, true),
+  skillCatalogReadKey(repoSkillKey, false),
+  "a lightweight Skill read must not swallow a queued full extension read",
+);
+const skillRead = {
+  key: repoSkillKey,
+  requestId: "skills-request-a",
+  engine: "codex",
+  space: "code",
+  cwd: "/repo/a",
+  skillsOnly: true,
+} as const;
+const skillResponse = {
+  v: 26,
+  ts: 0,
+  type: "engine_capabilities",
+  engine: "codex",
+  space: "code",
+  request_id: "skills-request-a",
+  cwd: "/repo/a",
+  items: skillCatalog,
+  errors: [],
+  notes: [],
+  skills_only: true,
+} satisfies EngineCapabilities;
+assert.equal(skillCatalogResponseMatches(skillRead, skillResponse), true);
+assert.equal(skillCatalogResponseMatches(
+  skillRead, { ...skillResponse, request_id: "replayed-old-request" }), false,
+  "a replayed capability response must not complete a newer read",
+);
+assert.equal(skillCatalogResponseMatches(
+  skillRead, { ...skillResponse, cwd: "/repo/b" }), false,
+  "a capability response from another cwd must not complete the active read",
+);
+assert.equal(skillCatalogResponseMatches(
+  { ...skillRead, cwd: "" }, skillResponse), true,
+  "an omitted cwd must accept the wrapper's resolved default directory",
+);
+assert.equal(skillCatalogRefreshSucceeded(skillResponse), true);
+assert.equal(skillCatalogRefreshSucceeded({
+  ...skillResponse,
+  items: [],
+  errors: ["skills: app-server request failed"],
+}), false, "a failed Skill refresh must preserve stale cached items");
+assert.equal(skillCatalogRefreshSucceeded({
+  ...skillResponse,
+  skills_only: false,
+  errors: ["plugins: app-server request failed"],
+}), true, "an unrelated full-inventory failure must not hide valid Skills");
+
+const capabilityRequest = (
+  key: string,
+  cwd: string,
+  skillsOnly: boolean,
+) => ({
+  key,
+  engine: "codex" as const,
+  space: "code" as const,
+  cwd,
+  skillsOnly,
+});
+const capabilityResponse = (
+  requestId: string,
+  cwd: string,
+  skillsOnly: boolean,
+): EngineCapabilities => ({
+  ...skillResponse,
+  request_id: requestId,
+  cwd,
+  skills_only: skillsOnly,
+});
+
+const mutationRaceStarts: Array<{ requestId: string; key: string; skillsOnly: boolean }> = [];
+const mutationRace = new SkillCatalogRequestCoordinator((request) => {
+  const requestId = `race-read-${mutationRaceStarts.length + 1}`;
+  mutationRaceStarts.push({
+    requestId, key: request.key, skillsOnly: request.skillsOnly,
+  });
+  return requestId;
+});
+const raceSkillsRequest = capabilityRequest(repoSkillKey, "/repo/a", true);
+const raceFullRequest = capabilityRequest(repoSkillKey, "/repo/a", false);
+assert.equal(mutationRace.request(raceSkillsRequest), true);
+assert.equal(mutationRace.trackMutation("race-mutation", raceFullRequest), true);
+assert.equal(mutationRace.request(raceFullRequest), false,
+  "a read requested during a same-scope mutation must wait");
+const raceMutationAcceptance = mutationRace.accept(
+  capabilityResponse("race-mutation", "/repo/a", false));
+assert.equal(raceMutationAcceptance?.superseded, false);
+assert.equal(mutationRaceStarts.length, 1,
+  "the queued refresh must not overtake the still-active old read");
+const staleReadAcceptance = mutationRace.accept(
+  capabilityResponse("race-read-1", "/repo/a", true));
+assert.equal(staleReadAcceptance?.superseded, true,
+  "a read started before mutation must not roll the catalog back");
+assert.deepEqual(mutationRaceStarts.at(-1), {
+  requestId: "race-read-2",
+  key: repoSkillKey,
+  skillsOnly: false,
+}, "the queued full refresh must continue after mutation and stale-read drain");
+
+const blockedMutationStarts: string[] = [];
+const blockedMutation = new SkillCatalogRequestCoordinator((request) => {
+  blockedMutationStarts.push(request.key);
+  return `blocked-read-${blockedMutationStarts.length}`;
+});
+assert.equal(blockedMutation.trackMutation(
+  "blocked-mutation", raceFullRequest), true);
+assert.equal(blockedMutation.request(raceSkillsRequest), false);
+assert.deepEqual(blockedMutationStarts, [],
+  "same-scope reads must stay queued while a mutation is pending");
+assert.equal(blockedMutation.accept(
+  capabilityResponse("blocked-mutation", "/repo/b", false)), null,
+  "a mutation response from another cwd must not release the scoped queue");
+assert.deepEqual(blockedMutationStarts, []);
+assert.ok(blockedMutation.accept(
+  capabilityResponse("blocked-mutation", "/repo/a", false)));
+assert.deepEqual(blockedMutationStarts, [repoSkillKey],
+  "a queued read must start after the mutation response");
+
+const isolatedStarts: string[] = [];
+const isolatedRequests = new SkillCatalogRequestCoordinator((request) => {
+  const requestId = `isolated-${isolatedStarts.length + 1}`;
+  isolatedStarts.push(request.key);
+  return requestId;
+});
+const machineARequest = capabilityRequest(repoSkillKey, "/repo/a", true);
+const machineBKey = skillCatalogKey(
+  "machine-b", "codex", "code", "/repo/b");
+const machineBRequest = capabilityRequest(machineBKey, "/repo/b", true);
+assert.equal(isolatedRequests.request(machineARequest), true);
+isolatedRequests.reset();
+assert.equal(isolatedRequests.request(machineBRequest), true);
+assert.equal(isolatedRequests.accept(
+  capabilityResponse("isolated-1", "/repo/a", true)), null,
+  "a delayed response from a reset machine scope must be ignored");
+assert.equal(isolatedRequests.accept(
+  capabilityResponse("isolated-2", "/repo/a", true)), null,
+  "even a current request id must not authorize another cwd");
+assert.equal(isolatedRequests.accept(
+  capabilityResponse("isolated-2", "/repo/b", true))?.request.key,
+  machineBKey);
+
+const failedDrainStarts: string[] = [];
+const failedDrain = new SkillCatalogRequestCoordinator((request) => {
+  failedDrainStarts.push(request.key);
+  if (request.key === "send-fails") return null;
+  return `drain-${failedDrainStarts.length}`;
+});
+const drainActive = capabilityRequest("active", "/active", true);
+assert.equal(failedDrain.request(drainActive), true);
+assert.equal(failedDrain.request(
+  capabilityRequest("send-fails", "/bad", true)), false);
+assert.equal(failedDrain.request(
+  capabilityRequest("send-works", "/good", true)), false);
+assert.ok(failedDrain.accept(
+  capabilityResponse("drain-1", "/active", true)));
+assert.deepEqual(failedDrainStarts, ["active", "send-fails", "send-works"],
+  "one failed queued send must not discard later runnable scopes");
 const freshSkillEntry = { items: skillCatalog, fetchedAt: 1_000 };
 assert.equal(skillCatalogFresh(freshSkillEntry, 1_000 + SKILL_CATALOG_TTL_MS - 1),
   true);
@@ -6898,6 +7067,19 @@ assert.equal(claudeDefaultsFrame.cwd, "/tmp/project");
 assert.equal(typeof claudeDefaultsFrame.cmd_id, "string");
 assert.equal(typeof claudeDefaultsFrame.client_id, "string");
 
+const skillOnlyCapabilitiesRequestId = relay.sendGetEngineCapabilities(
+  "codex", "code", "/tmp/project", true,
+);
+const skillOnlyCapabilitiesFrame = JSON.parse(socket.sent.at(-1) ?? "{}");
+assert.equal(skillOnlyCapabilitiesFrame.type, "get_engine_capabilities");
+assert.equal(skillOnlyCapabilitiesFrame.skills_only, true);
+assert.equal(skillOnlyCapabilitiesFrame.cwd, "/tmp/project");
+assert.equal(typeof skillOnlyCapabilitiesFrame.client_id, "string");
+assert.equal(
+  skillOnlyCapabilitiesFrame.cmd_id, skillOnlyCapabilitiesRequestId,
+  "capability responses need the reliable request id for exact correlation",
+);
+
 const appSource = readFileSync(resolve(process.cwd(), "src/App.tsx"), "utf8");
 for (const optimisticAction of ["set_model", "set_effort", "set_perm", "set_collaboration_mode"]) {
   assert.doesNotMatch(appSource, new RegExp(`dispatch\\(\\{ type: ["']${optimisticAction}["']`));
@@ -7044,6 +7226,18 @@ assert.match(composerSource, /正在读取当前目录的 Skills/,
   "the Skill palette must stay visible while native discovery is in flight");
 assert.match(appSource, /skills=\{skillCatalogs\[focusedSkillCatalogKey\]\?\.items\}/,
   "the composer must paint a cwd-scoped Skill cache synchronously");
+assert.match(appSource,
+  /onRequestSkills=\{\(\) => \{[\s\S]{0,500}skillsOnly: true/,
+  "$ completion must request only the lightweight Skill inventory");
+assert.match(appSource,
+  /onOpenExtensions=\{\(kind\) => \{[\s\S]{0,600}skillsOnly: false/,
+  "the extensions sheet must continue requesting the complete inventory");
+assert.match(appSource,
+  /report=\{capabilitiesByScope\[focusedSkillCatalogKey\] \?\? null\}/,
+  "the full Extensions report must share the machine and cwd scope key");
+assert.match(appSource,
+  /skillCatalogRefreshSucceeded\(msg\)[\s\S]{0,200}storeSkillCatalog/,
+  "a failed Skill refresh must not replace a usable cached catalog");
 assert.match(appSource, /Warm the cwd-scoped Codex Skill catalog[\s\S]*requestSkillCatalog/,
   "focused Codex sessions must prefetch Skills before the user types $");
 assert.match(appSource,


### PR DESCRIPTION
## Summary

- preserve complete process history across refreshes and session switches, including one-to-one cache restoration for adjacent turns with identical prompts
- add lazy KaTeX rendering for completed chat formulas while keeping Mermaid and historical process details bounded
- make Skills discovery fast, request-correlated, cwd-scoped, and isolated from slower plugin/app/MCP inventory reads
- refine compact mobile composer controls without changing their underlying session settings

## Why

Long-running sessions could lose or cross-attach cached process details after refresh, especially when consecutive prompts had the same text. Formula markup was shown as plain text. Capability discovery could also be delayed by unrelated app-server inventory calls or accept a response for the wrong scope, while the mobile composer controls had become too compressed.

The capability response correlation requires protocol v26, so Relay, Web, and all Wrappers must be deployed together after merge.

## Validation

- `.venv/bin/python -m pytest` — 1316 passed, 2 skipped
- `uvx --from ruff==0.15.13 ruff check cc_remote tests deploy`
- `npm --prefix web run build`
- `npm --prefix web run test:reliability`
- `npm --prefix web run test:history-browser` — 99 passed, 11 skipped
- `npm --prefix web run lint`
- `bash -n deploy/install.sh deploy/install-relay.sh deploy/install-wrapper.sh deploy/setup-vps.sh`
- `shellcheck -x deploy/install.sh deploy/install-relay.sh deploy/install-wrapper.sh deploy/setup-vps.sh deploy/setup_transaction.sh`
- `git diff --check`

No live model calls were used.