### PR TITLE
fix(goal): preserve replacement state across clients

### DIFF
--- a/cc_remote/wrapper/codex_handle.py
+++ b/cc_remote/wrapper/codex_handle.py
@@ -328,6 +328,31 @@ class _GoalPromptCandidate:
         self.deadline = deadline
 
 
+class _GoalReplacementFence:
+    """Track Goal objectives still draining behind newer replacements."""
+
+    __slots__ = (
+        "objective",
+        "current_turn_ids",
+        "retired_turn_ids",
+        "generation",
+        "authoritative",
+    )
+
+    def __init__(
+        self,
+        objective: str,
+        current_turn_ids: set[str],
+        retired_turn_ids: dict[str, set[str]],
+        generation: int,
+    ):
+        self.objective = objective
+        self.current_turn_ids = current_turn_ids
+        self.retired_turn_ids = retired_turn_ids
+        self.generation = generation
+        self.authoritative = False
+
+
 class _CodexCompactionContinuation:
     """One managed browser turn spanning native compact turn ids.
 
@@ -1137,6 +1162,11 @@ class CodexHandle:
         self._goal_baseline_loaded = False
         self._goal_prompt_pending: OrderedDict[str, str] = OrderedDict()
         self._goal_prompt_candidate: Optional[_GoalPromptCandidate] = None
+        # Prompt correlation ends as soon as turn/started claims its candidate.
+        # Keep retired objectives independently across response -> notification
+        # gaps. Authoritative external replacements extend the same fence so
+        # delayed old-turn updates cannot regress state after rapid edits either.
+        self._goal_replacement_fence: Optional[_GoalReplacementFence] = None
         # A goal/automatic continuation can start without query(), hence without
         # a response queue owned by Machine._run_turn.  Track that one turn
         # separately so the machine can lock the session, expose interrupt, and
@@ -1386,6 +1416,7 @@ class CodexHandle:
         self._goal_baseline_loaded = False
         self._goal_prompt_pending.clear()
         self._goal_prompt_candidate = None
+        self._goal_replacement_fence = None
         self._spontaneous_turn_id = None
         self._compaction_continuation_turn_id = None
         self._discard_managed_compaction_continuation()
@@ -2689,6 +2720,7 @@ class CodexHandle:
         self._spontaneous_turn_id = None
         self._compaction_continuation_turn_id = None
         self._goal_prompt_candidate = None
+        self._goal_replacement_fence = None
         self._discard_managed_compaction_continuation()
         self._clear_review_tracking()
         tasks = [t for t in (self._reader, self._stderr_task)
@@ -3096,12 +3128,198 @@ class CodexHandle:
             self._goal_objective_baseline = None
             self._goal_status_baseline = None
             self._goal_baseline_loaded = True
+            self._goal_replacement_fence = None
             return None
-        self.last_goal = _sanitize_thread_goal(goal, self.thread_id)
+        candidate = _sanitize_thread_goal(goal, self.thread_id)
+        previous_objective = self._goal_objective_baseline
+        previous_goal_turn_id = self.last_goal_turn_id
+        self.last_goal = candidate
         self._goal_objective_baseline = self.last_goal.get("objective")
         self._goal_status_baseline = self.last_goal.get("status")
         self._goal_baseline_loaded = True
+        # Unlike a streamed snapshot, thread/goal/get reads the app-server's
+        # current persisted Goal. It is the escape hatch for an external client
+        # intentionally restoring the objective fenced below.
+        self._observe_goal_objective(
+            self.last_goal.get("objective"),
+            previous_objective=previous_objective,
+            previous_turn_ids=(
+                {previous_goal_turn_id}
+                if previous_goal_turn_id is not None else set()
+            ),
+            authoritative=True,
+        )
+        if self._goal_objective_baseline != previous_objective:
+            # A persisted snapshot has no turn attribution. Do not let the last
+            # extension turn from the replaced objective become the new
+            # objective's owner.
+            self.last_goal_turn_id = None
         return self.last_goal
+
+    def _current_goal_replacement_fence(
+        self,
+    ) -> Optional[_GoalReplacementFence]:
+        fence = self._goal_replacement_fence
+        if fence is None:
+            return None
+        if fence.generation != self._generation:
+            self._goal_replacement_fence = None
+            return None
+        return fence
+
+    def _observe_goal_objective(
+        self,
+        objective: Any,
+        *,
+        previous_objective: Any = None,
+        turn_id: Optional[str] = None,
+        previous_turn_ids: Optional[set[str]] = None,
+        authoritative: bool = False,
+    ) -> None:
+        """Advance one authoritative response/notification fence."""
+        fence = self._current_goal_replacement_fence()
+        if not isinstance(objective, str):
+            return
+        if fence is None and (authoritative or turn_id is not None):
+            observed_turn_ids = {turn_id} if turn_id is not None else set()
+            if objective == previous_objective:
+                observed_turn_ids.update(previous_turn_ids or set())
+            self._rotate_goal_replacement_fence(
+                objective,
+                previous_objective=previous_objective,
+                current_turn_ids=observed_turn_ids,
+                previous_turn_ids=previous_turn_ids,
+                authoritative=True,
+            )
+            return
+        if fence is not None and objective == fence.objective:
+            if (
+                isinstance(previous_objective, str)
+                and previous_objective
+                and previous_objective != objective
+            ):
+                known_previous_turn_ids = {
+                    item for item in (previous_turn_ids or set())
+                    if isinstance(item, str) and item
+                }
+                if known_previous_turn_ids:
+                    fence.retired_turn_ids.setdefault(
+                        previous_objective, set()
+                    ).update(known_previous_turn_ids)
+            fence.authoritative = True
+            if isinstance(turn_id, str) and turn_id:
+                fence.current_turn_ids.add(turn_id)
+            return
+        if not authoritative:
+            return
+        self._rotate_goal_replacement_fence(
+            objective,
+            previous_objective=previous_objective,
+            current_turn_ids={turn_id} if turn_id else set(),
+            previous_turn_ids=previous_turn_ids,
+            authoritative=True,
+        )
+
+    def _rotate_goal_replacement_fence(
+        self,
+        objective: str,
+        *,
+        previous_objective: Any,
+        current_turn_ids: Optional[set[str]] = None,
+        previous_turn_ids: Optional[set[str]] = None,
+        authoritative: bool,
+    ) -> None:
+        current = self._current_goal_replacement_fence()
+        retired_turn_ids = {
+            retired_objective: set(turn_ids)
+            for retired_objective, turn_ids in (
+                current.retired_turn_ids.items() if current is not None else ()
+            )
+        }
+        if (
+            current is not None
+            and current.authoritative
+            and current.objective != objective
+        ):
+            if current.current_turn_ids:
+                retired_turn_ids.setdefault(
+                    current.objective, set()
+                ).update(current.current_turn_ids)
+        if (
+            isinstance(previous_objective, str)
+            and previous_objective
+            and previous_objective != objective
+        ):
+            known_previous_turn_ids = {
+                item for item in (previous_turn_ids or set())
+                if isinstance(item, str) and item
+            }
+            if known_previous_turn_ids:
+                retired_turn_ids.setdefault(
+                    previous_objective, set()
+                ).update(known_previous_turn_ids)
+        replacement = _GoalReplacementFence(
+            objective,
+            {
+                item for item in (current_turn_ids or set())
+                if isinstance(item, str) and item
+            },
+            retired_turn_ids,
+            self._generation,
+        )
+        replacement.authoritative = authoritative
+        self._goal_replacement_fence = replacement
+
+    def _is_superseded_goal_update(
+        self,
+        candidate: dict[str, Any],
+        turn_id: Optional[str],
+    ) -> bool:
+        """Reject only old turns fenced by a Goal replacement.
+
+        The public Goal contract has no generation id. A permanent
+        different-objective filter would therefore drop legitimate replacements
+        made by another shared-daemon client. Retain objectives retired by
+        authoritative set responses, persisted reads, or accepted replacement
+        notifications. Quarantine observed old turn ids until their individual
+        drain boundary, clear, or reconnect. Without an old turn id, public
+        objective text cannot distinguish a delayed update from a legitimate
+        same-objective restore, so turn-owned updates remain authoritative.
+        Explicit set notifications use turnId=null and remain authoritative
+        even when another client restores that exact objective.
+        """
+        fence = self._current_goal_replacement_fence()
+        if (
+            fence is None
+            or not fence.authoritative
+            or not isinstance(turn_id, str)
+            or not turn_id
+        ):
+            return False
+        incoming_objective = candidate.get("objective")
+        if not isinstance(incoming_objective, str):
+            return False
+        retired_turn_ids = fence.retired_turn_ids.get(
+            incoming_objective, set()
+        )
+        if (
+            incoming_objective == fence.objective
+            and turn_id in fence.current_turn_ids
+        ):
+            return False
+        # A restored objective can have the same public text but a new automatic
+        # turn. The app-server does not expose its internal Goal generation id,
+        # so reject only turn ids observed on a retired generation.
+        superseded = turn_id in retired_turn_ids
+        if superseded and candidate.get("status") == "complete":
+            # Listener FIFO makes this the retired turn's drain boundary. Drop
+            # only that turn because multiple generations may reuse one public
+            # objective string.
+            if turn_id in retired_turn_ids:
+                retired_turn_ids.discard(turn_id)
+                if not retired_turn_ids:
+                    fence.retired_turn_ids.pop(incoming_objective, None)
+        return superseded
 
     def take_goal_prompt(self, turn_id: str) -> Optional[str]:
         """Consume the one visible objective owned by ``turn_id``."""
@@ -3184,8 +3402,27 @@ class CodexHandle:
             candidate_objective = objective or self._goal_objective_baseline
         if candidate_objective is not None:
             # thread/goal/set may synchronously emit turn/started before its RPC
-            # response. Seed the candidate first so that exact spontaneous turn
-            # can claim it even if the goal notification is delayed or omitted.
+            # response. Record the replacement and seed the prompt candidate
+            # before sending so both early notification orders stay correlated.
+            previous_objective = self._goal_objective_baseline
+            previous_turn_ids = {
+                turn_id for turn_id in (
+                    self.last_goal_turn_id,
+                    self.turn_id if self.turn_active else None,
+                )
+                if isinstance(turn_id, str) and turn_id
+            }
+            current_fence = self._current_goal_replacement_fence()
+            if (
+                current_fence is None
+                or current_fence.objective != candidate_objective
+            ):
+                self._rotate_goal_replacement_fence(
+                    candidate_objective,
+                    previous_objective=previous_objective,
+                    previous_turn_ids=previous_turn_ids,
+                    authoritative=False,
+                )
             self._seed_goal_prompt_candidate(candidate_objective)
         try:
             result = await self._request("thread/goal/set", params)
@@ -3196,10 +3433,27 @@ class CodexHandle:
         if not isinstance(goal, dict):
             self._goal_prompt_candidate = None
             raise RuntimeError("codex app-server did not return a goal")
+        response_previous_objective = self._goal_objective_baseline
+        response_previous_turn_id = self.last_goal_turn_id
         self.last_goal = _sanitize_thread_goal(goal, self.thread_id)
         self._goal_objective_baseline = self.last_goal.get("objective")
         self._goal_status_baseline = self.last_goal.get("status")
         self._goal_baseline_loaded = True
+        self._observe_goal_objective(
+            self.last_goal.get("objective"),
+            previous_objective=response_previous_objective,
+            previous_turn_ids=(
+                {response_previous_turn_id}
+                if response_previous_turn_id is not None else set()
+            ),
+            authoritative=True,
+        )
+        if self._goal_objective_baseline != response_previous_objective:
+            # The RPC response itself is not tied to an automatic turn. An
+            # earlier matching notification already changed the baseline and
+            # therefore keeps its turn id; response-first ordering clears the
+            # previous objective's attribution until a notification arrives.
+            self.last_goal_turn_id = None
         if (
             self.last_goal.get("status") != "active"
         ):
@@ -3221,6 +3475,7 @@ class CodexHandle:
             self._goal_baseline_loaded = True
             self._goal_prompt_pending.clear()
             self._goal_prompt_candidate = None
+            self._goal_replacement_fence = None
         return cleared
 
     async def start_review(self, target: dict[str, Any]) -> dict[str, str]:
@@ -4087,6 +4342,7 @@ class CodexHandle:
                     self._proxy_read_buffer.clear()
                 self._compaction_continuation_turn_id = None
                 self._goal_prompt_candidate = None
+                self._goal_replacement_fence = None
                 self._discard_managed_compaction_continuation()
                 self._clear_review_tracking()
                 spontaneous_turn_id = self._spontaneous_turn_id
@@ -4518,6 +4774,10 @@ class CodexHandle:
                         self._goal_prompt_pending.move_to_end(turn_id)
                         while len(self._goal_prompt_pending) > 8:
                             self._goal_prompt_pending.popitem(last=False)
+                        self._observe_goal_objective(
+                            objective,
+                            turn_id=turn_id,
+                        )
                 # Managed query/review turns have their own authoritative user
                 # boundary. Never let a stale Goal candidate steal one.
                 self._goal_prompt_candidate = None
@@ -4592,7 +4852,24 @@ class CodexHandle:
                         error_type=type(exc).__name__,
                     )
                 else:
+                    raw_turn_id = params.get("turnId")
+                    explicit_goal_update = (
+                        "turnId" in params and raw_turn_id is None
+                    )
+                    turn_id = (
+                        raw_turn_id
+                        if isinstance(raw_turn_id, str) and raw_turn_id
+                        else None
+                    )
+                    if self._is_superseded_goal_update(goal, turn_id):
+                        log.warning(
+                            "superseded codex goal notification ignored",
+                            thread_id=self.thread_id,
+                            incoming_status=goal.get("status"),
+                        )
+                        return
                     previous_objective = self._goal_objective_baseline
+                    previous_goal_turn_id = self.last_goal_turn_id
                     objective = goal.get("objective")
                     created_at = goal.get("createdAt")
                     updated_at = goal.get("updatedAt")
@@ -4615,9 +4892,23 @@ class CodexHandle:
                         self._goal_baseline_loaded = True
                     self.goal_revision += 1
                     self._goal_status_baseline = goal.get("status")
-                    turn_id = params.get("turnId")
-                    self.last_goal_turn_id = (
-                        turn_id if isinstance(turn_id, str) and turn_id else None
+                    self.last_goal_turn_id = turn_id
+                    self._observe_goal_objective(
+                        objective,
+                        previous_objective=previous_objective,
+                        turn_id=turn_id,
+                        previous_turn_ids=(
+                            {previous_goal_turn_id}
+                            if previous_goal_turn_id is not None else set()
+                        ),
+                        authoritative=(
+                            explicit_goal_update
+                            or (
+                                isinstance(previous_objective, str)
+                                and isinstance(objective, str)
+                                and previous_objective != objective
+                            )
+                        ),
                     )
                     if goal.get("status") != "active":
                         self._goal_prompt_candidate = None
@@ -4651,6 +4942,7 @@ class CodexHandle:
                 self._goal_baseline_loaded = True
                 self._goal_prompt_pending.clear()
                 self._goal_prompt_candidate = None
+                self._goal_replacement_fence = None
                 self.goal_revision += 1
                 self.last_goal_turn_id = None
                 await self._publish_goal(None)

--- a/tests/test_codex_controls.py
+++ b/tests/test_codex_controls.py
@@ -3659,6 +3659,612 @@ def test_codex_goal_notifications_are_sanitized_filtered_and_cleared():
     asyncio.run(run())
 
 
+def test_codex_goal_ignores_late_turn_updates_after_local_replacement(
+    monkeypatch,
+):
+    clock = [100.0]
+    monkeypatch.setattr(
+        codex_handle_module.time, "monotonic", lambda: clock[0])
+
+    async def run():
+        seen = []
+
+        async def on_goal(goal):
+            seen.append(goal)
+
+        handle = CodexHandle(_Cfg(), goal_callback=on_goal)
+        handle.thread_id = "thread-1"
+        old_goal = {
+            "threadId": "thread-1", "objective": "old objective",
+            "status": "active", "tokensUsed": 20,
+            "timeUsedSeconds": 30, "createdAt": 1, "updatedAt": 20,
+        }
+        replacement = {
+            "threadId": "thread-1", "objective": "new objective",
+            "status": "active", "tokensUsed": 20,
+            "timeUsedSeconds": 31, "createdAt": 1, "updatedAt": 21,
+        }
+        stale_progress = {
+            **old_goal, "status": "active", "tokensUsed": 21,
+            "timeUsedSeconds": 34, "createdAt": 1, "updatedAt": 24,
+        }
+        stale_completion = {
+            **old_goal, "status": "complete", "tokensUsed": 22,
+            "timeUsedSeconds": 38, "createdAt": 1, "updatedAt": 28,
+        }
+
+        async def request(method, params=None):
+            if method == "thread/goal/get":
+                assert params == {"threadId": "thread-1"}
+                return {"goal": old_goal}
+            assert (method, params) == (
+                "thread/goal/set",
+                {
+                    "threadId": "thread-1",
+                    "objective": "new objective",
+                    "status": "active",
+                },
+            )
+            return {"goal": replacement}
+
+        handle._request = request
+        assert (await handle.get_goal())["objective"] == "old objective"
+        handle.turn_id = "old-turn"
+        handle.turn_active = True
+        assert (await handle.set_goal(
+            objective="new objective", status="active"
+        ))["objective"] == "new objective"
+        fence = handle._goal_replacement_fence
+        assert fence is not None and fence.authoritative
+
+        # A previous turn may drain behind a long-running tool. The replacement
+        # boundary is event-driven and must not expire on wall-clock time.
+        clock[0] += 60 * 60
+
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-turn",
+                "goal": stale_progress,
+            },
+        })
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-turn",
+                "goal": stale_completion,
+            },
+        })
+
+        assert seen == []
+        assert handle.last_goal["objective"] == "new objective"
+        assert handle.last_goal["status"] == "active"
+        assert handle.goal_revision == 0
+
+        current_completion = {
+            **replacement, "status": "complete", "updatedAt": 29,
+        }
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "replacement-turn",
+                "goal": current_completion,
+            },
+        })
+        assert seen[-1]["objective"] == "new objective"
+        assert seen[-1]["status"] == "complete"
+        assert handle.last_goal == seen[-1]
+        assert handle.goal_revision == 1
+
+        # A persisted read is authoritative even when another client restores
+        # the exact objective protected by the short-lived local fence.
+        async def restored_read(method, params=None):
+            assert (method, params) == (
+                "thread/goal/get", {"threadId": "thread-1"})
+            return {"goal": {**old_goal, "updatedAt": 30}}
+
+        handle._request = restored_read
+        assert (await handle.get_goal())["objective"] == "old objective"
+        restored_fence = handle._goal_replacement_fence
+        assert restored_fence is not None and restored_fence.authoritative
+        assert restored_fence.objective == "old objective"
+        assert restored_fence.retired_turn_ids == {
+            "new objective": {"replacement-turn"},
+        }
+
+    asyncio.run(run())
+
+
+def test_codex_goal_accepts_unowned_shared_daemon_replacement():
+    async def run():
+        seen = []
+
+        async def on_goal(goal):
+            seen.append(goal)
+
+        handle = CodexHandle(_Cfg(), goal_callback=on_goal)
+        handle.thread_id = "thread-1"
+        old_goal = {
+            "threadId": "thread-1", "objective": "old objective",
+            "status": "active", "tokensUsed": 10,
+            "timeUsedSeconds": 20, "createdAt": 1, "updatedAt": 2,
+        }
+        external_replacement = {
+            **old_goal,
+            "objective": "another client's objective",
+            "tokensUsed": 0,
+            "timeUsedSeconds": 0,
+            "updatedAt": 3,
+        }
+
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-turn",
+                "goal": old_goal,
+            },
+        })
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-continuation",
+                "goal": {**old_goal, "tokensUsed": 11, "updatedAt": 2.5},
+            },
+        })
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "external-turn",
+                "goal": external_replacement,
+            },
+        })
+
+        assert [goal["objective"] for goal in seen] == [
+            "old objective", "old objective",
+            "another client's objective",
+        ]
+        assert handle.last_goal == seen[-1]
+        assert handle.goal_revision == 3
+        external_fence = handle._goal_replacement_fence
+        assert external_fence is not None and external_fence.authoritative
+        assert external_fence.objective == "another client's objective"
+        assert external_fence.current_turn_ids == {"external-turn"}
+        assert external_fence.retired_turn_ids == {
+            "old objective": {"old-turn", "old-continuation"},
+        }
+
+        rapid_replacement = {
+            **external_replacement,
+            "objective": "rapid third objective",
+            "updatedAt": 4,
+        }
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "rapid-turn",
+                "goal": rapid_replacement,
+            },
+        })
+        rapid_fence = handle._goal_replacement_fence
+        assert rapid_fence is not None and rapid_fence.authoritative
+        assert rapid_fence.objective == "rapid third objective"
+        assert rapid_fence.current_turn_ids == {"rapid-turn"}
+        assert rapid_fence.retired_turn_ids == {
+            "old objective": {"old-turn", "old-continuation"},
+            "another client's objective": {"external-turn"},
+        }
+
+        # Another daemon client may restore an older public objective before its
+        # original turn drains. The new turn is authoritative; retaining the old
+        # turn id still lets us reject only that original generation.
+        restored_old_objective = {
+            **old_goal, "tokensUsed": 0, "timeUsedSeconds": 0,
+            "updatedAt": 5,
+        }
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "restored-turn",
+                "goal": restored_old_objective,
+            },
+        })
+        assert [goal["objective"] for goal in seen] == [
+            "old objective",
+            "old objective",
+            "another client's objective",
+            "rapid third objective",
+            "old objective",
+        ]
+        restored_fence = handle._goal_replacement_fence
+        assert restored_fence is not None and restored_fence.authoritative
+        assert restored_fence.objective == "old objective"
+        assert restored_fence.current_turn_ids == {"restored-turn"}
+        assert restored_fence.retired_turn_ids == {
+            "old objective": {"old-turn", "old-continuation"},
+            "another client's objective": {"external-turn"},
+            "rapid third objective": {"rapid-turn"},
+        }
+
+        # Turn-owned snapshots from the original Goal stay fenced even though
+        # its objective text is current again under a different turn.
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-turn",
+                "goal": {**old_goal, "tokensUsed": 11, "updatedAt": 6},
+            },
+        })
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-turn",
+                "goal": {
+                    **old_goal, "status": "usageLimited", "updatedAt": 6.5,
+                },
+            },
+        })
+        assert handle._goal_replacement_fence.retired_turn_ids[
+            "old objective"
+        ] == {"old-turn", "old-continuation"}
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-turn",
+                "goal": {**old_goal, "tokensUsed": 12, "updatedAt": 6.75},
+            },
+        })
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-turn",
+                "goal": {**old_goal, "status": "complete", "updatedAt": 7},
+            },
+        })
+        assert handle._goal_replacement_fence.retired_turn_ids[
+            "old objective"
+        ] == {"old-continuation"}
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-continuation",
+                "goal": {**old_goal, "tokensUsed": 12, "updatedAt": 7.5},
+            },
+        })
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-continuation",
+                "goal": {**old_goal, "status": "complete", "updatedAt": 7.6},
+            },
+        })
+        assert len(seen) == 5
+        assert handle.last_goal["objective"] == "old objective"
+        assert handle.last_goal_turn_id == "restored-turn"
+        assert handle.goal_revision == 5
+        assert handle._goal_replacement_fence.retired_turn_ids == {
+            "another client's objective": {"external-turn"},
+            "rapid third objective": {"rapid-turn"},
+        }
+
+        third_objective = {
+            **rapid_replacement,
+            "objective": "authoritative read objective",
+            "updatedAt": 8,
+        }
+
+        async def external_read(method, params=None):
+            assert (method, params) == (
+                "thread/goal/get", {"threadId": "thread-1"})
+            return {"goal": third_objective}
+
+        handle._request = external_read
+        assert (await handle.get_goal())["objective"] == (
+            "authoritative read objective")
+        assert handle.last_goal["objective"] == "authoritative read objective"
+
+        # An explicit set notification is authoritative and may restore the
+        # exact objective currently protected as the previous generation.
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": None,
+                "goal": {**external_replacement, "updatedAt": 9},
+            },
+        })
+        assert len(seen) == 6
+        assert handle.last_goal["objective"] == "another client's objective"
+        fence = handle._goal_replacement_fence
+        assert fence is not None
+        assert fence.objective == "another client's objective"
+        assert fence.retired_turn_ids == {
+            "old objective": {"restored-turn"},
+            "another client's objective": {"external-turn"},
+            "rapid third objective": {"rapid-turn"},
+        }
+
+    asyncio.run(run())
+
+
+def test_codex_goal_accepts_unbound_turn_owned_restore():
+    async def run():
+        seen = []
+
+        async def on_goal(goal):
+            seen.append(goal)
+
+        handle = CodexHandle(_Cfg(), goal_callback=on_goal)
+        handle.thread_id = "thread-1"
+        original = {
+            "threadId": "thread-1", "objective": "original objective",
+            "status": "active", "tokensUsed": 4,
+            "timeUsedSeconds": 8, "createdAt": 1, "updatedAt": 2,
+        }
+
+        async def get_original(method, params=None):
+            assert (method, params) == (
+                "thread/goal/get", {"threadId": "thread-1"})
+            return {"goal": original}
+
+        handle._request = get_original
+        assert (await handle.get_goal())["objective"] == "original objective"
+        initial_fence = handle._goal_replacement_fence
+        assert initial_fence is not None
+        assert initial_fence.current_turn_ids == set()
+
+        intervening = {
+            **original, "objective": "intervening objective", "updatedAt": 3,
+        }
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "intervening-turn",
+                "goal": intervening,
+            },
+        })
+        assert handle.last_goal["objective"] == "intervening objective"
+        assert "original objective" not in (
+            handle._goal_replacement_fence.retired_turn_ids
+        )
+
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "restored-turn",
+                "goal": {**original, "updatedAt": 4},
+            },
+        })
+        assert [goal["objective"] for goal in seen] == [
+            "intervening objective", "original objective",
+        ]
+        assert handle.last_goal_turn_id == "restored-turn"
+        restored_fence = handle._goal_replacement_fence
+        assert restored_fence is not None and restored_fence.authoritative
+        assert restored_fence.objective == "original objective"
+        assert restored_fence.current_turn_ids == {"restored-turn"}
+        assert restored_fence.retired_turn_ids == {
+            "intervening objective": {"intervening-turn"},
+        }
+
+    asyncio.run(run())
+
+
+def test_codex_goal_same_objective_resume_preserves_replacement_fence():
+    async def run():
+        seen = []
+
+        async def on_goal(goal):
+            seen.append(goal)
+
+        handle = CodexHandle(_Cfg(), goal_callback=on_goal)
+        handle.thread_id = "thread-1"
+        old_goal = {
+            "threadId": "thread-1", "objective": "old objective",
+            "status": "active", "tokensUsed": 10,
+            "timeUsedSeconds": 20, "createdAt": 1, "updatedAt": 2,
+        }
+        paused_goal = {
+            **old_goal, "objective": "current objective", "status": "paused",
+            "updatedAt": 3,
+        }
+        active_goal = {**paused_goal, "status": "active", "updatedAt": 4}
+
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-turn",
+                "goal": old_goal,
+            },
+        })
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "current-turn",
+                "goal": paused_goal,
+            },
+        })
+        fence = handle._goal_replacement_fence
+        assert fence is not None and fence.authoritative
+        assert fence.retired_turn_ids == {"old objective": {"old-turn"}}
+        seen.clear()
+
+        async def resume_request(method, params=None):
+            assert (method, params) == (
+                "thread/goal/set",
+                {"threadId": "thread-1", "status": "active"},
+            )
+            await handle._dispatch({
+                "method": "thread/goal/updated",
+                "params": {
+                    "threadId": "thread-1", "turnId": "old-turn",
+                    "goal": {**old_goal, "tokensUsed": 11, "updatedAt": 5},
+                },
+            })
+            assert handle._goal_replacement_fence is fence
+            assert handle.last_goal["objective"] == "current objective"
+            return {"goal": active_goal}
+
+        handle._request = resume_request
+        resumed = await handle.set_goal(status="active")
+        assert resumed["objective"] == "current objective"
+        assert resumed["status"] == "active"
+        assert seen == []
+        assert handle._goal_replacement_fence is fence
+        assert fence.authoritative
+        assert fence.retired_turn_ids == {"old objective": {"old-turn"}}
+
+    asyncio.run(run())
+
+
+def test_codex_goal_replacement_retires_turn_learned_during_rpc():
+    async def run():
+        seen = []
+
+        async def on_goal(goal):
+            seen.append(goal)
+
+        handle = CodexHandle(_Cfg(), goal_callback=on_goal)
+        handle.thread_id = "thread-1"
+        old_goal = {
+            "threadId": "thread-1", "objective": "old objective",
+            "status": "active", "tokensUsed": 10,
+            "timeUsedSeconds": 20, "createdAt": 1, "updatedAt": 2,
+        }
+        replacement = {
+            **old_goal, "objective": "new objective", "updatedAt": 3,
+        }
+
+        async def request(method, params=None):
+            if method == "thread/goal/get":
+                assert params == {"threadId": "thread-1"}
+                return {"goal": old_goal}
+            assert (method, params) == (
+                "thread/goal/set",
+                {
+                    "threadId": "thread-1",
+                    "objective": "new objective",
+                    "status": "active",
+                },
+            )
+            # The persisted baseline had no turn attribution. Learn the old
+            # turn only after the replacement request has started.
+            await handle._dispatch({
+                "method": "thread/goal/updated",
+                "params": {
+                    "threadId": "thread-1", "turnId": "old-turn",
+                    "goal": {**old_goal, "tokensUsed": 11, "updatedAt": 2.5},
+                },
+            })
+            return {"goal": replacement}
+
+        handle._request = request
+        result = await handle.set_goal(
+            objective="new objective", status="active")
+        assert result["objective"] == "new objective"
+        fence = handle._goal_replacement_fence
+        assert fence is not None and fence.authoritative
+        assert fence.objective == "new objective"
+        assert fence.retired_turn_ids == {
+            "old objective": {"old-turn"},
+        }
+        assert len(seen) == 1
+
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-turn",
+                "goal": {**old_goal, "status": "complete", "updatedAt": 4},
+            },
+        })
+        assert len(seen) == 1
+        assert handle.last_goal["objective"] == "new objective"
+        assert handle.last_goal["status"] == "active"
+        assert fence.retired_turn_ids == {}
+
+    asyncio.run(run())
+
+
+def test_codex_goal_replacement_accepts_update_before_lost_response():
+    async def run():
+        seen = []
+
+        async def on_goal(goal):
+            seen.append(goal)
+
+        handle = CodexHandle(_Cfg(), goal_callback=on_goal)
+        handle.thread_id = "thread-1"
+        old_goal = {
+            "threadId": "thread-1", "objective": "old objective",
+            "status": "active", "tokensUsed": 20,
+            "timeUsedSeconds": 30, "createdAt": 1, "updatedAt": 20,
+        }
+        replacement = {
+            "threadId": "thread-1", "objective": "new objective",
+            "status": "active", "tokensUsed": 20,
+            "timeUsedSeconds": 31, "createdAt": 1, "updatedAt": 21,
+        }
+
+        async def lost_response(method, params=None):
+            assert (method, params) == (
+                "thread/goal/set",
+                {
+                    "threadId": "thread-1",
+                    "objective": "new objective",
+                    "status": "active",
+                },
+            )
+            # turn/started consumes the short-lived prompt candidate. The
+            # independent replacement fence must still admit the matching Goal
+            # notification before this RPC response is lost.
+            await handle._dispatch({
+                "method": "turn/started",
+                "params": {"turn": {"id": "replacement-turn"}},
+            })
+            assert handle._goal_prompt_candidate is None
+            await handle._dispatch({
+                "method": "thread/goal/updated",
+                "params": {
+                    "threadId": "thread-1",
+                    "turnId": "replacement-turn",
+                    "goal": replacement,
+                },
+            })
+            raise TimeoutError("response lost after Goal replacement")
+
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-turn",
+                "goal": old_goal,
+            },
+        })
+        seen.clear()
+        handle._request = lost_response
+        with pytest.raises(TimeoutError, match="response lost"):
+            await handle.set_goal(
+                objective="new objective", status="active")
+
+        assert [goal["objective"] for goal in seen] == ["new objective"]
+        assert handle.last_goal == seen[0]
+        assert handle.goal_revision == 2
+        assert handle.last_goal_turn_id == "replacement-turn"
+        fence = handle._goal_replacement_fence
+        assert fence is not None and fence.authoritative
+        assert handle.take_goal_prompt("replacement-turn") == "new objective"
+
+        await handle._dispatch({
+            "method": "thread/goal/updated",
+            "params": {
+                "threadId": "thread-1", "turnId": "old-turn",
+                "goal": {**old_goal, "status": "complete", "updatedAt": 22},
+            },
+        })
+        assert [goal["objective"] for goal in seen] == ["new objective"]
+        assert handle.last_goal == seen[0]
+        assert handle.goal_revision == 2
+
+    asyncio.run(run())
+
+
 def test_machine_goal_emits_authoritative_state():
     async def run():
         machine, transport = _mk_machine()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -666,8 +666,7 @@ export default function App() {
 
   useEffect(() => {
     if (!authed || !focusedSid || !focusedGoalScopeKey || state.newChat
-        || state.connState !== "connected" || !state.wrapperOnline
-        || !goalUiPreferencesRef.current[focusedGoalScopeKey]?.known) {
+        || state.connState !== "connected" || !state.wrapperOnline) {
       return;
     }
     const requestKey = `${wsLifecycleEpochRef.current}\0${focusedGoalScopeKey}`;
@@ -685,7 +684,10 @@ export default function App() {
       return {
         ...current,
         [focusedGoalScopeKey]: {
-          revealed: !preference?.hiddenGoal,
+          // Discover an existing Goal silently on a new browser/device. The
+          // authoritative non-null response reveals it; an exact local
+          // dismissal remains hidden across refreshes on this device.
+          revealed: !!preference?.known && !preference.hiddenGoal,
           open: false,
           loading: true,
         },

--- a/web/src/scoped-goal-ui.ts
+++ b/web/src/scoped-goal-ui.ts
@@ -45,7 +45,24 @@ export function goalStableIdentity(goal: ThreadGoal | null | undefined): string 
   if (typeof marker !== "number" || !Number.isFinite(marker) || marker < 0) {
     return null;
   }
-  return JSON.stringify([goal.engine, goal.threadId, marker]);
+  // Codex currently mutates one thread-level Goal record and can reuse
+  // createdAt when the objective is replaced. Keep the objective out of
+  // localStorage while still making a dismissal specific to that generation.
+  let left = 0x9e3779b9;
+  let right = 0x85ebca6b;
+  for (let index = 0; index < goal.objective.length; index += 1) {
+    const code = goal.objective.charCodeAt(index);
+    left = Math.imul(left ^ code, 0x85ebca6b);
+    right = Math.imul(right ^ code, 0xc2b2ae35);
+  }
+  const objectiveFingerprint = [
+    (left >>> 0).toString(36),
+    (right >>> 0).toString(36),
+    goal.objective.length.toString(36),
+  ].join(".");
+  return JSON.stringify([
+    goal.engine, goal.threadId, marker, objectiveFingerprint,
+  ]);
 }
 
 function boundPreferences(preferences: GoalUiPreferences): GoalUiPreferences {
@@ -139,7 +156,13 @@ export function reconcileGoalUiPreference(
   now = Date.now(),
 ): { preferences: GoalUiPreferences; revealed: boolean } {
   const current = preferences[key];
-  if (!current?.known) return { preferences, revealed: false };
+  if (!current?.known) {
+    if (!goal) return { preferences, revealed: false };
+    return {
+      preferences: rememberGoalUi(preferences, key, now),
+      revealed: true,
+    };
+  }
   const identity = goalStableIdentity(goal);
   const hidden = !!identity && current.hiddenGoal === identity;
   const next = boundPreferences({

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -220,10 +220,13 @@ const persistedGoal = {
   timeUsedSeconds: 2,
   createdAt: 100,
 };
-let goalPreferences = rememberGoalUi({}, goalScopeA, 10);
-assert.equal(reconcileGoalUiPreference(
-  {}, goalScopeA, persistedGoal, 10).revealed, false,
-"an unsolicited Goal broadcast must not reveal Goal UI for an unknown scope");
+const discoveredGoal = reconcileGoalUiPreference(
+  {}, goalScopeA, persistedGoal, 10);
+assert.equal(discoveredGoal.revealed, true,
+  "an authoritative Goal must reveal itself on a new browser or device");
+assert.equal(discoveredGoal.preferences[goalScopeA]?.known, true,
+  "Goal discovery must survive a refresh without requiring /goal");
+let goalPreferences = rememberGoalUi(discoveredGoal.preferences, goalScopeA, 10);
 let reconciledGoal = reconcileGoalUiPreference(
   goalPreferences, goalScopeA, persistedGoal, 11);
 assert.equal(reconciledGoal.revealed, true);
@@ -237,6 +240,13 @@ reconciledGoal = reconcileGoalUiPreference(
   goalPreferences, goalScopeA, { ...persistedGoal, createdAt: 101 }, 14);
 assert.equal(reconciledGoal.revealed, true,
   "a newly-created Goal must not inherit the previous Goal's dismissal");
+reconciledGoal = reconcileGoalUiPreference(
+  goalPreferences, goalScopeA, {
+    ...persistedGoal,
+    objective: "a replacement objective with the same native createdAt",
+  }, 15);
+assert.equal(reconciledGoal.revealed, true,
+  "a replacement Codex Goal must not inherit the previous Goal's dismissal");
 assert.equal(goalStableIdentity({ ...persistedGoal, createdAt: undefined }), null);
 const identitylessDismissal = dismissGoalUi(
   rememberGoalUi({}, goalScopeA, 20), goalScopeA,
@@ -13177,6 +13187,9 @@ assert.match(appSource, /fallback=\{\(goalUi\?\.revealed \|\| goalUi\?\.open\)[\
   "a remembered Goal entry stays visible while its component chunk loads");
 assert.match(appSource, /recoverableReads\.retry\(\["goal", key\]/,
   "a transient Goal read failure must be retried in the same connection");
+assert.doesNotMatch(appSource,
+  /state\.wrapperOnline\s*\n?\s*\|\|\s*!goalUiPreferencesRef\.current/,
+  "Goal recovery must query the focused session on a new browser/device");
 assert.match(appSource,
   /Goal chip owns its retry state; feeding the same[\s\S]{0,240}\n\s*return;/,
   "a handled Goal read failure must not also become a global command banner");


### PR DESCRIPTION
## Summary

- ignore delayed terminal updates from a replaced Codex Goal so they cannot overwrite the newly active objective
- recover an existing Goal automatically on a fresh browser, device, or page reload without requiring another `/goal` command
- scope a locally dismissed Goal to its objective generation while keeping the raw objective text out of local storage

## Dependency

Depends on #28.

This is a stacked PR targeting `agent/v3-history-reconnect-fixes`, the head branch of #28. It should be merged only after #28; once #28 lands, this PR can be retargeted to `master`.

## Testing

- `.venv/bin/python -m pytest` — 1521 passed, 1 skipped
- `uvx --from ruff==0.15.13 ruff check cc_remote tests deploy`
- `npm --prefix web run build`
- `npm --prefix web run test:reliability`
- `CI=1 npm --prefix web run test:history-browser` — 190 passed, 20 platform-defined skips
- `npm --prefix web run lint`
- `bash -n deploy/install.sh deploy/install-relay.sh deploy/install-wrapper.sh deploy/setup-vps.sh`
- `shellcheck -x deploy/install.sh deploy/install-relay.sh deploy/install-wrapper.sh deploy/setup-vps.sh deploy/setup_transaction.sh`
- `git diff --check`
