### PR TITLE
fix(device): avoid double-close of fd when staging device config

### DIFF
--- a/cc_remote/device.py
+++ b/cc_remote/device.py
@@ -55,16 +55,18 @@ def _write_private_text(path: Path, content: str, *, replace: bool) -> None:
     try:
         os.fchmod(fd, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
             handle.write(content)
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(staged, path)
         os.chmod(path, 0o600)
     except Exception:
-        try:
-            os.close(fd)
-        except OSError:
-            pass
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         staged.unlink(missing_ok=True)
         raise
 


### PR DESCRIPTION
  `os.fdopen()` takes ownership of the descriptor and closes it when the file
  object exits. If a later operation such as `os.replace()` or `os.chmod()`
  fails, the exception handler still holds the stale descriptor number and
  attempts to close it again.

  Besides producing a redundant `EBADF`, that stale number could theoretically
  have been reused concurrently for another descriptor. Tracking the ownership
  transfer avoids closing a descriptor no longer owned by this function.

  ### Testing

  - Python: 1479 passed, 1 skipped
  - Ruff: passed
  - Web build, reliability, browser, and lint tests: passed
  - Playwright: 162 passed, 14 configured skips
  - Shell syntax and ShellCheck: passed
  - `git diff --check`: passed