### PR TITLE
feat: persist plans and synchronize presentation state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ local `claude` or `codex` session through a WebSocket relay. Two independent lin
   transport, never the caller's Origin. Uvicorn trusts forwarded transport
   metadata only from loopback Caddy. Never put tokens in URLs or protocol
   message bodies; logging redacts token/password fields.
-- **Protocol version gate**: current wire protocol v33 is declared by
+- **Protocol version gate**: current wire protocol v34 is declared by
   `PROTOCOL_VERSION` in both `protocol.py` and `web/src/protocol.ts`.
   `deserialize` hard-rejects a version mismatch, and
   `_Base` is `extra="forbid"`, so ANY protocol change must be deployed to all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+- Upgrade the coordinated Wrapper/Relay/Web gate to protocol v34. Main-session
+  completion acknowledgements and exact Goal-generation dismissals now live in
+  bounded wrapper-owned state, so reading or hiding them in one browser updates
+  every connected browser and survives reconnects without hiding replacements.
 - Store files and images attached to Work messages under that conversation's
   private `workspace/uploads` directory, where the Work sandbox can actually
   read them, while keeping uploaded source material out of generated Artifacts

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -4,6 +4,9 @@
 
 ## 未发布
 
+- Wrapper、Relay 与 Web 的协同 gate 升级到 protocol v34。主会话完成回执和精确
+  Goal generation 的隐藏回执改由 wrapper 有界持久化；任一浏览器已读或隐藏后会
+  同步到所有已连接浏览器，重连后仍保持一致，同时不会误隐藏后来替换的新 Goal。
 - Work 消息附带的文件和图片现在会保存到当前会话私有的
   `workspace/uploads` 目录，Work 沙箱可以直接读取；上传的输入资料不会被误列为
   生成的 Artifacts，同时旧版相邻目录中的附件路径仍可兼容历史展示。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ local `claude` or `codex` session through a WebSocket relay. Two independent lin
   `useLayoutEffect` is deliberately dependency-free — late virtualizer/image
   measurements settle without a React render, and constraining it to its read
   set reintroduces a full-viewport jump on touch release.
-- **Protocol version gate**: current wire protocol v33 is declared by
+- **Protocol version gate**: current wire protocol v34 is declared by
   `PROTOCOL_VERSION` in both `protocol.py` and `web/src/protocol.ts`.
   `deserialize` hard-rejects a version mismatch, and
   `_Base` is `extra="forbid"`, so ANY protocol change must be deployed to all

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 自托管 · 双引擎 · 多会话 · 实时过程 · 响应式 Web
 
-**当前版本：v3.0.0** · Wire protocol v33
+**当前版本：v3.0.0** · Wire protocol v34
 
 [English](README_en.md) ·
 [5 分钟上手](#本地快速开始一台机器5-分钟) ·
@@ -466,14 +466,14 @@ npm --prefix web run build   # 产出 web/dist/
 
 > 现在网页**不再把 token 烤进 JS**：登录改为向中继 POST 口令换取短期会话 token。所以构建不需要任何 `VITE_*` 变量。
 
-> **升级到协议 v33**：线协议会严格拒绝版本不一致。请在同一次维护窗口部署
+> **升级到协议 v34**：线协议会严格拒绝版本不一致。请在同一次维护窗口部署
 > `cc_remote/` 和新的 `web/dist/`，然后依次重启 relay、wrapper；不要新旧版本滚动混跑。
 > 升级期间已有 WebSocket 会短暂重连，relay 重启也会要求浏览器重新登录。已打开的
 > 旧版页面必须做一次**硬刷新**（重新加载新的带 hash 静态资源），仅重新登录不够。
-> 手工发布时先停本机 wrapper，再停服更新 relay + web，最后启动 v33 relay 和
-> v33 wrapper；这样旧 wrapper 不会占住同一 `machine_id` 的连接槽。v33 会迁移本机
-> Work SQLite；手工发布还必须在启动 v33 前用
-> `deploy/work_registry_snapshot.py snapshot` 保存两个注册表。回滚时先停 v33、恢复该
+> 手工发布时先停本机 wrapper，再停服更新 relay + web，最后启动 v34 relay 和
+> v34 wrapper；这样旧 wrapper 不会占住同一 `machine_id` 的连接槽。v34 会迁移本机
+> Work SQLite；手工发布还必须在启动 v34 前用
+> `deploy/work_registry_snapshot.py snapshot` 保存两个注册表。回滚时先停 v34、恢复该
 > 快照，再切回旧代码；不要在 wrapper 运行时只复制主 `.sqlite3` 文件而漏掉 WAL。
 
 ### 3）上传 staging，由原子 release 安装器发布
@@ -528,7 +528,7 @@ sudo bash ~/cc-remote-upload/deploy/setup-vps.sh \
 脚本会：装 `python3-venv` + Caddy、建 `ccremote` 系统用户、创建不可变 release
 和 release-local venv、合并 Caddy 配置、原子切换 `current`，再重启 relay。若新
 relay 重启或健康检查失败，`current`、Caddyfile、systemd unit 会作为一个事务全部
-恢复，并验证旧 release 的 `/healthz`。成功后再启动 v33 wrapper。
+恢复，并验证旧 release 的 `/healthz`。成功后再启动 v34 wrapper。
 
 验证：
 

--- a/README_en.md
+++ b/README_en.md
@@ -4,7 +4,7 @@
 
 Self-hosted · Dual-engine · Multi-session · Live process · Responsive Web
 
-**Current release: v3.0.0** · Wire protocol v33
+**Current release: v3.0.0** · Wire protocol v34
 
 [中文](README.md) ·
 [5-minute quick start](#quick-start-local-one-machine-5-min) ·
@@ -548,17 +548,17 @@ npm --prefix web run build   # produces web/dist/
 
 > The web client no longer bakes any token into the JS: login POSTs the password to the relay for a short-lived session token. So the build needs no `VITE_*` variables.
 
-> **Upgrading to protocol v33:** the wire gate rejects mixed versions. Deploy
+> **Upgrading to protocol v34:** the wire gate rejects mixed versions. Deploy
 > `cc_remote/` and the new `web/dist/` in one maintenance window, then restart the
 > relay and wrapper; do not run a rolling mixture. Existing sockets reconnect
 > briefly, and a relay restart intentionally requires browsers to log in again.
 > Any already-open older page also needs one **hard refresh** to load the new hashed
 > assets; logging in again inside the old JavaScript bundle isn't sufficient.
 > For a manual release, stop the local wrapper first, stop and update relay + web,
-> then start the v33 relay and v33 wrapper so the old wrapper cannot occupy the
-> slot for the same `machine_id`. v33 migrates provider-local Work SQLite data;
+> then start the v34 relay and v34 wrapper so the old wrapper cannot occupy the
+> slot for the same `machine_id`. v34 migrates provider-local Work SQLite data;
 > a manual release must also run `deploy/work_registry_snapshot.py snapshot`
-> before v33 starts. To roll back, stop v33, restore that snapshot, then switch
+> before v34 starts. To roll back, stop v34, restore that snapshot, then switch
 > to the old code. Do not copy only the main `.sqlite3` file while the wrapper is
 > live because committed pages may still be in WAL.
 
@@ -617,7 +617,7 @@ The script installs `python3-venv` + Caddy, creates the `ccremote` service user,
 builds an immutable release and its venv, merges Caddy configuration, atomically
 switches `current`, and restarts the relay. If restart/readiness fails, `current`,
 the Caddyfile, and the systemd unit roll back as one transaction and the previous
-release's `/healthz` is verified. Start the v33 wrapper after success.
+release's `/healthz` is verified. Start the v34 wrapper after success.
 
 Verify:
 

--- a/cc_remote/protocol.py
+++ b/cc_remote/protocol.py
@@ -28,7 +28,7 @@ from cc_remote.attachments import (
     MAX_SINGLE_ATTACHMENT_BYTES,
 )
 
-PROTOCOL_VERSION = 33
+PROTOCOL_VERSION = 34
 
 # Codex Desktop renders a 53-week daily token-activity calendar. Keep the wire
 # payload to that same bounded window so an account response can never turn a
@@ -902,6 +902,11 @@ class SessionInfo(BaseModel):
     native_session_id: Optional[WireId] = None
     codex_profile_id: Optional[WireId] = None
     codex_profile_label: Optional[str] = Field(default=None, max_length=48)
+    # A catalog read also repairs completion receipts for cold/evicted sessions
+    # which have no resident Snapshot on reconnect.
+    completion_id: Optional[WireId] = None
+    completion_unread: Optional[bool] = None
+    completion_revision: Optional[int] = Field(default=None, ge=0)
 
 
 class ListSessions(_Command):
@@ -2166,6 +2171,20 @@ class ClearGoal(_Command):
     type: Literal["clear_goal"] = "clear_goal"
 
 
+class DismissGoal(_Command):
+    """Hide one exact Goal generation on every connected client."""
+
+    type: Literal["dismiss_goal"] = "dismiss_goal"
+    goal_id: WireId
+
+
+class AcknowledgeCompletion(_Command):
+    """Mark one exact main-session completion as seen across clients."""
+
+    type: Literal["acknowledge_completion"] = "acknowledge_completion"
+    completion_id: WireId
+
+
 class ThreadGoal(BaseModel):
     """Display-safe goal state shared by the Codex and Claude engines.
 
@@ -2206,10 +2225,29 @@ class GoalState(_Base):
     """
     type: Literal["goal_state"] = "goal_state"
     goal: Optional[ThreadGoal] = None
+    # Opaque identity for the exact objective generation. DismissGoal echoes it
+    # so a delayed click can never hide a replacement Goal.
+    goal_id: Optional[WireId] = None
+    dismissed: bool = False
     # Present only on the one-shot GetGoal response. Broadcast mutations omit
     # it, so clients can freeze request-time surface ownership without changing
     # the normal per-session Goal stream.
     request_id: Optional[WireId] = None
+
+
+class CompletionState(_Base):
+    """Authoritative cross-client unread state for a main-session turn."""
+
+    type: Literal["completion_state"] = "completion_state"
+    completion_id: Optional[WireId] = None
+    unread: bool = False
+    revision: int = Field(default=0, ge=0)
+
+    @model_validator(mode="after")
+    def unread_requires_identity(self):
+        if self.unread and self.completion_id is None:
+            raise ValueError("unread completion state requires completion_id")
+        return self
 
 
 AnyMessage = Union[
@@ -2217,7 +2255,8 @@ AnyMessage = Union[
     ReplayStart, ReplayEnd, Snapshot, StateEvent, Model, Effort, Perm, PermissionProfiles, PermissionProfile, WebSearch, ContextReport, StatusReport, Notice, RateLimitUpdate, DiffReport, FilePreview, FileSaveResult, PreviewAsset, PreviewAuthorizationRequired, PreviewAuthorizationResult, History, TurnDetail, HistoryImage, HistoryInvalidated, ArtifactInvalidated, Models, EngineCapabilities, AskUser, AskUserClosed, AnswerQuestion,
     SessionList, SessionListInvalidated, SessionActivity, SessionFocus, SessionRekey, RenameSession, ArchiveSession, PinSession, WorkDashboard, WorkArtifacts,
     ForkSession, ForkSessionWorktree, SessionForked, MigrateSession, SessionMigrated, DirList,
-    GetGoal, SetGoal, ClearGoal, GoalState,
+    GetGoal, SetGoal, ClearGoal, DismissGoal, GoalState,
+    AcknowledgeCompletion, CompletionState,
     UserMsg, TurnSteered, AssistantMsgStart, Delta, ToolUse, ToolDelta, ToolResult,
     AssistantMsgEnd, ProcessEvent, TurnPlan, TurnDiff, TurnBinding,
     TurnEnd, Error, WrapperDisconnected, WrapperReconnected,
@@ -2232,7 +2271,7 @@ DOWNSTREAM_TYPES = frozenset({
     "collaboration_mode", "session_control", "query_queue", "btw_opened",
     "assistant_msg_start", "delta", "tool_use", "tool_delta", "tool_result",
     "assistant_msg_end", "process", "turn_plan", "turn_diff", "turn_binding",
-    "turn_end",
+    "turn_end", "completion_state",
     "error", "ask_user", "ask_user_closed", "history_invalidated", "artifact_invalidated",
 })
 
@@ -2344,7 +2383,10 @@ _TYPE_MAP: dict[str, type[BaseModel]] = {
     "get_goal": GetGoal,
     "set_goal": SetGoal,
     "clear_goal": ClearGoal,
+    "dismiss_goal": DismissGoal,
     "goal_state": GoalState,
+    "acknowledge_completion": AcknowledgeCompletion,
+    "completion_state": CompletionState,
     "session_list": SessionList,
     "session_list_invalidated": SessionListInvalidated,
     "session_activity": SessionActivity,

--- a/cc_remote/wrapper/command_router.py
+++ b/cc_remote/wrapper/command_router.py
@@ -49,6 +49,8 @@ COMMAND_HANDLER_NAMES = MappingProxyType({
     "get_goal": "_handle_get_goal",
     "set_goal": "_handle_set_goal",
     "clear_goal": "_handle_clear_goal",
+    "dismiss_goal": "_handle_dismiss_goal",
+    "acknowledge_completion": "_handle_acknowledge_completion",
     "list_sessions": "_handle_list_sessions",
     "switch_session": "_handle_switch_session",
     "new_session": "_handle_new_session",

--- a/cc_remote/wrapper/machine.py
+++ b/cc_remote/wrapper/machine.py
@@ -108,8 +108,8 @@ from cc_remote.protocol import (
     PreviewAuthorizationRequired, PreviewAuthorizationResult,
     ConversationTurn, History, TurnDetail, HistoryImage,
     HistoryInvalidated, ArtifactInvalidated, AskUser, AskUserClosed,
-    GoalState, ReplayStart, ReplayEnd, Snapshot, StateEvent, State,
-    TakeoverState, SessionControl,
+    GoalState, CompletionState, ReplayStart, ReplayEnd, Snapshot, StateEvent,
+    State, TakeoverState, SessionControl,
     UserMsg, TurnSteered,
     ToolUse, ToolResult, ProcessEvent, TurnPlan, TurnBinding, TurnEnd,
     TurnNotificationContext,
@@ -129,6 +129,11 @@ from cc_remote.wrapper.session_pins import SessionPinStore, SessionPinStoreError
 from cc_remote.wrapper.session_plans import (
     SessionPlanStore,
     SessionPlanStoreError,
+)
+from cc_remote.wrapper.session_presentation import (
+    SessionPresentationSnapshot,
+    SessionPresentationStore,
+    SessionPresentationStoreError,
 )
 from cc_remote.wrapper.claude_controls import (
     ClaudeControlStore,
@@ -1297,7 +1302,9 @@ class WrapperMachine:
         "list_sessions", "get_history", "get_turn_detail", "get_history_image",
         "get_models", "get_permission_profiles", "get_engine_capabilities",
         "get_context", "get_status", "get_diff", "get_file_preview",
-        "get_preview_asset", "get_goal", "get_queued_query", "list_dir",
+        "get_preview_asset", "get_goal", "dismiss_goal",
+        "acknowledge_completion",
+        "get_queued_query", "list_dir",
         "get_work_dashboard",
     })
     # Commands whose target is a runtime ``sid``.  A /btw runtime is private to
@@ -1313,6 +1320,7 @@ class WrapperMachine:
         "get_context", "get_status", "get_diff", "get_file_preview", "save_markdown",
         "get_preview_asset", "authorize_preview",
         "answer_question", "get_goal", "set_goal", "clear_goal",
+        "dismiss_goal", "acknowledge_completion",
     })
     # These commands address a session through ``session_id`` instead.
     BTW_SESSION_COMMANDS = frozenset({
@@ -1613,6 +1621,16 @@ class WrapperMachine:
             # private cache must not prevent users from reaching their engine.
             self._session_plans = None
             log.exception("session plan store unavailable")
+        try:
+            self._session_presentation: SessionPresentationStore | None = (
+                SessionPresentationStore(self.cfg.state_dir)
+            )
+        except SessionPresentationStoreError:
+            # Presentation receipts must never prevent access to the native
+            # engines. Live clients retain their local fallback if this private
+            # cache is damaged.
+            self._session_presentation = None
+            log.exception("session presentation store unavailable")
         try:
             self._claude_controls: ClaudeControlStore | None = (
                 ClaudeControlStore(self.cfg.state_dir)
@@ -1981,6 +1999,81 @@ class WrapperMachine:
             display_name=display_name,
             parent_session_id=ctx.parent_sid if ctx.btw else None,
         )
+
+    @staticmethod
+    def _goal_identity(goal: object) -> Optional[str]:
+        """Return one opaque identity for a stable Goal generation."""
+        if goal is None:
+            return None
+        if hasattr(goal, "model_dump"):
+            raw = goal.model_dump(mode="json")
+        elif isinstance(goal, dict):
+            raw = goal
+        else:
+            return None
+        if not isinstance(raw, dict):
+            return None
+        thread_id = raw.get("threadId")
+        objective = raw.get("objective")
+        engine = raw.get("engine")
+        if (
+            not isinstance(thread_id, str)
+            or not isinstance(objective, str)
+            or engine not in {"claude", "codex"}
+        ):
+            return None
+        marker = raw.get("createdAt")
+        if marker is None:
+            marker = raw.get("setAt")
+        if (
+            isinstance(marker, bool)
+            or not isinstance(marker, (int, float))
+            or (isinstance(marker, float) and not math.isfinite(marker))
+            or marker < 0
+        ):
+            # Without a native generation marker a repeated objective cannot
+            # be distinguished safely. Keep that rare legacy Goal page-local
+            # instead of allowing a delayed dismissal to hide a replacement.
+            return None
+        payload = json.dumps(
+            [engine, thread_id, marker, objective],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return f"goal-{hashlib.sha256(payload).hexdigest()[:40]}"
+
+    @staticmethod
+    def _completion_state(
+        snapshot: SessionPresentationSnapshot,
+    ) -> CompletionState:
+        return CompletionState(
+            completion_id=snapshot.completion_id,
+            unread=snapshot.completion_unread,
+            revision=snapshot.completion_revision,
+        )
+
+    def _session_presentation_fields(
+        self,
+        session_id: str,
+    ) -> dict[str, object]:
+        """Project a durable completion receipt into one cold catalog row."""
+        if self._session_presentation is None:
+            return {}
+        try:
+            snapshot = self._session_presentation.get(session_id)
+        except SessionPresentationStoreError:
+            log.warning(
+                "session completion receipt could not be listed",
+                session_id=session_id,
+            )
+            return {}
+        if snapshot.completion_revision == 0:
+            return {}
+        return {
+            "completion_id": snapshot.completion_id,
+            "completion_unread": snapshot.completion_unread,
+            "completion_revision": snapshot.completion_revision,
+        }
 
     def _history_revision(self, sid: str) -> str:
         return f"{self.instance_id}-{self._history_revision_epochs.get(sid, 0)}"
@@ -5701,6 +5794,23 @@ class WrapperMachine:
                           type=getattr(msg, "type", None))
                 return
             msg.to = ctx.owner_client_id
+        if isinstance(msg, GoalState) and msg.sid:
+            goal_id = self._goal_identity(msg.goal)
+            dismissed = False
+            if self._session_presentation is not None:
+                try:
+                    dismissed = await asyncio.to_thread(
+                        self._session_presentation.reconcile_goal,
+                        msg.sid,
+                        goal_id,
+                    )
+                except SessionPresentationStoreError:
+                    log.warning(
+                        "Goal presentation receipt could not be reconciled",
+                        session_id=msg.sid,
+                    )
+            msg.goal_id = goal_id
+            msg.dismissed = dismissed
         if (
             isinstance(msg, (UserMsg, TurnSteered))
             and ctx.engine == "codex"
@@ -5778,6 +5888,32 @@ class WrapperMachine:
         await self._observe_preview_path_event(ctx, msg)
         async with ctx.emit_lock:
             await self._emit_locked(ctx, msg)
+            if (
+                isinstance(msg, TurnEnd)
+                and not msg.result.is_error
+                and not ctx.btw
+                and self._session_presentation is not None
+            ):
+                sid = self._ctx_wire_sid(ctx) or ctx.key
+                if sid:
+                    try:
+                        snapshot = await asyncio.to_thread(
+                            self._session_presentation.mark_completion,
+                            sid,
+                            msg.turn_id,
+                        )
+                    except SessionPresentationStoreError:
+                        log.warning(
+                            "session completion receipt could not be persisted",
+                            session_id=sid,
+                        )
+                    else:
+                        # Publish after TurnEnd so every client first observes
+                        # the real terminal boundary, then the shared unread
+                        # receipt which a visible client may acknowledge.
+                        await self._emit_locked(
+                            ctx, self._completion_state(snapshot)
+                        )
 
     async def _emit_focused(self, msg) -> None:
         """For control-path errors with no target ctx (cap reached, bad cwd):
@@ -6744,9 +6880,10 @@ class WrapperMachine:
         if seen:
             if cmd.type in self.SAFE_RETRY_COMMANDS:
                 # The original one-shot response may have died on the same link as
-                # its ACK. Safe reads are intentionally re-run to recreate it.
+                # its ACK. Safe reads and idempotent reconciliations are re-run
+                # to recreate an authoritative response.
                 await self._handle(cmd)
-                log.info("duplicate read command replayed", client_id=client_id,
+                log.info("duplicate safe command replayed", client_id=client_id,
                          cmd_id=cmd_id, type=cmd.type)
             else:
                 switch_ctx = None
@@ -6785,9 +6922,9 @@ class WrapperMachine:
         result = await self._handle(cmd)
 
         if reliable:
-            # Safe reads are recreated on retry, so retaining their potentially
-            # large History/file/image payloads in the command-id LRU buys
-            # nothing and can multiply memory by clients × commands.
+            # Safe commands are recreated on retry, so retaining their response
+            # payloads in the command-id LRU buys nothing and can multiply
+            # memory by clients × commands.
             if cmd.type in self.SAFE_RETRY_COMMANDS:
                 responses = ()
             elif cmd.type == "steer":
@@ -7026,6 +7163,27 @@ class WrapperMachine:
                         "sid": sid,
                         "route_id": getattr(cmd, "route_id", None),
                     }))
+                if not ctx.btw and self._session_presentation is not None:
+                    try:
+                        presentation = await asyncio.to_thread(
+                            self._session_presentation.get, sid
+                        )
+                    except SessionPresentationStoreError:
+                        log.warning(
+                            "session completion receipt could not be seeded",
+                            session_id=sid,
+                        )
+                    else:
+                        await self.transport.send(
+                            self._completion_state(presentation).model_copy(
+                                deep=True,
+                                update={
+                                    "to": cmd.client_id,
+                                    "sid": sid,
+                                    "route_id": getattr(cmd, "route_id", None),
+                                },
+                            )
+                        )
                 # Permission/collaboration modes are live control state, not
                 # transcript history. Always seed them on hello even when the
                 # browser's replay cursor is already at the ring tail.
@@ -14607,6 +14765,105 @@ class WrapperMachine:
             log.warning("get_goal failed", error_type=type(exc).__name__)
             return await self._emit_goal_error(ctx, cmd, "Goal 状态暂不可用")
 
+    async def _handle_dismiss_goal(self, cmd) -> None:
+        ctx = await self._goal_ctx(cmd)
+        if ctx is None:
+            return await self._missing_session_error(cmd, "隐藏 Goal")
+        if self._session_presentation is None:
+            return await self._emit_goal_error(ctx, cmd, "Goal 隐藏状态暂不可用")
+        try:
+            goal = (
+                await ctx.sdk.get_goal()
+                if ctx.engine == "codex"
+                else await ctx.sdk.refresh_goal(ctx.session_id)
+            )
+            goal_id = self._goal_identity(goal)
+            # Treat a delayed click as a harmless reconciliation read. It must
+            # reveal the replacement Goal rather than hiding a generation the
+            # user never saw.
+            if goal_id is not None and goal_id == cmd.goal_id:
+                await asyncio.to_thread(
+                    self._session_presentation.dismiss_goal,
+                    self._ctx_wire_sid(ctx) or ctx.key,
+                    goal_id,
+                )
+            event = GoalState(goal=goal)
+            await self._emit(ctx, event)
+            return event
+        except SessionPresentationStoreError:
+            log.warning(
+                "Goal dismissal receipt could not be persisted",
+                session_id=self._ctx_wire_sid(ctx) or ctx.key,
+            )
+            return await self._emit_goal_error(ctx, cmd, "Goal 隐藏状态保存失败")
+        except Exception as exc:
+            log.warning("dismiss_goal failed", error_type=type(exc).__name__)
+            return await self._emit_goal_error(ctx, cmd, "Goal 状态暂不可用")
+
+    async def _handle_acknowledge_completion(self, cmd) -> None:
+        sid = getattr(cmd, "sid", None)
+        ctx = self._ctx_for(sid)
+        if ctx is None and not isinstance(sid, str):
+            return await self._missing_session_error(cmd, "确认任务完成状态")
+        if ctx is not None and ctx.btw:
+            error = Error(
+                code=ERR_PROTOCOL,
+                message="临时 BTW 完成状态仅属于其创建页面",
+                request_id=getattr(cmd, "cmd_id", None),
+                to=getattr(cmd, "client_id", None),
+            )
+            await self._emit(ctx, error)
+            return error
+        if self._session_presentation is None:
+            error = Error(
+                code=ERR_INTERNAL,
+                message="任务完成状态暂不可用",
+                request_id=getattr(cmd, "cmd_id", None),
+                to=getattr(cmd, "client_id", None),
+            )
+            if ctx is not None:
+                await self._emit(ctx, error)
+            else:
+                await self._emit_to_sid(sid, error)
+            return error
+        try:
+            session_id = (
+                (self._ctx_wire_sid(ctx) or ctx.key)
+                if ctx is not None
+                else sid
+            )
+            snapshot = await asyncio.to_thread(
+                self._session_presentation.acknowledge_completion,
+                session_id,
+                cmd.completion_id,
+            )
+            event = self._completion_state(snapshot)
+            if ctx is not None:
+                await self._emit(ctx, event)
+            else:
+                await self._emit_to_sid(sid, event)
+            return event
+        except SessionPresentationStoreError:
+            log.warning(
+                "session completion acknowledgement could not be persisted",
+                session_id=(
+                    (self._ctx_wire_sid(ctx) or ctx.key)
+                    if ctx is not None
+                    else sid
+                ),
+            )
+            error = Error(
+                code=ERR_INTERNAL,
+                message="任务完成状态保存失败",
+                request_id=getattr(cmd, "cmd_id", None),
+                to=getattr(cmd, "client_id", None),
+            )
+            if ctx is not None:
+                await self._emit(ctx, error)
+            else:
+                await self._emit_to_sid(sid, error)
+            return error
+
     async def _handle_set_goal(self, cmd) -> None:
         ctx = await self._goal_ctx(cmd)
         if ctx is None:
@@ -16516,6 +16773,7 @@ class WrapperMachine:
                     state=resident_state.get(info.session_id),
                     engine="claude", space=space,
                     work_id=record.work_id if record else None,
+                    **self._session_presentation_fields(info.session_id),
                 ))
             if space == "code" and self._claude_broker_enabled:
                 # `claude-remote new` reserves the native session UUID before
@@ -16553,6 +16811,7 @@ class WrapperMachine:
                                 pinned=broker_sid in pinned_ids,
                                 engine="claude",
                                 space="code",
+                                **self._session_presentation_fields(broker_sid),
                             ))
                             known.add(broker_sid)
             for session in sessions:
@@ -17028,6 +17287,7 @@ class WrapperMachine:
                     native_session_id=native_sid,
                     codex_profile_id=row.get("codex_profile_id"),
                     codex_profile_label=row.get("codex_profile_label"),
+                    **self._session_presentation_fields(wire_sid),
                 ))
             for session in sessions:
                 self._remember_notification_title(
@@ -17178,6 +17438,21 @@ class WrapperMachine:
         control_event = self._session_control(ctx)
         await self._emit(ctx, control_event)
         cached_responses.append(control_event)
+        if not ctx.btw and self._session_presentation is not None:
+            try:
+                presentation = await asyncio.to_thread(
+                    self._session_presentation.get,
+                    self._ctx_wire_sid(ctx) or ctx.key,
+                )
+            except SessionPresentationStoreError:
+                log.warning(
+                    "session completion receipt could not be seeded",
+                    session_id=self._ctx_wire_sid(ctx) or ctx.key,
+                )
+            else:
+                completion_event = self._completion_state(presentation)
+                await self._emit(ctx, completion_event)
+                cached_responses.append(completion_event)
         permission_mode = _session_permission_mode(ctx)
         ctx.announced_perm = permission_mode
         permission_event = Perm(mode=permission_mode)
@@ -17350,6 +17625,17 @@ class WrapperMachine:
                 except SessionPlanStoreError:
                     log.warning(
                         "temporary session plan snapshot rekey failed",
+                        old_key=old_key,
+                        session_id=route_sid,
+                    )
+            if self._session_presentation is not None:
+                try:
+                    await asyncio.to_thread(
+                        self._session_presentation.move, old_key, route_sid
+                    )
+                except SessionPresentationStoreError:
+                    log.warning(
+                        "temporary session presentation rekey failed",
                         old_key=old_key,
                         session_id=route_sid,
                     )
@@ -17884,6 +18170,16 @@ class WrapperMachine:
         else:
             await self._delete_codex_client_message_ids(codex_alias_path)
         await self._drop_preview_session(engine, sid)
+        if self._session_presentation is not None:
+            try:
+                await asyncio.to_thread(
+                    self._session_presentation.delete, sid
+                )
+            except SessionPresentationStoreError:
+                log.warning(
+                    "stale Work presentation cleanup failed",
+                    session_id=sid,
+                )
         if self._session_pins is not None:
             try:
                 await asyncio.to_thread(
@@ -18072,6 +18368,16 @@ class WrapperMachine:
             except SessionPlanStoreError:
                 log.warning(
                     "stale Codex plan cleanup failed", session_id=sid)
+        if self._session_presentation is not None:
+            try:
+                await asyncio.to_thread(
+                    self._session_presentation.delete, sid
+                )
+            except SessionPresentationStoreError:
+                log.warning(
+                    "stale Code presentation cleanup failed",
+                    session_id=sid,
+                )
         if self._session_pins is not None:
             try:
                 await asyncio.to_thread(
@@ -18403,6 +18709,20 @@ class WrapperMachine:
                 except SessionPlanStoreError:
                     log.warning(
                         "Codex plan cleanup after rollback failed",
+                        session_id=sid,
+                    )
+            if self._session_presentation is not None:
+                try:
+                    presentation = await asyncio.to_thread(
+                        self._session_presentation.clear_completion, sid
+                    )
+                    if presentation.completion_revision > 0:
+                        await self._emit(
+                            ctx, self._completion_state(presentation)
+                        )
+                except SessionPresentationStoreError:
+                    log.warning(
+                        "completion receipt cleanup after rollback failed",
                         session_id=sid,
                     )
             try:

--- a/cc_remote/wrapper/machine.py
+++ b/cc_remote/wrapper/machine.py
@@ -111,7 +111,8 @@ from cc_remote.protocol import (
     GoalState, ReplayStart, ReplayEnd, Snapshot, StateEvent, State,
     TakeoverState, SessionControl,
     UserMsg, TurnSteered,
-    ToolUse, ToolResult, ProcessEvent, TurnBinding, TurnEnd, TurnNotificationContext,
+    ToolUse, ToolResult, ProcessEvent, TurnPlan, TurnBinding, TurnEnd,
+    TurnNotificationContext,
     TurnResult, is_downstream,
     is_reliable_command,
     SessionInfo, SessionList, SessionListInvalidated, SessionActivity,
@@ -125,6 +126,10 @@ from cc_remote.protocol import (
 )
 from cc_remote.wrapper.ringbuffer import RingBuffer
 from cc_remote.wrapper.session_pins import SessionPinStore, SessionPinStoreError
+from cc_remote.wrapper.session_plans import (
+    SessionPlanStore,
+    SessionPlanStoreError,
+)
 from cc_remote.wrapper.claude_controls import (
     ClaudeControlStore,
     ClaudeControlStoreError,
@@ -1600,6 +1605,14 @@ class WrapperMachine:
         except SessionPinStoreError:
             self._session_pins = None
             log.exception("session pin store unavailable")
+        try:
+            self._session_plans: SessionPlanStore | None = SessionPlanStore(
+                self.cfg.state_dir)
+        except SessionPlanStoreError:
+            # Codex plan notifications are presentation state. A damaged
+            # private cache must not prevent users from reaching their engine.
+            self._session_plans = None
+            log.exception("session plan store unavailable")
         try:
             self._claude_controls: ClaudeControlStore | None = (
                 ClaudeControlStore(self.cfg.state_dir)
@@ -5688,6 +5701,61 @@ class WrapperMachine:
                           type=getattr(msg, "type", None))
                 return
             msg.to = ctx.owner_client_id
+        if (
+            isinstance(msg, (UserMsg, TurnSteered))
+            and ctx.engine == "codex"
+            and not ctx.btw
+            and self._session_plans is not None
+            and msg.sid
+        ):
+            if isinstance(msg, UserMsg):
+                current_ids = {
+                    value
+                    for value in (msg.msg_id, msg.client_msg_id)
+                    if value
+                }
+                binding = ctx.active_turn_binding
+                if (
+                    binding is not None
+                    and binding.generation == self.instance_id
+                    and binding.msg_id in current_ids
+                ):
+                    current_ids.add(binding.turn_id)
+                current_turn_ids = frozenset(current_ids)
+            else:
+                current_turn_ids = frozenset()
+            try:
+                # Completed Plan state belongs to the task which just ended.
+                # Retire it before broadcasting the next user boundary so a
+                # reconnect cannot recover the old green monitor.
+                await asyncio.to_thread(
+                    self._session_plans.retire_completed,
+                    msg.sid,
+                    current_turn_ids=current_turn_ids,
+                )
+            except SessionPlanStoreError:
+                log.warning(
+                    "Codex completed plan snapshot could not be retired",
+                    session_id=msg.sid,
+                )
+        if (
+            isinstance(msg, TurnPlan)
+            and ctx.engine == "codex"
+            and not ctx.btw
+            and self._session_plans is not None
+            and msg.sid
+        ):
+            try:
+                # Persist before broadcasting: a browser which paints this
+                # update and immediately reconnects must not lose the control.
+                await asyncio.to_thread(self._session_plans.put, msg.sid, msg)
+            except SessionPlanStoreError:
+                # Losing the optional recovery snapshot must not drop the live
+                # plan notification or abort the model turn.
+                log.warning(
+                    "Codex session plan snapshot could not be persisted",
+                    session_id=msg.sid,
+                )
         if isinstance(msg, TurnEnd):
             # The replayable object is deliberately notification-free. Only a
             # copy sent on this live call receives presentation metadata.
@@ -9958,6 +10026,62 @@ class WrapperMachine:
         # Routing and command correlation are requester-specific; never mutate
         # the shared task's History instance in place.
         hist = template.model_copy(deep=True)
+        if (
+            hist.authoritative is not False
+            and hist.detail == "summary"
+            and not hist.before
+            and hist.turns
+            and self._session_plans is not None
+        ):
+            try:
+                snapshot = await asyncio.to_thread(
+                    self._session_plans.get, sid)
+            except SessionPlanStoreError:
+                snapshot = None
+                log.warning(
+                    "Codex session plan snapshot could not be read",
+                    session_id=sid,
+                )
+            if snapshot is not None:
+                turns = list(hist.turns)
+                target_index = None
+                if snapshot.turn_id:
+                    for index in range(len(turns) - 1, -1, -1):
+                        turn = turns[index]
+                        if snapshot.turn_id in {
+                            turn.id,
+                            turn.clientMsgId,
+                            turn.forkPointId,
+                        }:
+                            target_index = index
+                            break
+                # An unfinished Plan may legitimately span several steer turns
+                # after its owner fell off the newest page. A completed Plan
+                # must never be rebound to an unrelated newest turn: that would
+                # resurrect it after the user already started another task.
+                if target_index is None and not snapshot.complete:
+                    target_index = len(turns) - 1
+                if target_index is not None:
+                    target = turns[target_index]
+                    block = snapshot.as_process_block()
+                    blocks = [
+                        dict(existing)
+                        for existing in target.blocks
+                        if not (
+                            existing.get("kind") == "process"
+                            and existing.get("item_id") == snapshot.item_id
+                        )
+                    ]
+                    if len(blocks) >= 32:
+                        drop = next((
+                            index for index, existing in enumerate(blocks)
+                            if existing.get("kind") != "text"
+                        ), 0)
+                        blocks.pop(drop)
+                    blocks.append(block)
+                    turns[target_index] = target.model_copy(
+                        update={"blocks": blocks})
+                    hist.turns = turns
         client_id = getattr(cmd, "client_id", None)
         if client_id:
             hist.to = client_id            # relay routes it to just this client
@@ -17219,6 +17343,16 @@ class WrapperMachine:
                 rekey_goal(sid)
             save_session_id(self.cfg.state_dir, ctx.cwd, sid)
         if old_key and old_key != route_sid:
+            if self._session_plans is not None:
+                try:
+                    await asyncio.to_thread(
+                        self._session_plans.move, old_key, route_sid)
+                except SessionPlanStoreError:
+                    log.warning(
+                        "temporary session plan snapshot rekey failed",
+                        old_key=old_key,
+                        session_id=route_sid,
+                    )
             await self._rekey_preview_session(ctx, old_key, route_sid)
             self._remember_session_alias(old_key, route_sid, ctx.cwd)
             self.sessions.pop(old_key, None)
@@ -17932,6 +18066,12 @@ class WrapperMachine:
             except CodexControlStoreError:
                 log.warning(
                     "stale Codex controls cleanup failed", session_id=sid)
+        if engine == "codex" and self._session_plans is not None:
+            try:
+                await asyncio.to_thread(self._session_plans.delete, sid)
+            except SessionPlanStoreError:
+                log.warning(
+                    "stale Codex plan cleanup failed", session_id=sid)
         if self._session_pins is not None:
             try:
                 await asyncio.to_thread(
@@ -18257,6 +18397,14 @@ class WrapperMachine:
 
         if invalidate_conversation:
             ctx.active_msg_id = None
+            if ctx.engine == "codex" and self._session_plans is not None:
+                try:
+                    await asyncio.to_thread(self._session_plans.delete, sid)
+                except SessionPlanStoreError:
+                    log.warning(
+                        "Codex plan cleanup after rollback failed",
+                        session_id=sid,
+                    )
             try:
                 self._resync_watch(sid)
             except Exception as exc:

--- a/cc_remote/wrapper/session_plans.py
+++ b/cc_remote/wrapper/session_plans.py
@@ -1,0 +1,297 @@
+"""Durable latest-plan snapshots for Codex sessions.
+
+Codex emits ``turn/plan/updated`` as a live notification, but its persisted
+``thread/turns/list`` projection does not currently retain that notification.
+Keep the latest display-safe snapshot in cc-remote's private state so a fresh
+browser can recover the same plan affordance without replaying a model turn.
+"""
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import threading
+import time
+from typing import Any
+from uuid import uuid4
+
+from cc_remote.protocol import TurnPlan
+
+
+_SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$")
+_MAX_ENTRIES = 4096
+_MAX_FILE_BYTES = 16 * 1024 * 1024
+
+
+class SessionPlanStoreError(RuntimeError):
+    """The Remote-owned plan snapshot store is unsafe or malformed."""
+
+
+@dataclass(frozen=True)
+class SessionPlanSnapshot:
+    item_id: str
+    turn_id: str | None
+    explanation: str | None
+    plan: tuple[dict[str, str], ...]
+    updated_at: float
+
+    @property
+    def complete(self) -> bool:
+        return bool(self.plan) and all(
+            entry["status"] == "completed" for entry in self.plan)
+
+    @classmethod
+    def from_event(
+        cls,
+        event: TurnPlan,
+        *,
+        updated_at: float | None = None,
+    ) -> "SessionPlanSnapshot":
+        # TurnPlan is the public bounded schema. Re-validating a copied payload
+        # keeps this private store aligned if a caller supplies a subclass or a
+        # test double instead of the exact model instance.
+        clean = TurnPlan.model_validate(event.model_dump(mode="python"))
+        return cls(
+            item_id=clean.item_id,
+            turn_id=clean.turn_id,
+            explanation=clean.explanation,
+            plan=tuple(dict(entry) for entry in clean.plan),
+            updated_at=time.time() if updated_at is None else updated_at,
+        )
+
+    def as_event(self) -> TurnPlan:
+        return TurnPlan(
+            item_id=self.item_id,
+            turn_id=self.turn_id,
+            explanation=self.explanation,
+            plan=[dict(entry) for entry in self.plan],
+        )
+
+    def as_process_block(self) -> dict[str, Any]:
+        return {
+            "kind": "process",
+            "item_id": self.item_id,
+            "processKind": "plan",
+            "phase": "snapshot",
+            "status": "succeeded" if self.complete else "running",
+            "turn_id": self.turn_id,
+            "parent_id": None,
+            "title": "计划",
+            "done": self.complete,
+            "explanation": self.explanation,
+            "plan": [dict(entry) for entry in self.plan],
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "item_id": self.item_id,
+            "turn_id": self.turn_id,
+            "explanation": self.explanation,
+            "plan": [dict(entry) for entry in self.plan],
+            "updated_at": self.updated_at,
+        }
+
+
+def _session_id(value: object) -> str:
+    if not isinstance(value, str) or not _SESSION_ID.fullmatch(value):
+        raise SessionPlanStoreError("Codex session id is invalid")
+    return value
+
+
+def _snapshot(value: object) -> SessionPlanSnapshot:
+    if not isinstance(value, dict) or set(value) != {
+        "item_id", "turn_id", "explanation", "plan", "updated_at",
+    }:
+        raise SessionPlanStoreError("Codex plan snapshot has an invalid shape")
+    updated_at = value.get("updated_at")
+    if (
+        isinstance(updated_at, bool)
+        or not isinstance(updated_at, (int, float))
+        or updated_at < 0
+    ):
+        raise SessionPlanStoreError("Codex plan snapshot timestamp is invalid")
+    try:
+        event = TurnPlan(
+            item_id=value.get("item_id"),
+            turn_id=value.get("turn_id"),
+            explanation=value.get("explanation"),
+            plan=value.get("plan"),
+        )
+    except Exception as exc:
+        raise SessionPlanStoreError(
+            "Codex plan snapshot payload is invalid") from exc
+    return SessionPlanSnapshot.from_event(event, updated_at=float(updated_at))
+
+
+class SessionPlanStore:
+    """Atomic, bounded plan snapshots that survive browser/wrapper restarts."""
+
+    def __init__(self, state_dir: Path):
+        self.path = Path(state_dir) / "session-plans.json"
+        self._lock = threading.RLock()
+        self._plans = self._load()
+
+    def get(self, session_id: str) -> SessionPlanSnapshot | None:
+        session_id = _session_id(session_id)
+        with self._lock:
+            snapshot = self._plans.get(session_id)
+            if snapshot is not None:
+                self._plans.move_to_end(session_id)
+            return snapshot
+
+    def put(self, session_id: str, event: TurnPlan) -> SessionPlanSnapshot:
+        session_id = _session_id(session_id)
+        snapshot = SessionPlanSnapshot.from_event(event)
+        with self._lock:
+            updated = OrderedDict(self._plans)
+            updated.pop(session_id, None)
+            updated[session_id] = snapshot
+            while len(updated) > _MAX_ENTRIES:
+                updated.popitem(last=False)
+            self._persist_bounded(updated)
+            self._plans = updated
+        return snapshot
+
+    def move(self, old_session_id: str, session_id: str) -> None:
+        old_session_id = _session_id(old_session_id)
+        session_id = _session_id(session_id)
+        if old_session_id == session_id:
+            return
+        with self._lock:
+            snapshot = self._plans.get(old_session_id)
+            if snapshot is None:
+                return
+            updated = OrderedDict(self._plans)
+            updated.pop(old_session_id, None)
+            updated.pop(session_id, None)
+            updated[session_id] = snapshot
+            self._persist_bounded(updated)
+            self._plans = updated
+
+    def delete(self, session_id: str) -> None:
+        session_id = _session_id(session_id)
+        with self._lock:
+            if session_id not in self._plans:
+                return
+            updated = OrderedDict(self._plans)
+            updated.pop(session_id, None)
+            self._persist_bounded(updated)
+            self._plans = updated
+
+    def retire_completed(
+        self,
+        session_id: str,
+        *,
+        current_turn_ids: frozenset[str] = frozenset(),
+    ) -> bool:
+        """Delete a completed Plan when a later user message begins.
+
+        A replay of the Plan's own ``UserMsg`` is not a later message, so its
+        known native/client identity may protect the snapshot. A steer is
+        always a new user boundary and therefore passes no protected ids.
+        """
+        session_id = _session_id(session_id)
+        with self._lock:
+            snapshot = self._plans.get(session_id)
+            if (
+                snapshot is None
+                or not snapshot.complete
+                or (
+                    snapshot.turn_id is not None
+                    and snapshot.turn_id in current_turn_ids
+                )
+            ):
+                return False
+            updated = OrderedDict(self._plans)
+            updated.pop(session_id, None)
+            self._persist_bounded(updated)
+            self._plans = updated
+            return True
+
+    def _load(self) -> OrderedDict[str, SessionPlanSnapshot]:
+        try:
+            info = self.path.lstat()
+            if not stat.S_ISREG(info.st_mode) or info.st_size > _MAX_FILE_BYTES:
+                raise ValueError("session plan store is not a bounded regular file")
+            raw_bytes = self.path.read_bytes()
+            if len(raw_bytes) > _MAX_FILE_BYTES:
+                raise ValueError("session plan store exceeds size limit")
+            raw = json.loads(raw_bytes.decode("utf-8"))
+            if not isinstance(raw, dict) or set(raw) != {"version", "plans"}:
+                raise ValueError("session plan store has an invalid envelope")
+            if raw.get("version") != 1 or not isinstance(raw.get("plans"), dict):
+                raise ValueError("session plan store version is unsupported")
+            loaded: OrderedDict[str, SessionPlanSnapshot] = OrderedDict()
+            for session_id, value in raw["plans"].items():
+                loaded[_session_id(session_id)] = _snapshot(value)
+            if len(loaded) > _MAX_ENTRIES:
+                raise ValueError("session plan store has too many entries")
+            return loaded
+        except FileNotFoundError:
+            return OrderedDict()
+        except Exception as exc:
+            raise SessionPlanStoreError(
+                "session plan store is unreadable") from exc
+
+    @staticmethod
+    def _payload(
+        plans: OrderedDict[str, SessionPlanSnapshot],
+    ) -> bytes:
+        return json.dumps({
+            "version": 1,
+            "plans": {
+                session_id: snapshot.as_dict()
+                for session_id, snapshot in plans.items()
+            },
+        }, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+    def _persist_bounded(
+        self,
+        plans: OrderedDict[str, SessionPlanSnapshot],
+    ) -> None:
+        bounded = OrderedDict(plans)
+        payload = self._payload(bounded)
+        while len(payload) > _MAX_FILE_BYTES and len(bounded) > 1:
+            bounded.popitem(last=False)
+            payload = self._payload(bounded)
+        if len(payload) > _MAX_FILE_BYTES:
+            raise SessionPlanStoreError("session plan store exceeds size limit")
+        # Propagate LRU evictions back to the caller's replacement map.
+        plans.clear()
+        plans.update(bounded)
+        self._persist(payload)
+
+    def _persist(self, payload: bytes) -> None:
+        tmp = self.path.with_suffix(f".{os.getpid()}.{uuid4().hex}.tmp")
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            os.chmod(self.path.parent, 0o700)
+            fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            try:
+                with os.fdopen(fd, "wb") as stream:
+                    stream.write(payload)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+            except Exception:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+                raise
+            os.replace(tmp, self.path)
+            directory_fd = os.open(self.path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except Exception as exc:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            raise SessionPlanStoreError(
+                "session plan store could not be persisted") from exc

--- a/cc_remote/wrapper/session_presentation.py
+++ b/cc_remote/wrapper/session_presentation.py
@@ -1,0 +1,397 @@
+"""Durable cross-client presentation receipts for native sessions.
+
+Completion badges and Goal dismissal are user-visible session state, not
+engine transcript metadata.  Keep their latest bounded projection in the
+wrapper so acknowledging either surface on one browser immediately applies to
+every other browser and survives a wrapper restart.
+"""
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, replace
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import threading
+import time
+from uuid import uuid4
+
+
+_WIRE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$")
+_MAX_ENTRIES = 4096
+_MAX_FILE_BYTES = 16 * 1024 * 1024
+
+
+class SessionPresentationStoreError(RuntimeError):
+    """The Remote-owned presentation receipt store is unsafe or malformed."""
+
+
+@dataclass(frozen=True)
+class SessionPresentationSnapshot:
+    completion_id: str | None = None
+    completion_unread: bool = False
+    completion_revision: int = 0
+    dismissed_goal_id: str | None = None
+    updated_at: float = 0.0
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "completion_id": self.completion_id,
+            "completion_unread": self.completion_unread,
+            "completion_revision": self.completion_revision,
+            "dismissed_goal_id": self.dismissed_goal_id,
+            "updated_at": self.updated_at,
+        }
+
+
+def _wire_id(value: object, *, optional: bool = False) -> str | None:
+    if optional and value is None:
+        return None
+    if not isinstance(value, str) or not _WIRE_ID.fullmatch(value):
+        raise SessionPresentationStoreError("session presentation id is invalid")
+    return value
+
+
+def _snapshot(value: object) -> SessionPresentationSnapshot:
+    if not isinstance(value, dict) or set(value) != {
+        "completion_id",
+        "completion_unread",
+        "completion_revision",
+        "dismissed_goal_id",
+        "updated_at",
+    }:
+        raise SessionPresentationStoreError(
+            "session presentation snapshot has an invalid shape"
+        )
+    revision = value.get("completion_revision")
+    updated_at = value.get("updated_at")
+    if (
+        isinstance(revision, bool)
+        or not isinstance(revision, int)
+        or revision < 0
+    ):
+        raise SessionPresentationStoreError(
+            "session presentation revision is invalid"
+        )
+    if (
+        isinstance(updated_at, bool)
+        or not isinstance(updated_at, (int, float))
+        or updated_at < 0
+    ):
+        raise SessionPresentationStoreError(
+            "session presentation timestamp is invalid"
+        )
+    unread = value.get("completion_unread")
+    if not isinstance(unread, bool):
+        raise SessionPresentationStoreError(
+            "session completion receipt is invalid"
+        )
+    completion_id = _wire_id(value.get("completion_id"), optional=True)
+    dismissed_goal_id = _wire_id(
+        value.get("dismissed_goal_id"), optional=True
+    )
+    if unread and completion_id is None:
+        raise SessionPresentationStoreError(
+            "an unread completion requires an identity"
+        )
+    return SessionPresentationSnapshot(
+        completion_id=completion_id,
+        completion_unread=unread,
+        completion_revision=revision,
+        dismissed_goal_id=dismissed_goal_id,
+        updated_at=float(updated_at),
+    )
+
+
+class SessionPresentationStore:
+    """Atomic, bounded completion and Goal presentation receipts."""
+
+    def __init__(self, state_dir: Path):
+        self.path = Path(state_dir) / "session-presentation.json"
+        self._lock = threading.RLock()
+        self._sessions = self._load()
+
+    def get(self, session_id: str) -> SessionPresentationSnapshot:
+        session_id = _wire_id(session_id)  # type: ignore[assignment]
+        assert session_id is not None
+        with self._lock:
+            snapshot = self._sessions.get(session_id)
+            if snapshot is None:
+                return SessionPresentationSnapshot()
+            self._sessions.move_to_end(session_id)
+            return snapshot
+
+    def mark_completion(
+        self,
+        session_id: str,
+        completion_id: str | None = None,
+    ) -> SessionPresentationSnapshot:
+        session_id = _wire_id(session_id)  # type: ignore[assignment]
+        completion_id = _wire_id(
+            completion_id or f"completion-{uuid4().hex}"
+        )
+        assert session_id is not None and completion_id is not None
+        with self._lock:
+            current = self._sessions.get(
+                session_id, SessionPresentationSnapshot()
+            )
+            if (
+                current.completion_id == completion_id
+                and current.completion_unread
+            ):
+                return current
+            return self._replace_locked(
+                session_id,
+                replace(
+                    current,
+                    completion_id=completion_id,
+                    completion_unread=True,
+                    completion_revision=current.completion_revision + 1,
+                    updated_at=time.time(),
+                ),
+            )
+
+    def acknowledge_completion(
+        self,
+        session_id: str,
+        completion_id: str,
+    ) -> SessionPresentationSnapshot:
+        session_id = _wire_id(session_id)  # type: ignore[assignment]
+        completion_id = _wire_id(completion_id)  # type: ignore[assignment]
+        assert session_id is not None and completion_id is not None
+        with self._lock:
+            current = self._sessions.get(
+                session_id, SessionPresentationSnapshot()
+            )
+            # A delayed acknowledgement for turn N must never clear the unread
+            # receipt for a newer turn N+1.
+            if (
+                current.completion_id != completion_id
+                or not current.completion_unread
+            ):
+                return current
+            return self._replace_locked(
+                session_id,
+                replace(
+                    current,
+                    completion_unread=False,
+                    completion_revision=current.completion_revision + 1,
+                    updated_at=time.time(),
+                ),
+            )
+
+    def clear_completion(
+        self,
+        session_id: str,
+    ) -> SessionPresentationSnapshot:
+        session_id = _wire_id(session_id)  # type: ignore[assignment]
+        assert session_id is not None
+        with self._lock:
+            current = self._sessions.get(
+                session_id, SessionPresentationSnapshot()
+            )
+            if current.completion_id is None and not current.completion_unread:
+                return current
+            return self._replace_locked(
+                session_id,
+                replace(
+                    current,
+                    completion_id=None,
+                    completion_unread=False,
+                    completion_revision=current.completion_revision + 1,
+                    updated_at=time.time(),
+                ),
+            )
+
+    def dismiss_goal(
+        self,
+        session_id: str,
+        goal_id: str,
+    ) -> SessionPresentationSnapshot:
+        session_id = _wire_id(session_id)  # type: ignore[assignment]
+        goal_id = _wire_id(goal_id)  # type: ignore[assignment]
+        assert session_id is not None and goal_id is not None
+        with self._lock:
+            current = self._sessions.get(
+                session_id, SessionPresentationSnapshot()
+            )
+            if current.dismissed_goal_id == goal_id:
+                return current
+            return self._replace_locked(
+                session_id,
+                replace(
+                    current,
+                    dismissed_goal_id=goal_id,
+                    updated_at=time.time(),
+                ),
+            )
+
+    def reconcile_goal(self, session_id: str, goal_id: str | None) -> bool:
+        """Return whether *goal_id* is hidden, clearing stale generations."""
+        session_id = _wire_id(session_id)  # type: ignore[assignment]
+        goal_id = _wire_id(goal_id, optional=True)  # type: ignore[assignment]
+        assert session_id is not None
+        with self._lock:
+            current = self._sessions.get(
+                session_id, SessionPresentationSnapshot()
+            )
+            dismissed = current.dismissed_goal_id
+            if dismissed is not None and dismissed != goal_id:
+                current = self._replace_locked(
+                    session_id,
+                    replace(
+                        current,
+                        dismissed_goal_id=None,
+                        updated_at=time.time(),
+                    ),
+                )
+            return goal_id is not None and current.dismissed_goal_id == goal_id
+
+    def move(self, old_session_id: str, session_id: str) -> None:
+        old_session_id = _wire_id(old_session_id)  # type: ignore[assignment]
+        session_id = _wire_id(session_id)  # type: ignore[assignment]
+        assert old_session_id is not None and session_id is not None
+        if old_session_id == session_id:
+            return
+        with self._lock:
+            snapshot = self._sessions.get(old_session_id)
+            if snapshot is None:
+                return
+            updated = OrderedDict(self._sessions)
+            updated.pop(old_session_id, None)
+            target = updated.get(session_id)
+            if target is None or snapshot.updated_at >= target.updated_at:
+                updated.pop(session_id, None)
+                updated[session_id] = snapshot
+            self._persist_bounded(updated)
+            self._sessions = updated
+
+    def delete(self, session_id: str) -> None:
+        session_id = _wire_id(session_id)  # type: ignore[assignment]
+        assert session_id is not None
+        with self._lock:
+            if session_id not in self._sessions:
+                return
+            updated = OrderedDict(self._sessions)
+            updated.pop(session_id, None)
+            self._persist_bounded(updated)
+            self._sessions = updated
+
+    def _replace_locked(
+        self,
+        session_id: str,
+        snapshot: SessionPresentationSnapshot,
+    ) -> SessionPresentationSnapshot:
+        updated = OrderedDict(self._sessions)
+        updated.pop(session_id, None)
+        updated[session_id] = snapshot
+        while len(updated) > _MAX_ENTRIES:
+            updated.popitem(last=False)
+        self._persist_bounded(updated)
+        self._sessions = updated
+        return snapshot
+
+    def _load(self) -> OrderedDict[str, SessionPresentationSnapshot]:
+        try:
+            info = self.path.lstat()
+            if not stat.S_ISREG(info.st_mode) or info.st_size > _MAX_FILE_BYTES:
+                raise ValueError(
+                    "session presentation store is not a bounded regular file"
+                )
+            raw_bytes = self.path.read_bytes()
+            if len(raw_bytes) > _MAX_FILE_BYTES:
+                raise ValueError("session presentation store exceeds size limit")
+            raw = json.loads(raw_bytes.decode("utf-8"))
+            if not isinstance(raw, dict) or set(raw) != {"version", "sessions"}:
+                raise ValueError(
+                    "session presentation store has an invalid envelope"
+                )
+            if raw.get("version") != 1 or not isinstance(
+                raw.get("sessions"), dict
+            ):
+                raise ValueError(
+                    "session presentation store version is unsupported"
+                )
+            loaded: OrderedDict[
+                str, SessionPresentationSnapshot
+            ] = OrderedDict()
+            for session_id, value in raw["sessions"].items():
+                clean_id = _wire_id(session_id)
+                assert clean_id is not None
+                loaded[clean_id] = _snapshot(value)
+            if len(loaded) > _MAX_ENTRIES:
+                raise ValueError("session presentation store has too many entries")
+            return loaded
+        except FileNotFoundError:
+            return OrderedDict()
+        except Exception as exc:
+            raise SessionPresentationStoreError(
+                "session presentation store is unreadable"
+            ) from exc
+
+    @staticmethod
+    def _payload(
+        sessions: OrderedDict[str, SessionPresentationSnapshot],
+    ) -> bytes:
+        return json.dumps(
+            {
+                "version": 1,
+                "sessions": {
+                    session_id: snapshot.as_dict()
+                    for session_id, snapshot in sessions.items()
+                },
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+    def _persist_bounded(
+        self,
+        sessions: OrderedDict[str, SessionPresentationSnapshot],
+    ) -> None:
+        bounded = OrderedDict(sessions)
+        payload = self._payload(bounded)
+        while len(payload) > _MAX_FILE_BYTES and len(bounded) > 1:
+            bounded.popitem(last=False)
+            payload = self._payload(bounded)
+        if len(payload) > _MAX_FILE_BYTES:
+            raise SessionPresentationStoreError(
+                "session presentation store exceeds size limit"
+            )
+        sessions.clear()
+        sessions.update(bounded)
+        self._persist(payload)
+
+    def _persist(self, payload: bytes) -> None:
+        tmp = self.path.with_suffix(f".{os.getpid()}.{uuid4().hex}.tmp")
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            os.chmod(self.path.parent, 0o700)
+            fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            try:
+                with os.fdopen(fd, "wb") as stream:
+                    stream.write(payload)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+            except Exception:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+                raise
+            os.replace(tmp, self.path)
+            directory_fd = os.open(self.path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except Exception as exc:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            raise SessionPresentationStoreError(
+                "session presentation store could not be persisted"
+            ) from exc

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -61,13 +61,13 @@ machine). The **full step-by-step guide is in the main [README](../README.md#生
   of embedding control credentials in the plist.
 - `work_registry_snapshot.py` — snapshots provider-local Work SQLite databases
   through SQLite's backup API, restores the matching pre-release images before
-  an older wrapper is restarted, and verifies the v33 Codex ownership backfill.
+  an older wrapper is restarted, and verifies the v34 Codex ownership backfill.
 
-Protocol v33 is a coordinated upgrade: publish freshly built Relay/Web and
+Protocol v34 is a coordinated upgrade: publish freshly built Relay/Web and
 Wrapper artifacts from the same tagged commit. The strict protocol gate is
 intentional and mixed protocol versions will not communicate. `setup-vps.sh`
 rejects a missing or mismatched web build manifest. Stop the wrapper first;
-activate the v33 relay/web release; then start the v33 wrapper.
+activate the v34 relay/web release; then start the v34 wrapper.
 
 The wrapper installer treats local Work data as part of the release
 transaction. It stops the existing service, writes a private snapshot below
@@ -78,8 +78,8 @@ restores and starts the previous code. If data restoration fails, it leaves the
 wrapper stopped instead of running old code against a new schema. A manual or
 legacy-layout deployment must use the same order: stop the wrapper, run
 `work_registry_snapshot.py snapshot` from the new staging tree, activate and
-verify v33, and retain that snapshot with the previous release. To roll back,
-stop v33, run `work_registry_snapshot.py restore`, then switch and start the old
+verify v34, and retain that snapshot with the previous release. To roll back,
+stop v34, run `work_registry_snapshot.py restore`, then switch and start the old
 release. Never copy only `registry.sqlite3` while the wrapper is live because
 committed state may still be in its WAL file. Restoring a pre-release snapshot
 also restores pre-release Work metadata: sessions, projects, or schedule state

--- a/tests/test_claude_permission_state.py
+++ b/tests/test_claude_permission_state.py
@@ -729,12 +729,12 @@ def test_switching_to_resident_claude_reseeds_its_actual_permission():
             session_id="claude-1", engine="claude"))
 
         assert [event.type for event in result] == [
-            "session_focus", "session_control", "perm", "model", "effort",
-            "state"]
-        assert result[2].mode == "default"
-        assert result[3].model == "claude-sonnet-5"
-        assert result[4].effort == "high"
-        assert result[5].state == "idle"
+            "session_focus", "session_control", "completion_state", "perm",
+            "model", "effort", "state"]
+        assert result[3].mode == "default"
+        assert result[4].model == "claude-sonnet-5"
+        assert result[5].effort == "high"
+        assert result[6].state == "idle"
 
     asyncio.run(go())
 

--- a/tests/test_codex_session_migration.py
+++ b/tests/test_codex_session_migration.py
@@ -79,7 +79,7 @@ def _stub_migration_dependencies(monkeypatch, machine):
 
 
 def test_session_migration_protocol_roundtrips_as_control_frames():
-    assert PROTOCOL_VERSION == 33
+    assert PROTOCOL_VERSION == 34
     command = deserialize(serialize(_command("/tmp/new-cwd")))
     assert command.type == "migrate_session"
     assert command.session_id == "thread-1"

--- a/tests/test_command_router.py
+++ b/tests/test_command_router.py
@@ -53,6 +53,8 @@ EXPECTED_COMMAND_HANDLERS = {
     "get_goal": "_handle_get_goal",
     "set_goal": "_handle_set_goal",
     "clear_goal": "_handle_clear_goal",
+    "dismiss_goal": "_handle_dismiss_goal",
+    "acknowledge_completion": "_handle_acknowledge_completion",
     "list_sessions": "_handle_list_sessions",
     "switch_session": "_handle_switch_session",
     "new_session": "_handle_new_session",

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -661,7 +661,7 @@ def test_setup_protocol_gate_has_no_release_specific_literal():
     assert not re.search(r'"protocol"[^\n]*[0-9]+', source)
 
 
-def test_release_docs_and_examples_describe_one_atomic_v33_layout():
+def test_release_docs_and_examples_describe_one_atomic_v34_layout():
     deploy_readme = (ROOT / "deploy" / "README.md").read_text()
     readme = (ROOT / "README.md").read_text()
     readme_en = (ROOT / "README_en.md").read_text()
@@ -674,10 +674,10 @@ def test_release_docs_and_examples_describe_one_atomic_v33_layout():
     relay_env = (ROOT / "deploy" / "env.relay.example").read_text()
     unit = (ROOT / "deploy" / "cc-remote-relay.service").read_text()
 
-    assert "Protocol v33" in deploy_readme
+    assert "Protocol v34" in deploy_readme
     assert "v14" not in deploy_readme
     for document in (deploy_readme, readme, readme_en):
-        assert "v33" in document
+        assert "v34" in document
         assert "v16" not in document
         assert "v18" not in document
         assert "sudo rsync -a --delete" not in document
@@ -714,7 +714,7 @@ def test_release_docs_and_examples_describe_one_atomic_v33_layout():
     assert "WorkingDirectory=/opt/cc-remote/current" in unit
     assert "ExecStart=/opt/cc-remote/current/.venv/bin/python" in unit
     assert "claude-agent-sdk==0.2.128" in claude
-    assert "protocol v33" in claude
+    assert "protocol v34" in claude
     assert "0.2.110" not in claude
     assert "protocol v10" not in claude
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -30,8 +30,9 @@ from cc_remote.protocol import (
     serialize, deserialize,
     GetHistory, GetHistoryImage, GetTurnDetail, History, HistoryImage,
     TurnDetail, HistoryInvalidated,
-    UserMsg, AssistantMsgStart, AssistantMsgEnd, Delta, ProcessEvent,
-    TurnBinding, TurnEnd, TurnResult, Error, is_downstream,
+    UserMsg, TurnSteered, AssistantMsgStart, AssistantMsgEnd, Delta,
+    ProcessEvent, TurnPlan, TurnBinding, TurnEnd, TurnResult, Error,
+    is_downstream,
 )
 from cc_remote.wrapper import machine as mm
 from cc_remote.wrapper import stream as stream_module
@@ -1219,6 +1220,188 @@ def test_requested_codex_summary_uses_official_turns_without_rollout_parse(
         assert history.has_more is True
         assert all(row["type"] in {"model", "effort"}
                    for row in history.events)
+
+    asyncio.run(run())
+
+
+def test_codex_plan_snapshot_survives_native_summary_omission():
+    """A fresh browser recovers a live plan absent from app-server history."""
+    events = (
+        UserMsg(
+            sid="plan-summary", msg_id="user-1", prompt="implement",
+        ).model_dump(mode="json"),
+        TurnEnd(
+            sid="plan-summary",
+            turn_id="native-1",
+            result=TurnResult(
+                subtype="success", duration_ms=1000, is_error=False),
+        ).model_dump(mode="json"),
+    )
+
+    class Official:
+        async def summary_page(self, _sid, **_kwargs):
+            return CodexHistoryPage(
+                events=events,
+                turns=materialize_history_turns(events),
+                has_more=False,
+                oldest_id="user-1",
+                newest_id="user-1",
+            )
+
+    async def run():
+        machine, transport = _mk_machine()
+        machine._codex_history = Official()
+        ctx = _mk_ctx("plan-summary", "plan-summary")
+        ctx.engine = "codex"
+        machine.sessions[ctx.key] = ctx
+
+        await machine._emit_locked(ctx, TurnPlan(
+            item_id="plan:native-1",
+            turn_id="native-1",
+            explanation="current phase",
+            plan=[
+                {"step": "inspect", "status": "completed"},
+                {"step": "implement", "status": "inProgress"},
+            ],
+        ))
+        # Re-open the on-disk store to prove this is not the live ring event.
+        machine._session_plans = type(machine._session_plans)(
+            machine.cfg.state_dir)
+
+        history = await machine._handle_get_history(SimpleNamespace(
+            session_id="plan-summary",
+            client_id="client-1",
+            before=None,
+            limit=4,
+            cwd=ctx.cwd,
+            detail="summary",
+        ))
+
+        plans = [
+            block
+            for turn in history.turns
+            for block in turn.blocks
+            if block.get("kind") == "process"
+            and block.get("processKind") == "plan"
+        ]
+        assert len(plans) == 1
+        assert plans[0]["item_id"] == "plan:native-1"
+        assert plans[0]["plan"][1] == {
+            "step": "implement", "status": "inProgress"}
+        assert history.to == "client-1"
+        assert transport.sent[-1] is history
+
+    asyncio.run(run())
+
+
+def test_codex_next_user_boundary_retires_only_completed_plan_snapshot():
+    async def run():
+        machine, _transport = _mk_machine()
+        ctx = _mk_ctx("plan-lifecycle", "plan-lifecycle")
+        ctx.engine = "codex"
+        machine.sessions[ctx.key] = ctx
+
+        await machine._emit_locked(ctx, TurnPlan(
+            item_id="plan:turn-1",
+            turn_id="turn-1",
+            explanation="done",
+            plan=[{"step": "ship", "status": "completed"}],
+        ))
+        assert machine._session_plans.get("plan-lifecycle") is not None
+
+        # Replaying the owning user boundary is not a later message. Codex
+        # carries its native owner separately from the browser/history ids.
+        await machine._emit_locked(ctx, TurnBinding(
+            msg_id="browser-turn-1", turn_id="turn-1"))
+        await machine._emit_locked(ctx, UserMsg(
+            msg_id="history-user-1",
+            client_msg_id="browser-turn-1",
+            prompt="original task",
+        ))
+        assert machine._session_plans.get("plan-lifecycle") is not None
+
+        await machine._emit_locked(ctx, UserMsg(
+            msg_id="turn-2", prompt="next task"))
+        assert machine._session_plans.get("plan-lifecycle") is None
+
+        await machine._emit_locked(ctx, TurnPlan(
+            item_id="plan:turn-3",
+            turn_id="turn-3",
+            explanation="still running",
+            plan=[
+                {"step": "inspect", "status": "completed"},
+                {"step": "fix", "status": "inProgress"},
+            ],
+        ))
+        await machine._emit_locked(ctx, UserMsg(
+            msg_id="turn-4", prompt="clarification"))
+        assert machine._session_plans.get("plan-lifecycle") is not None
+
+        await machine._emit_locked(ctx, TurnPlan(
+            item_id="plan:turn-5",
+            turn_id="turn-5",
+            explanation="done again",
+            plan=[{"step": "verify", "status": "completed"}],
+        ))
+        await machine._emit_locked(ctx, TurnSteered(
+            msg_id="steer-1", turn_id="turn-5", prompt="next request"))
+        assert machine._session_plans.get("plan-lifecycle") is None
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("plan_turn_id", ["native-1", None])
+def test_completed_codex_plan_is_not_rebound_without_matching_owner(
+    plan_turn_id,
+):
+    events = (
+        UserMsg(
+            sid="stale-plan-summary", msg_id="user-2", prompt="next task",
+        ).model_dump(mode="json"),
+        TurnEnd(
+            sid="stale-plan-summary",
+            turn_id="native-2",
+            result=TurnResult(
+                subtype="success", duration_ms=1000, is_error=False),
+        ).model_dump(mode="json"),
+    )
+
+    class Official:
+        async def summary_page(self, _sid, **_kwargs):
+            return CodexHistoryPage(
+                events=events,
+                turns=materialize_history_turns(events),
+                has_more=True,
+                oldest_id="user-2",
+                newest_id="user-2",
+            )
+
+    async def run():
+        machine, _transport = _mk_machine()
+        machine._codex_history = Official()
+        ctx = _mk_ctx("stale-plan-summary", "stale-plan-summary")
+        ctx.engine = "codex"
+        machine.sessions[ctx.key] = ctx
+        machine._session_plans.put("stale-plan-summary", TurnPlan(
+            item_id="plan:native-1",
+            turn_id=plan_turn_id,
+            explanation="old completed task",
+            plan=[{"step": "old", "status": "completed"}],
+        ))
+
+        history = await machine._handle_get_history(SimpleNamespace(
+            session_id="stale-plan-summary",
+            client_id="client-1",
+            before=None,
+            limit=4,
+            cwd=ctx.cwd,
+            detail="summary",
+        ))
+        assert all(
+            block.get("processKind") != "plan"
+            for turn in history.turns
+            for block in turn.blocks
+        )
 
     asyncio.run(run())
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -4786,8 +4786,8 @@ def test_hello_sends_snapshots_and_control_state_without_replay_flood():
         await m._handle_client_hello(SimpleNamespace(client_id="c1"))
         types = [msg.type for msg in tr.sent]
         assert types == [
-            "snapshot", "query_queue", "perm",
-            "snapshot", "query_queue", "perm",
+            "snapshot", "query_queue", "completion_state", "perm",
+            "snapshot", "query_queue", "completion_state", "perm",
         ]
         assert "replay_start" not in types and "user_msg" not in types
         assert all(msg.to == "c1" for msg in tr.sent)     # routed to the requesting client
@@ -4812,7 +4812,7 @@ def test_hello_with_cursor_replays_only_missing_tail():
 
         assert [msg.type for msg in tr.sent] == [
             "replay_start", "user_msg", "replay_end", "session_control",
-            "query_queue", "perm"]
+            "query_queue", "completion_state", "perm"]
         assert tr.sent[1].msg_id == "m3"
         assert all(msg.to == "c1" for msg in tr.sent)
 
@@ -4838,7 +4838,7 @@ def test_fresh_hello_replays_only_current_inflight_turn_after_snapshot():
 
         assert [msg.type for msg in tr.sent] == [
             "snapshot", "replay_start", "user_msg", "delta", "replay_end",
-            "query_queue", "perm"]
+            "query_queue", "completion_state", "perm"]
         assert tr.sent[2].prompt == "current"
         assert all(msg.to == "c1" for msg in tr.sent)
 

--- a/tests/test_multisession.py
+++ b/tests/test_multisession.py
@@ -322,7 +322,7 @@ def test_lost_rekey_is_replayed_before_cursor_catchup():
 
         assert [message.type for message in transport.sent] == [
             "session_rekey", "replay_start", "state", "replay_end",
-            "session_control", "query_queue", "perm"]
+            "session_control", "query_queue", "completion_state", "perm"]
         assert transport.sent[0].old_key == "tmp-lost"
         assert transport.sent[0].session_id == "real-1"
         assert all(message.to == "client-1" for message in transport.sent)

--- a/tests/test_presentation_sync.py
+++ b/tests/test_presentation_sync.py
@@ -1,0 +1,463 @@
+"""Cross-client completion and Goal presentation regressions."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from cc_remote.protocol import (
+    AcknowledgeCompletion,
+    CommandAck,
+    CompletionState,
+    DismissGoal,
+    GetGoal,
+    GoalState,
+    Hello,
+    TurnEnd,
+    TurnResult,
+    deserialize,
+    serialize,
+)
+from tests.test_multisession import _mk_ctx, _mk_machine
+
+
+def _success(turn_id: str) -> TurnEnd:
+    return TurnEnd(
+        turn_id=turn_id,
+        result=TurnResult(
+            subtype="success", duration_ms=10, is_error=False
+        ),
+    )
+
+
+def test_presentation_protocol_round_trips_exact_receipt_ids():
+    dismiss = deserialize(serialize(DismissGoal(
+        sid="session-1",
+        goal_id="goal-1",
+        client_id="desktop",
+        cmd_id="dismiss-1",
+    )))
+    assert dismiss.type == "dismiss_goal"
+    assert dismiss.goal_id == "goal-1"
+
+    acknowledge = deserialize(serialize(AcknowledgeCompletion(
+        sid="session-1",
+        completion_id="turn-1",
+        client_id="desktop",
+        cmd_id="ack-1",
+    )))
+    assert acknowledge.type == "acknowledge_completion"
+    assert acknowledge.completion_id == "turn-1"
+
+    state = deserialize(serialize(CompletionState(
+        sid="session-1",
+        completion_id="turn-1",
+        unread=False,
+        revision=2,
+    )))
+    assert state.type == "completion_state"
+    assert state.revision == 2
+
+
+def test_main_completion_acknowledgement_broadcasts_and_seeds_reconnect():
+    async def run():
+        machine, transport = _mk_machine()
+        ctx = _mk_ctx("session-1", "session-1")
+        machine.sessions[ctx.key] = ctx
+
+        await machine._emit(ctx, _success("turn-1"))
+        assert [message.type for message in transport.sent[-2:]] == [
+            "turn_end", "completion_state",
+        ]
+        unread = transport.sent[-1]
+        assert isinstance(unread, CompletionState)
+        assert unread.completion_id == "turn-1"
+        assert unread.unread is True
+        assert unread.to is None
+
+        await machine._handle_acknowledge_completion(
+            AcknowledgeCompletion(
+                sid="session-1",
+                completion_id="turn-1",
+                client_id="desktop",
+                cmd_id="ack-1",
+            )
+        )
+        acknowledged = transport.sent[-1]
+        assert isinstance(acknowledged, CompletionState)
+        assert acknowledged.unread is False
+        assert acknowledged.revision > unread.revision
+        assert acknowledged.to is None
+
+        transport.sent.clear()
+        await machine._handle_client_hello(Hello(
+            role="client",
+            client_id="phone",
+            route_id="phone-route",
+            cursors={"session-1": ctx.seq},
+            generations={"session-1": machine.instance_id},
+        ))
+        seeded = next(
+            message for message in transport.sent
+            if isinstance(message, CompletionState)
+        )
+        assert seeded.completion_id == "turn-1"
+        assert seeded.unread is False
+        assert seeded.to == "phone"
+        assert seeded.route_id == "phone-route"
+
+    asyncio.run(run())
+
+
+def test_stale_completion_ack_never_clears_a_newer_turn():
+    async def run():
+        machine, transport = _mk_machine()
+        ctx = _mk_ctx("session-1", "session-1")
+        machine.sessions[ctx.key] = ctx
+        await machine._emit(ctx, _success("turn-1"))
+        await machine._emit(ctx, _success("turn-2"))
+
+        await machine._handle_acknowledge_completion(
+            AcknowledgeCompletion(
+                sid="session-1",
+                completion_id="turn-1",
+                client_id="slow-browser",
+                cmd_id="stale-ack",
+            )
+        )
+        current = transport.sent[-1]
+        assert isinstance(current, CompletionState)
+        assert current.completion_id == "turn-2"
+        assert current.unread is True
+
+    asyncio.run(run())
+
+
+def test_completion_ack_retry_recomputes_newer_unread_after_lost_ack():
+    async def run():
+        machine, transport = _mk_machine()
+        ctx = _mk_ctx("session-1", "session-1")
+        machine.sessions[ctx.key] = ctx
+        await machine._emit(ctx, _success("turn-1"))
+        transport.sent.clear()
+
+        acknowledge = AcknowledgeCompletion(
+            sid="session-1",
+            completion_id="turn-1",
+            client_id="desktop",
+            cmd_id="ack-turn-1",
+        )
+        await machine._process_command(acknowledge)
+        first = next(
+            event for event in transport.sent
+            if isinstance(event, CompletionState)
+        )
+        assert first.completion_id == "turn-1"
+        assert first.unread is False
+        assert isinstance(transport.sent[-1], CommandAck)
+
+        # Simulate the acknowledgement response being lost, followed by a
+        # newer completion whose broadcast is also missed by this browser.
+        transport.sent.clear()
+        await machine._emit(ctx, _success("turn-2"))
+        transport.sent.clear()
+        await machine._process_command(acknowledge)
+
+        current = next(
+            event for event in transport.sent
+            if isinstance(event, CompletionState)
+        )
+        assert current.completion_id == "turn-2"
+        assert current.unread is True
+        assert isinstance(transport.sent[-1], CommandAck)
+        seen, cached = machine._command_seen("desktop", "ack-turn-1")
+        assert seen is True
+        assert cached == ()
+
+    asyncio.run(run())
+
+
+def test_cold_session_completion_can_be_acknowledged_without_resume():
+    async def run():
+        machine, transport = _mk_machine()
+        machine._session_presentation.mark_completion(
+            "cold-session", "turn-1"
+        )
+
+        await machine._process_command(AcknowledgeCompletion(
+            sid="cold-session",
+            completion_id="turn-1",
+            client_id="desktop",
+            cmd_id="ack-cold-turn-1",
+        ))
+
+        acknowledged = next(
+            event for event in transport.sent
+            if isinstance(event, CompletionState)
+        )
+        assert acknowledged.sid == "cold-session"
+        assert acknowledged.completion_id == "turn-1"
+        assert acknowledged.unread is False
+        assert isinstance(transport.sent[-1], CommandAck)
+        assert machine.sessions == {}
+
+    asyncio.run(run())
+
+
+def test_cold_session_catalog_carries_durable_completion_receipts(monkeypatch):
+    async def run():
+        machine, _ = _mk_machine()
+        machine._session_presentation.mark_completion("cold-seen", "turn-1")
+        machine._session_presentation.acknowledge_completion(
+            "cold-seen", "turn-1"
+        )
+        machine._session_presentation.mark_completion("cold-unread", "turn-2")
+        monkeypatch.setattr(
+            machine, "_prime_codex_sidebar_watches", lambda _raw: None
+        )
+
+        event = await machine._send_codex_session_list(
+            SimpleNamespace(
+                space="code", client_id="phone", cmd_id="list-cold"
+            ),
+            [
+                {
+                    "session_id": session_id,
+                    "summary": session_id,
+                    "first_prompt": None,
+                    "cwd": "/repo",
+                    "last_modified": "1",
+                    "git_branch": None,
+                    "tag": None,
+                    "status": "idle",
+                    "forked_from_id": None,
+                }
+                for session_id in ("cold-seen", "cold-unread")
+            ],
+        )
+
+        seen, unread = event.sessions
+        assert seen.completion_id == "turn-1"
+        assert seen.completion_unread is False
+        assert seen.completion_revision == 2
+        assert unread.completion_id == "turn-2"
+        assert unread.completion_unread is True
+        assert unread.completion_revision == 1
+
+    asyncio.run(run())
+
+
+def test_failed_and_private_btw_turns_do_not_create_shared_receipts():
+    async def run():
+        machine, transport = _mk_machine()
+        main = _mk_ctx("main", "main")
+        await machine._emit(main, TurnEnd(
+            turn_id="failed-turn",
+            result=TurnResult(
+                subtype="error_during_execution",
+                duration_ms=10,
+                is_error=True,
+            ),
+        ))
+        assert not any(
+            isinstance(message, CompletionState) for message in transport.sent
+        )
+
+        transport.sent.clear()
+        btw = _mk_ctx("btw-private", None)
+        btw.btw = True
+        btw.parent_sid = "main"
+        btw.owner_client_id = "owner"
+        await machine._emit(btw, _success("btw-turn"))
+        assert [message.type for message in transport.sent] == ["turn_end"]
+        assert transport.sent[0].to == "owner"
+
+    asyncio.run(run())
+
+
+class _GoalSdk:
+    def __init__(self):
+        self.goal = {
+            "threadId": "goal-session",
+            "objective": "finish the first task",
+            "status": "complete",
+            "engine": "codex",
+            "tokensUsed": 10,
+            "timeUsedSeconds": 20,
+            "createdAt": 100,
+        }
+
+    async def get_goal(self):
+        return dict(self.goal)
+
+
+def test_goal_dismissal_broadcasts_and_cannot_hide_a_replacement():
+    async def run():
+        machine, transport = _mk_machine()
+        ctx = _mk_ctx("goal-session", "goal-session")
+        ctx.engine = "codex"
+        ctx.sdk = _GoalSdk()
+        machine.sessions[ctx.key] = ctx
+
+        initial = await machine._handle_get_goal(GetGoal(
+            sid="goal-session", client_id="desktop", cmd_id="goal-read"
+        ))
+        assert isinstance(initial, GoalState)
+        assert initial.goal_id
+        assert initial.dismissed is False
+
+        dismissed = await machine._handle_dismiss_goal(DismissGoal(
+            sid="goal-session",
+            goal_id=initial.goal_id,
+            client_id="desktop",
+            cmd_id="goal-dismiss",
+        ))
+        assert isinstance(dismissed, GoalState)
+        assert dismissed.dismissed is True
+        assert dismissed.to is None
+
+        phone = await machine._handle_get_goal(GetGoal(
+            sid="goal-session", client_id="phone", cmd_id="phone-read"
+        ))
+        assert phone.dismissed is True
+        assert phone.goal_id == initial.goal_id
+
+        ctx.sdk.goal = {
+            **ctx.sdk.goal,
+            "objective": "finish the replacement task",
+            "createdAt": 101,
+        }
+        replacement = await machine._handle_dismiss_goal(DismissGoal(
+            sid="goal-session",
+            goal_id=initial.goal_id,
+            client_id="desktop",
+            cmd_id="late-dismiss",
+        ))
+        assert replacement.goal_id != initial.goal_id
+        assert replacement.dismissed is False
+
+    asyncio.run(run())
+
+
+def test_profiled_codex_receipts_use_the_routed_session_id():
+    async def run():
+        machine, transport = _mk_machine()
+        wire_sid = "secondary@native-session"
+        ctx = _mk_ctx(wire_sid, "native-session")
+        ctx.engine = "codex"
+        ctx.codex_profile_id = "secondary"
+        ctx.sdk = _GoalSdk()
+        ctx.sdk.goal["threadId"] = "native-session"
+        machine.sessions[ctx.key] = ctx
+
+        await machine._emit(ctx, _success("turn-profiled"))
+        assert machine._session_presentation_fields(wire_sid) == {
+            "completion_id": "turn-profiled",
+            "completion_unread": True,
+            "completion_revision": 1,
+        }
+        assert machine._session_presentation.get(
+            "native-session"
+        ).completion_revision == 0
+
+        await machine._handle_acknowledge_completion(
+            AcknowledgeCompletion(
+                sid=wire_sid,
+                completion_id="turn-profiled",
+                client_id="desktop",
+                cmd_id="ack-profiled",
+            )
+        )
+        assert machine._session_presentation.get(
+            wire_sid
+        ).completion_unread is False
+
+        initial = await machine._handle_get_goal(GetGoal(
+            sid=wire_sid, client_id="desktop", cmd_id="goal-profiled",
+        ))
+        assert isinstance(initial, GoalState)
+        assert initial.goal_id
+        dismissed = await machine._handle_dismiss_goal(DismissGoal(
+            sid=wire_sid,
+            goal_id=initial.goal_id,
+            client_id="desktop",
+            cmd_id="dismiss-profiled",
+        ))
+        assert dismissed.dismissed is True
+        assert machine._session_presentation.get(
+            wire_sid
+        ).dismissed_goal_id == initial.goal_id
+        assert machine._session_presentation.get(
+            "native-session"
+        ).dismissed_goal_id is None
+        assert all(
+            message.sid == wire_sid
+            for message in transport.sent
+            if isinstance(message, (CompletionState, GoalState))
+        )
+
+    asyncio.run(run())
+
+
+def test_goal_dismissal_retry_recomputes_replacement_after_lost_ack():
+    async def run():
+        machine, transport = _mk_machine()
+        ctx = _mk_ctx("goal-session", "goal-session")
+        ctx.engine = "codex"
+        ctx.sdk = _GoalSdk()
+        machine.sessions[ctx.key] = ctx
+
+        initial = await machine._handle_get_goal(GetGoal(
+            sid="goal-session", client_id="desktop", cmd_id="goal-read"
+        ))
+        assert isinstance(initial, GoalState)
+        assert initial.goal_id
+        transport.sent.clear()
+
+        dismiss = DismissGoal(
+            sid="goal-session",
+            goal_id=initial.goal_id,
+            client_id="desktop",
+            cmd_id="goal-dismiss",
+        )
+        await machine._process_command(dismiss)
+        first = next(
+            event for event in transport.sent if isinstance(event, GoalState)
+        )
+        assert first.goal_id == initial.goal_id
+        assert first.dismissed is True
+        assert isinstance(transport.sent[-1], CommandAck)
+
+        # Simulate the GoalState and ACK being lost while another browser
+        # creates or reveals a replacement Goal before this command retries.
+        transport.sent.clear()
+        ctx.sdk.goal = {
+            **ctx.sdk.goal,
+            "objective": "finish the replacement task",
+            "createdAt": 101,
+        }
+        await machine._process_command(dismiss)
+
+        replacement = next(
+            event for event in transport.sent if isinstance(event, GoalState)
+        )
+        assert replacement.goal_id != initial.goal_id
+        assert replacement.dismissed is False
+        assert isinstance(transport.sent[-1], CommandAck)
+        seen, cached = machine._command_seen("desktop", "goal-dismiss")
+        assert seen is True
+        assert cached == ()
+
+    asyncio.run(run())
+
+
+def test_goal_without_generation_marker_is_not_globally_dismissible():
+    goal = {
+        "threadId": "legacy-goal",
+        "objective": "repeatable objective",
+        "status": "complete",
+        "engine": "codex",
+        "tokensUsed": 1,
+        "timeUsedSeconds": 2,
+    }
+    machine, _ = _mk_machine()
+    assert machine._goal_identity(goal) is None

--- a/tests/test_product_version.py
+++ b/tests/test_product_version.py
@@ -45,7 +45,7 @@ def test_release_docs_distinguish_product_and_wire_protocol_versions():
     assert "## What changed in v3" in readme_en
     for document in (readme, readme_en, changelog):
         assert "v3.0.0" in document
-        assert "protocol v33" in document.lower()
+        assert "protocol v34" in document.lower()
 
 
 def test_readmes_use_safe_markdown_for_navigation_and_images():

--- a/tests/test_reliability_edges.py
+++ b/tests/test_reliability_edges.py
@@ -66,7 +66,7 @@ def test_client_hello_replays_only_cursor_sessions_and_routes_every_frame():
         replay_frames = [msg for msg in transport.sent if msg.sid == "s-replay"]
         assert [msg.type for msg in replay_frames] == [
             "replay_start", "delta", "turn_end", "replay_end",
-            "session_control", "query_queue", "perm",
+            "session_control", "query_queue", "completion_state", "perm",
         ]
         assert all(msg.to == "client-1" for msg in replay_frames)
         assert all(msg.sid == "s-replay" for msg in replay_frames)

--- a/tests/test_session_plans.py
+++ b/tests/test_session_plans.py
@@ -1,0 +1,90 @@
+"""Zero-token tests for durable Codex plan snapshots."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cc_remote.protocol import TurnPlan
+from cc_remote.wrapper.session_plans import (
+    SessionPlanStore,
+    SessionPlanStoreError,
+)
+
+
+def _plan() -> TurnPlan:
+    return TurnPlan(
+        item_id="plan:turn-1",
+        turn_id="turn-1",
+        explanation="ship it",
+        plan=[
+            {"step": "inspect", "status": "completed"},
+            {"step": "fix", "status": "inProgress"},
+        ],
+    )
+
+
+def test_session_plan_store_round_trips_rekeys_and_deletes(tmp_path):
+    store = SessionPlanStore(tmp_path)
+    stored = store.put("tmp-0123456789abcdef", _plan())
+    assert stored.as_event().plan[1]["status"] == "inProgress"
+
+    restored = SessionPlanStore(tmp_path)
+    assert restored.get("tmp-0123456789abcdef") == stored
+    restored.move("tmp-0123456789abcdef", "session-1")
+    assert restored.get("tmp-0123456789abcdef") is None
+    assert restored.get("session-1") == stored
+
+    restored.delete("session-1")
+    assert SessionPlanStore(tmp_path).get("session-1") is None
+
+
+def test_session_plan_store_retires_only_completed_previous_turns(tmp_path):
+    store = SessionPlanStore(tmp_path)
+    store.put("session-1", _plan())
+    assert store.retire_completed("session-1") is False
+    assert store.get("session-1") is not None
+
+    completed = TurnPlan(
+        item_id="plan:turn-1",
+        turn_id="turn-1",
+        explanation="done",
+        plan=[{"step": "ship", "status": "completed"}],
+    )
+    store.put("session-1", completed)
+    assert store.retire_completed(
+        "session-1", current_turn_ids=frozenset({"turn-1"})) is False
+    assert store.get("session-1") is not None
+
+    assert store.retire_completed(
+        "session-1", current_turn_ids=frozenset({"turn-2"})) is True
+    assert SessionPlanStore(tmp_path).get("session-1") is None
+
+
+def test_session_plan_store_rejects_unbounded_or_unknown_payloads(tmp_path):
+    path = tmp_path / "session-plans.json"
+    path.write_text(json.dumps({
+        "version": 1,
+        "plans": {
+            "session-1": {
+                "item_id": "plan-1",
+                "turn_id": "turn-1",
+                "explanation": None,
+                "plan": [{"step": "x", "status": "future"}],
+                "updated_at": 1,
+                "future_secret": "must-not-pass",
+            },
+        },
+    }), encoding="utf-8")
+
+    with pytest.raises(SessionPlanStoreError):
+        SessionPlanStore(tmp_path)
+
+
+def test_session_plan_store_rejects_symlinks(tmp_path):
+    target = tmp_path / "target.json"
+    target.write_text('{"version":1,"plans":{}}', encoding="utf-8")
+    (tmp_path / "session-plans.json").symlink_to(target)
+
+    with pytest.raises(SessionPlanStoreError):
+        SessionPlanStore(tmp_path)

--- a/tests/test_session_presentation.py
+++ b/tests/test_session_presentation.py
@@ -1,0 +1,93 @@
+"""Zero-token tests for durable cross-client presentation receipts."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cc_remote.wrapper.session_presentation import (
+    SessionPresentationStore,
+    SessionPresentationStoreError,
+)
+
+
+def test_completion_receipts_round_trip_and_reject_stale_acknowledgements(
+    tmp_path,
+):
+    store = SessionPresentationStore(tmp_path)
+    first = store.mark_completion("session-1", "turn-1")
+    assert first.completion_unread is True
+    assert first.completion_revision == 1
+
+    # Re-emitting the same native terminal boundary is idempotent.
+    assert store.mark_completion("session-1", "turn-1") == first
+    second = store.mark_completion("session-1", "turn-2")
+    assert second.completion_revision == 2
+    assert second.completion_id == "turn-2"
+
+    stale = store.acknowledge_completion("session-1", "turn-1")
+    assert stale == second
+    acknowledged = store.acknowledge_completion("session-1", "turn-2")
+    assert acknowledged.completion_unread is False
+    assert acknowledged.completion_revision == 3
+    assert SessionPresentationStore(tmp_path).get("session-1") == acknowledged
+
+
+def test_goal_dismissal_is_scoped_to_one_exact_generation(tmp_path):
+    store = SessionPresentationStore(tmp_path)
+    store.dismiss_goal("session-1", "goal-first")
+    assert store.reconcile_goal("session-1", "goal-first") is True
+
+    assert store.reconcile_goal("session-1", "goal-replacement") is False
+    assert store.get("session-1").dismissed_goal_id is None
+    store.dismiss_goal("session-1", "goal-replacement")
+    assert store.reconcile_goal("session-1", None) is False
+    assert store.get("session-1").dismissed_goal_id is None
+
+
+def test_session_presentation_rekeys_clears_and_deletes(tmp_path):
+    store = SessionPresentationStore(tmp_path)
+    store.mark_completion("tmp-session", "turn-1")
+    store.dismiss_goal("tmp-session", "goal-1")
+    store.move("tmp-session", "real-session")
+    assert store.get("tmp-session").completion_id is None
+    assert store.get("real-session").completion_id == "turn-1"
+    assert store.get("real-session").dismissed_goal_id == "goal-1"
+
+    cleared = store.clear_completion("real-session")
+    assert cleared.completion_id is None
+    assert cleared.completion_unread is False
+    assert cleared.completion_revision == 2
+    store.delete("real-session")
+    assert SessionPresentationStore(tmp_path).get(
+        "real-session"
+    ).completion_revision == 0
+
+
+def test_session_presentation_rejects_unknown_payload_fields(tmp_path):
+    (tmp_path / "session-presentation.json").write_text(
+        json.dumps({
+            "version": 1,
+            "sessions": {
+                "session-1": {
+                    "completion_id": "turn-1",
+                    "completion_unread": True,
+                    "completion_revision": 1,
+                    "dismissed_goal_id": None,
+                    "updated_at": 1,
+                    "future_secret": "must-not-pass",
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+    with pytest.raises(SessionPresentationStoreError):
+        SessionPresentationStore(tmp_path)
+
+
+def test_session_presentation_rejects_symlinks(tmp_path):
+    target = tmp_path / "target.json"
+    target.write_text('{"version":1,"sessions":{}}', encoding="utf-8")
+    (tmp_path / "session-presentation.json").symlink_to(target)
+    with pytest.raises(SessionPresentationStoreError):
+        SessionPresentationStore(tmp_path)

--- a/web/public/cc-remote-build.json
+++ b/web/public/cc-remote-build.json
@@ -1,1 +1,1 @@
-{"version":"3.0.0","protocol":33}
+{"version":"3.0.0","protocol":34}

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -216,6 +216,9 @@
 .goal-chip-dismiss { width:30px; display:grid; place-items:center; flex:none; color:var(--faint);
   border-left:1px solid var(--divider); }
 .goal-chip-dismiss:hover { color:var(--text); background:var(--raised); }
+.plan-chip { max-width:100%; }
+.plan-chip-ring.complete { color:var(--ok); }
+.plan-chip-ring.failed { color:var(--danger); }
 .goal-status { display:inline-flex; align-items:center; width:max-content; border-radius:999px; padding:2px 7px; font-size:10px; line-height:1.4; font-weight:700; color:var(--accent-ink); background:var(--accent-weak); }
 .goal-status-paused,.goal-status-blocked { color:var(--warn); background:var(--warn-weak); }
 .goal-status-complete { color:var(--ok); background:var(--ok-weak); }
@@ -277,6 +280,23 @@
 .goal-last-check { margin-top:12px; padding:10px 12px; border:0; border-left:3px solid var(--accent-line);
   border-radius:0 10px 10px 0; background:var(--raised); }
 .goal-last-check p { margin:3px 0 0; color:var(--dim); font-size:12px; line-height:1.5; white-space:pre-wrap; }
+.goal-plan-section { padding:0 0 17px; border-bottom:1px solid var(--divider); }
+.goal-plan-entry { width:100%; min-width:0; display:grid;
+  grid-template-columns:21px minmax(0,1fr) auto 18px; align-items:center; gap:10px;
+  padding:10px 11px; color:var(--text); text-align:left; border:1px solid var(--border-strong);
+  border-radius:12px; background:var(--raised); }
+.goal-plan-entry:hover,.goal-plan-entry[aria-expanded="true"] {
+  border-color:var(--accent-line); background:var(--accent-weak); }
+.goal-plan-entry-copy { min-width:0; display:flex; flex-direction:column; gap:2px; }
+.goal-plan-entry-copy b { color:var(--accent-ink); font-size:12.5px; }
+.goal-plan-entry-copy small { overflow:hidden; color:var(--dim); font-size:11.5px;
+  line-height:1.35; text-overflow:ellipsis; white-space:nowrap; }
+.goal-plan-entry > strong { color:var(--dim); font-family:var(--mono); font-size:10.5px; }
+.goal-plan-entry-chev { display:grid; place-items:center; color:var(--faint); transition:transform .16s var(--ease); }
+.goal-plan-entry-chev.open { transform:rotate(180deg); }
+.goal-plan-expanded { margin-top:12px; padding:2px 1px 0; }
+.goal-plan-expanded .plan-progress-content > header b { font-size:13.5px; }
+.goal-plan-expanded .plan-progress-content > p { margin-top:11px; }
 .goal-editor { display:flex; flex-direction:column; gap:11px; }
 .goal-editor label { display:flex; flex-direction:column; gap:5px; color:var(--dim); font-size:11px; font-weight:650; }
 .goal-editor textarea,.goal-editor input,.goal-editor select { width:100%; box-sizing:border-box; border:1px solid var(--border-strong); border-radius:11px; padding:10px 11px; background:var(--raised); color:var(--text); outline:none; font:inherit; font-size:16px; }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,7 +41,6 @@ import {
   reconcileNewChatSelection,
   resolveNewChatLocalDefaults,
 } from "./components/NewChatView";
-import { BtwPanel } from "./components/BtwPanel";
 import { QuestionSheet } from "./components/QuestionSheet";
 import { StatusSheet } from "./components/StatusSheet";
 import { UsageActivitySheet } from "./components/UsageActivitySheet";
@@ -217,6 +216,9 @@ const SPACE_KEY = "cc_remote_space";
 const MACHINE_KEY = "cc_remote_machine";
 const GoalPanel = lazy(() => import("./components/GoalPanel").then(
   ({ GoalPanel: Panel }) => ({ default: Panel }),
+));
+const BtwPanel = lazy(() => import("./components/BtwPanel").then(
+  ({ BtwPanel: Panel }) => ({ default: Panel }),
 ));
 const ArtifactPanel = lazy(() => import("./components/ArtifactPanel").then(
   ({ ArtifactPanel: Panel }) => ({ default: Panel }),
@@ -4647,7 +4649,8 @@ export default function App() {
         const view = rightView === "btw" && btwShowing ? "btw"
           : state.artifact ? "diff" : btwShowing ? "btw" : null;
         if (view === "btw")
-          return <BtwPanel sid={activeBtwSid ?? undefined} rt={activeBtwSid ? state.runtimes[activeBtwSid] : undefined}
+          return <Suspense fallback={null}>
+            <BtwPanel sid={activeBtwSid ?? undefined} rt={activeBtwSid ? state.runtimes[activeBtwSid] : undefined}
             engine={activeBtw?.engine} opening={btwOpening && !activeBtw}
             active="btw" hasArtifact={!!state.artifact} artifactKind={state.artifact?.kind} onTab={switchRight}
             catalog={focusedCatalog}
@@ -4691,7 +4694,8 @@ export default function App() {
             onAuthorizeImage={authorizeMessageImage}
             onDismissNotice={(noticeId) => {
               if (activeBtwSid) dispatch({ type: "dismiss_notice", sid: activeBtwSid, noticeId });
-            }} />;
+            }} />
+          </Suspense>;
         if (view === "diff" && state.artifact)
           return <Suspense fallback={
             <div className="artifact-panel empty" role="status">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -200,6 +200,12 @@ import {
   type SkillCatalogCacheEntry,
   type SkillCatalogRequest,
 } from "./skill-catalog-cache";
+import {
+  completedGoalHasNewerUserTurn,
+  latestPlanProgress,
+  planFollowsCompletedGoal,
+  SessionPlanProgressCache,
+} from "./plan-progress";
 
 const THEME_KEY = "cc_remote_theme";
 const ENGINE_KEY = "cc_remote_engine";  // which backend the NEXT new session uses
@@ -360,6 +366,7 @@ export default function App() {
   const goalUiPreferencesRef = useRef<GoalUiPreferences>(
     readGoalUiPreferences(localStorage));
   const goalRecoveryRequestsRef = useRef<Set<string>>(new Set());
+  const planProgressCacheRef = useRef(new SessionPlanProgressCache());
   const goalRequestScopeByIdRef = useRef<Map<
     string, { scopeKey: string; sid: string }
   >>(new Map());
@@ -678,6 +685,35 @@ export default function App() {
       : rt.ccSessionId);
   const focusedCatalog = catalogForEngineProfile(
     state.catalog, focusedEngine, focusedCodexProfileId);
+  const completedGoalRetired = completedGoalHasNewerUserTurn(
+    rt.goal, rt.turns,
+  ) || completedGoalHasNewerUserTurn(rt.goal, historyView.turns);
+  // A live plan always wins over plans found while browsing older history.
+  // When the runtime's small newest-turn window has no plan, the displayed
+  // history may still reveal the plan which owns this session's long task.
+  const runtimePlanProgress = latestPlanProgress(rt.turns);
+  const historyPlanProgress = historyView.browsing || historyView.recovering
+    ? latestPlanProgress(historyView.turns) : null;
+  let planProgress = focusedSid
+    ? planProgressCacheRef.current.resolve({
+        sid: focusedSid,
+        runtime: runtimePlanProgress,
+        history: historyPlanProgress,
+        runtimeTurns: rt.turns,
+        historyTurns: historyView.turns,
+        recovering: historyView.recovering,
+        runtimeLoading: rt.loading === true,
+      })
+    : null;
+  // An unfinished snapshot from the completed Goal must not briefly become the
+  // standalone monitor for the next task. Keep only a Plan whose owning user
+  // turn starts after the authoritative Goal completion boundary.
+  if (completedGoalRetired && planProgress
+      && !planFollowsCompletedGoal(rt.goal, planProgress)) {
+    planProgressCacheRef.current.clear(focusedSid!);
+    planProgress = null;
+  }
+  const planProgressSource = planProgress?.source ?? null;
   const capabilityCwd = focusedSession?.cwd || currentCwd;
   const focusedComposerDraftKey = composerDraftKey(
     machineId, space, focusedEngine, focusedSid ?? "",
@@ -1524,13 +1560,25 @@ export default function App() {
       const ws = new RelayWs({
         onEvent: (msg, ownership) => {
           if (!acceptsLifecycle()) return;
+          if (msg.type === "history_invalidated") {
+            planProgressCacheRef.current.clear(msg.session_id);
+          } else if (msg.type === "session_rekey") {
+            planProgressCacheRef.current.rekey(msg.old_key, msg.session_id);
+          }
           // SessionList is a scoped response, not a broadcast catalog. Without
           // the exact request ownership it may belong to an older surface or
           // WebSocket generation and must not mutate any sidebar/focus cache.
           if (msg.type === "session_list" && !ownership) return;
           if (msg.type === "goal_state" && msg.sid) {
+            const completedGoalRequest = msg.request_id
+              ? goalRequestScopeByIdRef.current.get(msg.request_id)
+              : undefined;
             if (msg.request_id) {
               goalRequestScopeByIdRef.current.delete(msg.request_id);
+            }
+            if (completedGoalRequest) {
+              goalRecoveryRequestsRef.current.delete(
+                `${lifecycleEpoch}\0${completedGoalRequest.scopeKey}`);
             }
             const key = goalUiScopeForEvent(msg.sid, ownership);
             if (key) {
@@ -2921,15 +2969,16 @@ export default function App() {
   }, [authed, focusedSid, rt.perm, rt.collaborationMode, rt.control,
     rt.external, focusedEngine]);
 
-  const loadHistoryTurnDetail = useCallback((
+  const requestHistoryTurnDetail = useCallback((
     displayTurnId: string, before?: string | null,
     autoLoad = true,
+    includeBrowseProjection = true,
   ): boolean => {
     const current = stateRef.current;
     const sid = current.focusedSid;
     const runtime = sid ? current.runtimes[sid] : null;
     if (!sid || !runtime?.historyRevision) return false;
-    const browse = current.historyBrowse?.sid === sid
+    const browse = includeBrowseProjection && current.historyBrowse?.sid === sid
       ? current.historyBrowse : null;
     const displayed = (browse?.turns ?? runtime.turns).find(
       (turn) => turn.id === displayTurnId
@@ -2986,6 +3035,16 @@ export default function App() {
     }
     return true;
   }, [focusedEngine, historyPageScopeFor, space]);
+  const loadHistoryTurnDetail = useCallback((
+    displayTurnId: string, before?: string | null,
+    autoLoad = true,
+  ) => requestHistoryTurnDetail(
+    displayTurnId, before, autoLoad, true), [requestHistoryTurnDetail]);
+  const loadRuntimeTurnDetail = useCallback((
+    displayTurnId: string, before?: string | null,
+    autoLoad = true,
+  ) => requestHistoryTurnDetail(
+    displayTurnId, before, autoLoad, false), [requestHistoryTurnDetail]);
   useEffect(() => {
     const current = stateRef.current;
     const sid = current.focusedSid;
@@ -4291,15 +4350,33 @@ export default function App() {
               onLoadHistoryImage={historyView.recovering
                 ? undefined : loadHistoryImage}
               onTextSelectionGuardChange={updateTextSelectionGuard}
+              externalPlanProgress={planProgress ? {
+                turnId: planProgress.turnId,
+                itemId: planProgress.block.item_id,
+              } : null}
               onFork={!historyView.recovering && space === "code"
                 ? forkFromTurn : undefined} />
 
-            <Suspense fallback={(goalUi?.revealed || goalUi?.open)
+            <Suspense fallback={((goalUi?.revealed && !completedGoalRetired)
+                || goalUi?.open || planProgress)
               ? <span className="goal-suspense" role="status"
-                  aria-label="正在加载 Goal" /> : null}>
+                  aria-label={planProgress ? "正在加载计划进度" : "正在加载 Goal"} />
+              : null}>
               <GoalPanel engine={focusedEngine} goal={rt.goal}
                 revealed={!!goalUi?.revealed} open={!!goalUi?.open}
                 loading={!!goalUi?.loading}
+                completedGoalRetired={completedGoalRetired}
+                plan={planProgress}
+                onLoadPlanDetail={planProgress?.needsDetail
+                    && !planProgress.detailLoading && !historyView.recovering
+                  ? () => {
+                      if (planProgressSource === "history") {
+                        loadHistoryTurnDetail(planProgress.turnId);
+                      } else {
+                        loadRuntimeTurnDetail(planProgress.turnId);
+                      }
+                    }
+                  : undefined}
                 onOpen={() => {
                   rememberFocusedGoalUi();
                   requestFocusedGoal();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -184,9 +184,13 @@ import {
 import { ComposerDraftStore, composerDraftKey } from "./composer-drafts";
 import {
   acknowledgeCompletion,
+  acknowledgeMatchingCompletion,
+  catalogCompletionProjection,
+  completionAcknowledgementId,
   completionBadgeKind,
   discardBtwCompletionReceipts,
   markCompletionUnread,
+  newestCompletionProjection,
   rekeyCompletionReceipts,
   type CompletionBadgeKind,
   type CompletionReceipts,
@@ -330,6 +334,8 @@ export default function App() {
     useState(machineId);
   const [workArtifactsBySid, setWorkArtifactsBySid] = useState<Record<string, WorkArtifactInfo[]>>({});
   const [completionReceipts, setCompletionReceipts] = useState<CompletionReceipts>({});
+  const completionReceiptsRef = useRef(completionReceipts);
+  completionReceiptsRef.current = completionReceipts;
   const [btwSendModeBySid, setBtwSendModeBySid] = useState<
     Record<string, SendMode>
   >({});
@@ -366,6 +372,7 @@ export default function App() {
   const goalUiPreferencesRef = useRef<GoalUiPreferences>(
     readGoalUiPreferences(localStorage));
   const goalRecoveryRequestsRef = useRef<Set<string>>(new Set());
+  const goalDismissMigrationsRef = useRef<Set<string>>(new Set());
   const planProgressCacheRef = useRef(new SessionPlanProgressCache());
   const goalRequestScopeByIdRef = useRef<Map<
     string, { scopeKey: string; sid: string }
@@ -554,6 +561,7 @@ export default function App() {
     setQueuedQueryEditor(null);
     btwDraftsRef.current.clear();
     setCompletionReceipts({});
+    goalDismissMigrationsRef.current.clear();
     sessionListsBySurfaceRef.current = {};
     historySessionListsRef.current = {};
     preferredSurfaceFocusRef.current = null;
@@ -609,9 +617,31 @@ export default function App() {
   const activeBtwSid = activeBtw?.sid ?? null;
   const btwOpening = visibleParentSid
     ? !!btwOpeningByParentSid[visibleParentSid] : false;
+  const completionBadgeSids = new Set([
+    ...Object.keys(completionReceipts),
+    ...state.sessions.filter(
+      (session) => session.completion_unread === true,
+    ).map((session) => session.session_id),
+    ...Object.keys(state.runtimes).filter(
+      (sid) => state.runtimes[sid]?.completion?.unread === true),
+  ]);
+  const catalogCompletionBySid = new Map(state.sessions.flatMap((session) => {
+    const completion = catalogCompletionProjection(session);
+    return completion
+      ? [[session.session_id, completion] as const]
+      : [];
+  }));
   const completionBadges = Object.fromEntries(
-    Object.entries(completionReceipts).flatMap(([sid, receipt]) => {
-      const kind = completionBadgeKind(receipt);
+    [...completionBadgeSids].flatMap((sid) => {
+      const local = completionReceipts[sid] ?? {
+        main: false, mainCompletionId: null,
+        mainTurnEndSeq: null, mainTurnEndGeneration: null, btwSids: [],
+      };
+      const authoritative = newestCompletionProjection(
+        state.runtimes[sid]?.completion,
+        catalogCompletionBySid.get(sid),
+      );
+      const kind = completionBadgeKind(local, authoritative?.unread);
       return kind ? [[sid, kind]] : [];
     }),
   ) as Record<string, CompletionBadgeKind>;
@@ -760,7 +790,7 @@ export default function App() {
   const goalUi = focusedGoalScopeKey
     ? goalUiByScope[focusedGoalScopeKey] ?? (storedGoalPreference?.known
       ? {
-          revealed: storedGoalPreference.hiddenGoal
+          revealed: rt.goalDismissed ? false : storedGoalPreference.hiddenGoal
             ? !!rt.goal && storedGoalPreference.hiddenGoal !== storedGoalIdentity
             : true,
           open: false,
@@ -800,8 +830,9 @@ export default function App() {
         ...current,
         [focusedGoalScopeKey]: {
           // Discover an existing Goal silently on a new browser/device. The
-          // authoritative non-null response reveals it; an exact local
-          // dismissal remains hidden across refreshes on this device.
+          // authoritative non-null response reveals it unless the wrapper says
+          // this exact generation was dismissed. Legacy local dismissals are
+          // migrated when that response arrives.
           revealed: !!preference?.known && !preference.hiddenGoal,
           open: false,
           loading: true,
@@ -824,9 +855,19 @@ export default function App() {
       const parentSid = current.newChat ? null : current.focusedSid;
       if (!parentSid) return;
       const binding = current.btwByParentSid[parentSid];
+      const completion = newestCompletionProjection(
+        current.runtimes[parentSid]?.completion,
+        catalogCompletionProjection(current.sessions.find(
+          (session) => session.session_id === parentSid)),
+      );
+      const completionId = completionAcknowledgementId(
+        completionReceiptsRef.current[parentSid], completion);
+      const mainAcknowledgementQueued = completionId !== null
+        && wsRef.current?.sendAcknowledgeCompletionTo(
+          parentSid, completionId) !== null;
       setCompletionReceipts((receipts) => {
         let next = acknowledgeCompletion(
-          receipts, parentSid, { main: true });
+          receipts, parentSid, { main: mainAcknowledgementQueued });
         if (binding
             && (rightViewRef.current === "btw" || !current.artifact)) {
           next = acknowledgeCompletion(
@@ -839,7 +880,17 @@ export default function App() {
     document.addEventListener("visibilitychange", acknowledgeVisible);
     return () => document.removeEventListener(
       "visibilitychange", acknowledgeVisible);
-  }, [visibleParentSid, activeBtwSid, rightView, state.artifact]);
+  }, [
+    visibleParentSid,
+    activeBtwSid,
+    rightView,
+    state.artifact,
+    rt.completion?.id,
+    rt.completion?.unread,
+    focusedSession?.completion_id,
+    focusedSession?.completion_revision,
+    focusedSession?.completion_unread,
+  ]);
 
   const storeSkillCatalog = useCallback((
     key: string,
@@ -1582,10 +1633,29 @@ export default function App() {
             }
             const key = goalUiScopeForEvent(msg.sid, ownership);
             if (key) {
+              const localGoalIdentity = goalStableIdentity(msg.goal);
+              const localPreference = goalUiPreferencesRef.current[key];
+              const legacyDismissed = !!localGoalIdentity
+                && localPreference?.hiddenGoal === localGoalIdentity;
+              const authoritativeDismissed = msg.dismissed === true;
+              const migrationKey = msg.goal_id
+                ? `${machineId}\0${msg.sid}\0${msg.goal_id}` : null;
+              if (migrationKey && authoritativeDismissed) {
+                goalDismissMigrationsRef.current.delete(migrationKey);
+              } else if (migrationKey && legacyDismissed
+                  && !goalDismissMigrationsRef.current.has(migrationKey)) {
+                const requestId = ws.sendDismissGoalTo(
+                  msg.sid, msg.goal_id!);
+                if (requestId) {
+                  goalDismissMigrationsRef.current.add(migrationKey);
+                }
+              }
               const reconciled = reconcileGoalUiPreference(
                 goalUiPreferencesRef.current,
                 key,
                 msg.goal,
+                Date.now(),
+                authoritativeDismissed,
               );
               persistGoalUiPreferences(reconciled.preferences);
               setGoalUiByScope((current) => {
@@ -1611,6 +1681,46 @@ export default function App() {
               }
               recoverableReads.complete(["goal", key].join("\u0000"));
             }
+          } else if (msg.type === "completion_state" && msg.sid
+              && msg.unread !== true) {
+            // Clear the page-local fallback as soon as the wrapper confirms an
+            // acknowledgement for the same completion from any browser. A
+            // delayed read receipt for an older completion cannot clear a
+            // newer turn_end fallback.
+            const authoritative = newestCompletionProjection(
+              stateRef.current.runtimes[msg.sid]?.completion,
+              {
+                id: msg.completion_id ?? null,
+                unread: msg.unread ?? false,
+                revision: msg.revision ?? 0,
+              },
+            );
+            setCompletionReceipts((receipts) => (
+              acknowledgeMatchingCompletion(
+                receipts, msg.sid!, authoritative,
+                {
+                  authoritativeSeq: msg.seq,
+                  authoritativeGeneration: ws.generationFor(msg.sid!),
+                })));
+          } else if (msg.type === "session_list") {
+            // A sleeping browser can miss the live acknowledgement and later
+            // reconnect after the session was evicted. Its catalog row carries
+            // the same durable receipt, so clear any older page-local fallback
+            // instead of letting it reappear if the runtime is pruned.
+            setCompletionReceipts((receipts) => {
+              let next = receipts;
+              for (const session of msg.sessions) {
+                const catalog = catalogCompletionProjection(session);
+                if (!catalog) continue;
+                const authoritative = newestCompletionProjection(
+                  stateRef.current.runtimes[session.session_id]?.completion,
+                  catalog,
+                );
+                next = acknowledgeMatchingCompletion(
+                  next, session.session_id, authoritative);
+              }
+              return next;
+            });
           } else if (msg.type === "error" && msg.request_id) {
             const request = goalRequestScopeByIdRef.current.get(msg.request_id);
             if (request) {
@@ -1781,6 +1891,9 @@ export default function App() {
                   parentSid,
                   msg.sid!,
                   isBtw ? "btw" : "main",
+                  isBtw ? null : msg.turn_id ?? null,
+                  isBtw ? null : msg.seq ?? null,
+                  isBtw ? null : ws.generationFor(msg.sid!),
                 ));
               }
             }
@@ -4384,6 +4497,10 @@ export default function App() {
                 }}
                 onClose={() => setGoalUi({ open: false })}
                 onDismiss={() => {
+                  if (focusedSid && rt.goalId) {
+                    wsRef.current?.sendDismissGoalTo(
+                      focusedSid, rt.goalId);
+                  }
                   if (focusedGoalScopeKey) {
                     persistGoalUiPreferences(dismissGoalUi(
                       goalUiPreferencesRef.current,

--- a/web/src/completion-badges.ts
+++ b/web/src/completion-badges.ts
@@ -1,21 +1,75 @@
 export interface CompletionReceipt {
   main: boolean;
+  mainCompletionId: string | null;
+  mainTurnEndSeq: number | null;
+  mainTurnEndGeneration: string | null;
   btwSids: string[];
 }
 
 export type CompletionReceipts = Record<string, CompletionReceipt>;
 export type CompletionBadgeKind = "main" | "btw" | "both";
+export interface CompletionProjection {
+  id: string | null;
+  unread: boolean;
+  revision: number;
+}
+
+export function catalogCompletionProjection(
+  session: {
+    completion_id?: string | null;
+    completion_unread?: boolean | null;
+    completion_revision?: number | null;
+  } | null | undefined,
+): CompletionProjection | null {
+  if (session?.completion_unread == null
+      || session.completion_revision == null) return null;
+  return {
+    id: session.completion_id ?? null,
+    unread: session.completion_unread,
+    revision: session.completion_revision,
+  };
+}
+
+export function newestCompletionProjection(
+  runtime: CompletionProjection | null | undefined,
+  catalog: CompletionProjection | null | undefined,
+): CompletionProjection | null {
+  if (!runtime) return catalog ?? null;
+  if (!catalog || runtime.revision >= catalog.revision) return runtime;
+  return catalog;
+}
 
 export function markCompletionUnread(
   current: CompletionReceipts,
   parentSid: string,
   sourceSid: string,
   source: "main" | "btw",
+  completionId: string | null = null,
+  turnEndSeq: number | null = null,
+  turnEndGeneration: string | null = null,
 ): CompletionReceipts {
-  const prior = current[parentSid] ?? { main: false, btwSids: [] };
+  const prior = current[parentSid] ?? {
+    main: false, mainCompletionId: null, mainTurnEndSeq: null,
+    mainTurnEndGeneration: null, btwSids: [],
+  };
   if (source === "main") {
-    if (prior.main) return current;
-    return { ...current, [parentSid]: { ...prior, main: true } };
+    if (prior.main && prior.mainCompletionId === completionId
+        && (completionId != null || (
+          prior.mainTurnEndSeq === turnEndSeq
+          && prior.mainTurnEndGeneration === turnEndGeneration
+        ))) {
+      return current;
+    }
+    return {
+      ...current,
+      [parentSid]: {
+        ...prior,
+        main: true,
+        mainCompletionId: completionId,
+        mainTurnEndSeq: turnEndSeq,
+        mainTurnEndGeneration: turnEndGeneration,
+      },
+    };
   }
   if (prior.btwSids.includes(sourceSid)) return current;
   return {
@@ -35,25 +89,78 @@ export function acknowledgeCompletion(
   const prior = current[parentSid];
   if (!prior) return current;
   const main = options.main ? false : prior.main;
+  const mainCompletionId = options.main ? null : prior.mainCompletionId;
+  const mainTurnEndSeq = options.main ? null : prior.mainTurnEndSeq;
+  const mainTurnEndGeneration = options.main
+    ? null : prior.mainTurnEndGeneration;
   const btwSids = options.btwSid
     ? prior.btwSids.filter((sid) => sid !== options.btwSid)
     : prior.btwSids;
-  if (main === prior.main && btwSids.length === prior.btwSids.length) {
+  if (main === prior.main
+      && mainCompletionId === prior.mainCompletionId
+      && mainTurnEndSeq === prior.mainTurnEndSeq
+      && mainTurnEndGeneration === prior.mainTurnEndGeneration
+      && btwSids.length === prior.btwSids.length) {
     return current;
   }
   const next = { ...current };
   if (!main && btwSids.length === 0) delete next[parentSid];
-  else next[parentSid] = { main, btwSids };
+  else next[parentSid] = {
+    main, mainCompletionId, mainTurnEndSeq, mainTurnEndGeneration, btwSids,
+  };
   return next;
+}
+
+/** Clear a local main fallback when the authoritative read receipt names the
+ * same completion, or when an ordered clear follows its TurnEnd. A delayed
+ * catalog/read frame for an older completion must not hide a newer turn_end
+ * fallback which has not received its durable completion_state yet.
+ */
+export function acknowledgeMatchingCompletion(
+  current: CompletionReceipts,
+  parentSid: string,
+  authoritative: CompletionProjection | null | undefined,
+  options: {
+    authoritativeSeq?: number | null;
+    authoritativeGeneration?: string | null;
+  } = {},
+): CompletionReceipts {
+  const local = current[parentSid];
+  if (!local?.main || authoritative?.unread !== false) return current;
+  const identityMatches = !!authoritative.id
+    && local.mainCompletionId === authoritative.id;
+  // A downstream CompletionState is ordered in the same per-session sequence
+  // as TurnEnd. That causal boundary lets an authoritative generated id clear
+  // a legacy/null-id fallback without letting an unordered catalog row do so.
+  const causallyClearsFallback = (
+    authoritative.id == null || local.mainCompletionId == null
+  )
+    && local.mainTurnEndSeq != null
+    && local.mainTurnEndGeneration != null
+    && options.authoritativeSeq != null
+    && options.authoritativeGeneration === local.mainTurnEndGeneration
+    && options.authoritativeSeq > local.mainTurnEndSeq;
+  if (!identityMatches && !causallyClearsFallback) return current;
+  return acknowledgeCompletion(current, parentSid, { main: true });
+}
+
+export function completionAcknowledgementId(
+  receipt: CompletionReceipt | undefined,
+  authoritative: { id: string | null; unread: boolean } | null | undefined,
+): string | null {
+  if (authoritative?.unread && authoritative.id) return authoritative.id;
+  return receipt?.main ? receipt.mainCompletionId : null;
 }
 
 export function completionBadgeKind(
   receipt: CompletionReceipt | undefined,
+  authoritativeUnread?: boolean | null,
 ): CompletionBadgeKind | undefined {
-  if (!receipt) return undefined;
-  if (receipt.main && receipt.btwSids.length > 0) return "both";
-  if (receipt.main) return "main";
-  if (receipt.btwSids.length > 0) return "btw";
+  const main = receipt?.main === true || authoritativeUnread === true;
+  const btwSids = receipt?.btwSids ?? [];
+  if (main && btwSids.length > 0) return "both";
+  if (main) return "main";
+  if (btwSids.length > 0) return "btw";
   return undefined;
 }
 
@@ -69,6 +176,12 @@ export function rekeyCompletionReceipts(
   delete next[oldSid];
   next[newSid] = target ? {
     main: target.main || source.main,
+    mainCompletionId: source.main
+      ? source.mainCompletionId : target.mainCompletionId,
+    mainTurnEndSeq: source.main
+      ? source.mainTurnEndSeq : target.mainTurnEndSeq,
+    mainTurnEndGeneration: source.main
+      ? source.mainTurnEndGeneration : target.mainTurnEndGeneration,
     btwSids: Array.from(new Set([...target.btwSids, ...source.btwSids])),
   } : source;
   return next;
@@ -81,7 +194,13 @@ export function discardBtwCompletionReceipts(
   const next: CompletionReceipts = {};
   for (const [parentSid, receipt] of Object.entries(current)) {
     if (receipt.btwSids.length > 0) changed = true;
-    if (receipt.main) next[parentSid] = { main: true, btwSids: [] };
+    if (receipt.main) next[parentSid] = {
+      main: true,
+      mainCompletionId: receipt.mainCompletionId,
+      mainTurnEndSeq: receipt.mainTurnEndSeq,
+      mainTurnEndGeneration: receipt.mainTurnEndGeneration,
+      btwSids: [],
+    };
   }
   return changed ? next : current;
 }

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -289,6 +289,7 @@ export function ChatView({ sid, turns: incomingTurns, engine = "claude", loading
   onAuthorizeImage,
   historyImageAssets, onLoadHistoryImage,
   onTextSelectionGuardChange,
+  externalPlanProgress,
   surface = "code" }: {
   sid: string | null;
   turns: Turn[];
@@ -336,6 +337,10 @@ export function ChatView({ sid, turns: incomingTurns, engine = "claude", loading
     turnId: string, imageId: string, variant: HistoryImageVariant,
   ) => boolean;
   onTextSelectionGuardChange?: (guard: TextSelectionGuard | null) => void;
+  externalPlanProgress?: {
+    turnId: string;
+    itemId: string;
+  } | null;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentSizerRef = useRef<HTMLDivElement>(null);
@@ -2466,6 +2471,11 @@ export function ChatView({ sid, turns: incomingTurns, engine = "claude", loading
             const processOpenKey =
               `${scrollScope}\u0000turn:${processDisclosureId}`;
             const historyTurnId = t.historyTurnId ?? t.id;
+            const externalPlanItemId = externalPlanProgress
+              && externalPlanProgress.itemId
+              && [t.id, historyTurnId, t.clientMsgId].includes(
+                externalPlanProgress.turnId)
+                ? externalPlanProgress.itemId : null;
             const detailRetryBefore = t.detailRetryBefore;
             const detailRetryDirection = t.detailRetryDirection;
             const historyImagesReady = !!t.imageRefs?.length
@@ -2566,6 +2576,7 @@ export function ChatView({ sid, turns: incomingTurns, engine = "claude", loading
                 deferredCount={!t.detailLoaded ? t.detailEventCount : 0}
                 detailLoading={t.detailLoading}
                 detailError={t.detailError}
+                externalPlanItemId={externalPlanItemId}
                 onLoadDetail={onLoadDetail
                   ? () => requestProcessDetail(
                       t.id, undefined, "initial", true)

--- a/web/src/components/GoalPanel.tsx
+++ b/web/src/components/GoalPanel.tsx
@@ -1,6 +1,12 @@
-import { useEffect, useState, type CSSProperties } from "react";
+import { useEffect, useId, useRef, useState, type CSSProperties } from "react";
 import type { GoalStatus, ThreadGoal } from "../protocol";
 import { Icon } from "../icons";
+import type { TurnPlanProgress } from "../plan-progress";
+import { planProgressPresentation } from "../plan-progress";
+import {
+  PlanProgressContent,
+  PlanProgressFloatingCard,
+} from "./PlanProgressPopover";
 
 interface Props {
   engine: "claude" | "codex";
@@ -8,6 +14,9 @@ interface Props {
   revealed: boolean;
   open: boolean;
   loading?: boolean;
+  completedGoalRetired?: boolean;
+  plan?: TurnPlanProgress | null;
+  onLoadPlanDetail?: () => void;
   onOpen: () => void;
   onClose: () => void;
   onDismiss: () => void;
@@ -36,25 +45,71 @@ export function GoalPanel(p: Props) {
   const [objective, setObjective] = useState("");
   const [status, setStatus] = useState<GoalStatus>("active");
   const [budget, setBudget] = useState("");
+  const [planOpen, setPlanOpen] = useState(false);
+  const planChipRef = useRef<HTMLButtonElement>(null);
+  const planPopoverId = useId();
   useEffect(() => {
     setObjective(p.goal?.objective ?? "");
     setStatus(p.goal?.status ?? "active");
     setBudget(p.goal?.tokenBudget ? String(p.goal.tokenBudget) : "");
   }, [p.goal, p.open]);
+  // Authoritative detail may replace a provisional plan item id inside the
+  // same turn. Keep the sheet open across that refresh; only a new turn owns a
+  // genuinely different plan entry.
+  useEffect(() => setPlanOpen(false), [p.plan?.turnId]);
 
-  if (!p.revealed && !p.open) return null;
+  const goalRevealed = p.revealed && !p.completedGoalRetired;
+  // An explicit /goal read may still open the completed Goal for inspection,
+  // but a Plan owned by the next task must remain a separate monitor.
+  const planMergedIntoGoal = !!p.plan && !p.completedGoalRetired
+    && (goalRevealed || p.open);
+  const standalonePlan = planMergedIntoGoal ? null : p.plan;
+  useEffect(() => {
+    if (planMergedIntoGoal && !p.open) setPlanOpen(false);
+  }, [planMergedIntoGoal, p.open]);
+  if (!goalRevealed && !p.open && !standalonePlan) return null;
   const goal = p.goal;
   const used = goal?.tokensUsed ?? 0;
   const total = goal?.tokenBudget ?? null;
   const progress = total ? Math.min(100, used / total * 100) : null;
   const visualProgress = goal?.status === "complete" ? 100 : progress;
   const engineName = p.engine === "codex" ? "Codex" : "Claude";
+  const planPresentation = p.plan
+    ? planProgressPresentation(p.plan.block, p.plan.detailLoading) : null;
+  const openGoal = () => p.onOpen();
 
   return <>
-    {p.revealed && !goal &&
+    {standalonePlan && planPresentation && (
+      <div className="goal-chip-wrap plan-chip-wrap">
+        <button ref={planChipRef} type="button" className="goal-chip plan-chip"
+          aria-expanded={planOpen} aria-controls={planPopoverId}
+          onClick={() => {
+            const next = !planOpen;
+            if (next) p.onLoadPlanDetail?.();
+            setPlanOpen(next);
+          }} aria-label={`查看计划进度，${planPresentation.progressLabel}`}>
+          <span className={`goal-chip-ring plan-chip-ring${planPresentation.complete ? " complete" : ""}${planPresentation.failed ? " failed" : ""}`}
+            aria-hidden="true"
+            style={{ "--goal-progress": `${planPresentation.progress * 3.6}deg` } as CSSProperties}>
+            <Icon name={planPresentation.complete ? "verify" : "plan"} size={11} />
+          </span>
+          <span className="goal-chip-label">计划</span>
+          <span className="goal-chip-objective">
+            {planPresentation.currentStep ?? planPresentation.description
+              ?? planPresentation.stateLabel}
+          </span>
+          <span className="goal-chip-status">{planPresentation.progressLabel}</span>
+        </button>
+        <PlanProgressFloatingCard anchorRef={planChipRef}
+          block={standalonePlan.block} open={planOpen}
+          onOpenChange={setPlanOpen} id={planPopoverId}
+          detailLoading={standalonePlan.detailLoading} compact />
+      </div>
+    )}
+    {goalRevealed && !goal &&
       <div className="goal-chip-wrap goal-loading" role="status"
         aria-label={p.loading ? "正在恢复 Goal" : "Goal 暂时不可用，可重试"}>
-        <button className="goal-chip goal-chip-loading" onClick={p.onOpen}>
+        <button className="goal-chip goal-chip-loading" onClick={openGoal}>
           <span className="goal-chip-dot goal-chip-dot-active" aria-hidden="true" />
           <span className="goal-chip-label">Goal</span>
           <span className="goal-chip-objective">
@@ -62,8 +117,8 @@ export function GoalPanel(p: Props) {
           </span>
         </button>
       </div>}
-    {p.revealed && goal && <div className={`goal-chip-wrap goal-${goal.status}`}>
-      <button className="goal-chip" onClick={p.onOpen}
+    {goalRevealed && goal && <div className={`goal-chip-wrap goal-${goal.status}`}>
+      <button className="goal-chip" onClick={openGoal}
         aria-label={`查看 Goal，${statusName[goal.status]}`}>
         {visualProgress != null
           ? <span className={`goal-chip-ring goal-chip-ring-${goal.status}`}
@@ -94,6 +149,37 @@ export function GoalPanel(p: Props) {
         </header>
 
         <div className="goal-sheet-scroll">
+          {p.plan && planPresentation && <section className="goal-plan-section">
+            <button type="button" className="goal-plan-entry"
+              aria-expanded={planOpen}
+              aria-label={`查看计划进度，${planPresentation.progressLabel}`}
+              onClick={() => {
+                const next = !planOpen;
+                if (next) p.onLoadPlanDetail?.();
+                setPlanOpen(next);
+              }}>
+              <span className={`goal-chip-ring plan-chip-ring${planPresentation.complete ? " complete" : ""}${planPresentation.failed ? " failed" : ""}`}
+                aria-hidden="true"
+                style={{ "--goal-progress": `${planPresentation.progress * 3.6}deg` } as CSSProperties}>
+                <Icon name={planPresentation.complete ? "verify" : "plan"} size={11} />
+              </span>
+              <span className="goal-plan-entry-copy">
+                <b>计划</b>
+                <small>{planPresentation.currentStep
+                  ?? planPresentation.description
+                  ?? planPresentation.stateLabel}</small>
+              </span>
+              <strong>{planPresentation.progressLabel}</strong>
+              <span className={`goal-plan-entry-chev${planOpen ? " open" : ""}`}
+                aria-hidden="true"><Icon name="chev" size={15} /></span>
+            </button>
+            {planOpen && <div className="goal-plan-expanded"
+              aria-label="计划执行状态">
+              <PlanProgressContent block={p.plan.block}
+                detailLoading={p.plan.detailLoading} />
+            </div>}
+          </section>}
+
           {goal && <div className="goal-overview">
             <div className="goal-overview-row">
               <span className={`goal-status goal-status-${goal.status}`}>{statusName[goal.status]}</span>

--- a/web/src/components/PlanProgressPopover.tsx
+++ b/web/src/components/PlanProgressPopover.tsx
@@ -6,10 +6,12 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type RefObject,
 } from "react";
 import { createPortal } from "react-dom";
 import type { ProcessBlock } from "../domain/conversation";
 import { Icon } from "../icons";
+import { planProgressPresentation } from "../plan-progress";
 import {
   cancelDraggedPointer,
   PointerTapGuard,
@@ -24,46 +26,53 @@ interface PlanPopoverPosition {
   bottom?: number;
 }
 
-export function PlanProgressPopover({ block, openOverride, onOpenChange,
-  detailLoading = false, onNeedDetail }: {
+export function PlanProgressContent({ block, detailLoading = false }: {
   block: ProcessBlock;
-  openOverride?: boolean;
-  onOpenChange?: (open: boolean) => void;
   detailLoading?: boolean;
-  onNeedDetail?: () => void;
 }) {
-  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
-  const [position, setPosition] = useState<PlanPopoverPosition | null>(null);
-  const open = openOverride ?? uncontrolledOpen;
-  const rootRef = useRef<HTMLDivElement>(null);
-  const cardRef = useRef<HTMLElement>(null);
-  const tapGuard = useRef(new PointerTapGuard());
-  const labelId = useId();
+  const presentation = planProgressPresentation(block, detailLoading);
   const steps = block.plan ?? [];
-  const completed = steps.filter((entry) => entry.status === "completed").length;
-  const current = steps.find((entry) => entry.status === "inProgress");
-  const failed = ["failed", "declined", "cancelled", "interrupted"]
-    .includes(block.status);
-  // A terminal turn closes any still-open process item as `succeeded`; that
-  // says the turn ended cleanly, not that every structured plan step ran.
-  // Structured step state is therefore authoritative whenever it exists.
-  const complete = !failed && steps.length > 0
-    && completed === steps.length;
-  const progress = steps.length > 0
-    ? Math.min(100, completed / steps.length * 100)
-    : 0;
-  const progressLabel = steps.length > 0
-    ? `${completed} / ${steps.length}`
-    : block.done ? "已记录" : "执行中";
-  const description = block.explanation || block.summary;
-  const fallbackDetail = steps.length === 0
-    ? block.detail || block.output || block.progress
-    : null;
+  return <div className="plan-progress-content">
+    <header>
+      <span className={`plan-progress-mark${presentation.complete ? " complete" : ""}${presentation.failed ? " failed" : ""}`}>
+        <Icon name={presentation.complete ? "verify" : "plan"} size={15} />
+      </span>
+      <span>
+        <b>计划</b>
+        <small>{presentation.stateLabel}</small>
+      </span>
+      <strong>{presentation.progressLabel}</strong>
+    </header>
+    {presentation.description && <p>{presentation.description}</p>}
+    {steps.length > 0 ? <ol>
+      {steps.map((entry, index) => (
+        <li key={`${index}-${entry.step}`} className={`plan-step-${entry.status}`}>
+          <span aria-hidden="true">{entry.status === "completed"
+            ? <Icon name="verify" size={14} />
+            : entry.status === "inProgress" ? <i /> : <em>{index + 1}</em>}</span>
+          <span>{entry.step}</span>
+        </li>
+      ))}
+    </ol> : presentation.fallbackDetail
+      ? <pre className="plan-progress-fallback">{presentation.fallbackDetail}</pre>
+      : <div className="plan-progress-empty">
+          {detailLoading ? "正在加载计划…" : "等待计划步骤…"}
+        </div>}
+  </div>;
+}
 
-  const setOpen = useCallback((next: boolean) => {
-    setUncontrolledOpen(next);
-    onOpenChange?.(next);
-  }, [onOpenChange]);
+export function PlanProgressFloatingCard({ anchorRef, block, open,
+  onOpenChange, id, detailLoading = false, compact = false }: {
+  anchorRef: RefObject<HTMLElement | null>;
+  block: ProcessBlock;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  id: string;
+  detailLoading?: boolean;
+  compact?: boolean;
+}) {
+  const [position, setPosition] = useState<PlanPopoverPosition | null>(null);
+  const cardRef = useRef<HTMLElement>(null);
 
   useLayoutEffect(() => {
     if (!open) {
@@ -71,7 +80,7 @@ export function PlanProgressPopover({ block, openOverride, onOpenChange,
       return;
     }
     const place = () => {
-      const trigger = rootRef.current?.getBoundingClientRect();
+      const trigger = anchorRef.current?.getBoundingClientRect();
       if (!trigger) return;
       // WebKit's fixed-position layout viewport can differ from innerWidth by
       // a few CSS pixels around the safe-area. Use the document viewport and a
@@ -81,7 +90,7 @@ export function PlanProgressPopover({ block, openOverride, onOpenChange,
         window.innerWidth,
         document.documentElement.clientWidth,
       );
-      const width = Math.min(360, viewportWidth - gutter * 2);
+      const width = Math.min(compact ? 320 : 360, viewportWidth - gutter * 2);
       const left = Math.min(
         Math.max(gutter, trigger.right - width),
         viewportWidth - width - gutter,
@@ -93,7 +102,7 @@ export function PlanProgressPopover({ block, openOverride, onOpenChange,
       setPosition({
         left,
         width,
-        maxHeight: Math.min(420, available),
+        maxHeight: Math.min(compact ? 360 : 420, available),
         ...(openUp
           ? { bottom: window.innerHeight - trigger.top + 6 }
           : { top: trigger.bottom + 6 }),
@@ -106,18 +115,19 @@ export function PlanProgressPopover({ block, openOverride, onOpenChange,
       window.removeEventListener("resize", place);
       document.removeEventListener("scroll", place, true);
     };
-  }, [open]);
+  }, [anchorRef, compact, open]);
 
   useEffect(() => {
     if (!open) return;
     const closeOutside = (event: PointerEvent) => {
       const target = event.target;
       if (!(target instanceof Node)) return;
-      if (rootRef.current?.contains(target) || cardRef.current?.contains(target)) return;
-      setOpen(false);
+      if (anchorRef.current?.contains(target)
+        || cardRef.current?.contains(target)) return;
+      onOpenChange(false);
     };
     const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
+      if (event.key === "Escape") onOpenChange(false);
     };
     document.addEventListener("pointerdown", closeOutside, true);
     document.addEventListener("keydown", closeOnEscape);
@@ -125,14 +135,45 @@ export function PlanProgressPopover({ block, openOverride, onOpenChange,
       document.removeEventListener("pointerdown", closeOutside, true);
       document.removeEventListener("keydown", closeOnEscape);
     };
-  }, [open, setOpen]);
+  }, [anchorRef, onOpenChange, open]);
+
+  if (!open || !position) return null;
+  return createPortal(
+    <section ref={cardRef} id={id}
+      className={`plan-progress-popover${compact ? " compact" : ""}`}
+      role="dialog" aria-label="计划进度" style={position}>
+      <PlanProgressContent block={block} detailLoading={detailLoading} />
+    </section>,
+    document.body,
+  );
+}
+
+export function PlanProgressPopover({ block, openOverride, onOpenChange,
+  detailLoading = false, onNeedDetail }: {
+  block: ProcessBlock;
+  openOverride?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  detailLoading?: boolean;
+  onNeedDetail?: () => void;
+}) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const open = openOverride ?? uncontrolledOpen;
+  const rootRef = useRef<HTMLDivElement>(null);
+  const tapGuard = useRef(new PointerTapGuard());
+  const labelId = useId();
+  const presentation = planProgressPresentation(block, detailLoading);
+
+  const setOpen = useCallback((next: boolean) => {
+    setUncontrolledOpen(next);
+    onOpenChange?.(next);
+  }, [onOpenChange]);
 
   return <div ref={rootRef} className="plan-progress-control">
     <button type="button"
-      className={`plan-progress-trigger${complete ? " complete" : ""}${failed ? " failed" : ""}`}
+      className={`plan-progress-trigger${presentation.complete ? " complete" : ""}${presentation.failed ? " failed" : ""}`}
       aria-expanded={open} aria-controls={labelId}
-      aria-label={`查看计划进度，${progressLabel}`}
-      title={`计划进度 · ${progressLabel}`}
+      aria-label={`查看计划进度，${presentation.progressLabel}`}
+      title={`计划进度 · ${presentation.progressLabel}`}
       onPointerDown={(event) => {
         tapGuard.current.pointerDown(
           event.pointerId, event.clientX, event.clientY);
@@ -165,42 +206,11 @@ export function PlanProgressPopover({ block, openOverride, onOpenChange,
         setOpen(next);
       }}>
       <span className="plan-progress-ring" aria-hidden="true"
-        style={{ "--plan-progress": `${progress * 3.6}deg` } as CSSProperties}>
-        <Icon name={complete ? "verify" : "plan"} size={12} />
+        style={{ "--plan-progress": `${presentation.progress * 3.6}deg` } as CSSProperties}>
+        <Icon name={presentation.complete ? "verify" : "plan"} size={12} />
       </span>
     </button>
-    {open && position && createPortal(
-      <section ref={cardRef} id={labelId} className="plan-progress-popover"
-        role="dialog" aria-label="计划进度" style={position}>
-        <header>
-          <span className={`plan-progress-mark${complete ? " complete" : ""}${failed ? " failed" : ""}`}>
-            <Icon name={complete ? "verify" : "plan"} size={15} />
-          </span>
-          <span>
-            <b>计划</b>
-            <small>{detailLoading ? "正在同步" : failed ? "执行异常"
-              : complete ? "全部完成" : block.done ? "执行已结束"
-                : current ? "正在执行" : "等待执行"}</small>
-          </span>
-          <strong>{progressLabel}</strong>
-        </header>
-        {description && <p>{description}</p>}
-        {steps.length > 0 ? <ol>
-          {steps.map((entry, index) => (
-            <li key={`${index}-${entry.step}`} className={`plan-step-${entry.status}`}>
-              <span aria-hidden="true">{entry.status === "completed"
-                ? <Icon name="verify" size={14} />
-                : entry.status === "inProgress" ? <i /> : <em>{index + 1}</em>}</span>
-              <span>{entry.step}</span>
-            </li>
-          ))}
-        </ol> : fallbackDetail
-          ? <pre className="plan-progress-fallback">{fallbackDetail}</pre>
-          : <div className="plan-progress-empty">
-              {detailLoading ? "正在加载计划…" : "等待计划步骤…"}
-            </div>}
-      </section>,
-      document.body,
-    )}
+    <PlanProgressFloatingCard anchorRef={rootRef} block={block} open={open}
+      onOpenChange={setOpen} id={labelId} detailLoading={detailLoading} />
   </div>;
 }

--- a/web/src/components/ProcessTimeline.tsx
+++ b/web/src/components/ProcessTimeline.tsx
@@ -589,6 +589,7 @@ export function ProcessTimeline({ blocks, done, active, durationMs, startTs, don
   imageAssets, onLoadImage, onAuthorizeImage, onPreviewImage, engine = "claude",
   historyTurnId, historyImageAssets, onLoadHistoryImage,
   onPreviewHistoryImage,
+  externalPlanItemId,
   openOverride, onOpenChange, itemOpen, onItemOpenChange,
   onInteractionStart, onInteractionEnd }: {
   blocks: Block[];
@@ -624,6 +625,8 @@ export function ProcessTimeline({ blocks, done, active, durationMs, startTs, don
   ) => boolean;
   onPreviewHistoryImage?: (turnId: string, imageId: string) => void;
   engine?: "claude" | "codex";
+  /** The session-level progress strip owns this plan instead of this row. */
+  externalPlanItemId?: string | null;
   openOverride?: boolean;
   onOpenChange?: (open: boolean) => void;
   itemOpen?: (key: string) => boolean | undefined;
@@ -663,6 +666,8 @@ export function ProcessTimeline({ blocks, done, active, durationMs, startTs, don
   // transition; otherwise one click makes its own popover disappear briefly.
   if (planBlock) retainedPlanBlock.current = planBlock;
   const visiblePlanBlock = planBlock ?? retainedPlanBlock.current;
+  const inlinePlanBlock = visiblePlanBlock?.item_id === externalPlanItemId
+    ? null : visiblePlanBlock;
   const timelineItems = planBlock
     ? items.filter((block) => block !== planBlock)
     : items;
@@ -717,7 +722,7 @@ export function ProcessTimeline({ blocks, done, active, durationMs, startTs, don
   const showOuterDisclosure = timelineItems.length > 0
     || hasDeferredOnly || waitingForContent || !!visibleDetailError
     || canLoadEarlier || canLoadNewer;
-  if (!visiblePlanBlock && !showOuterDisclosure
+  if (!inlinePlanBlock && !showOuterDisclosure
       && !visibleDetailError) return null;
   // A completed timeline is collapsed. Do not allocate/group hundreds of
   // historical rows until the user actually opens it.
@@ -849,10 +854,10 @@ export function ProcessTimeline({ blocks, done, active, durationMs, startTs, don
           <span className="turn-process-count">{countLabel}</span>
           <Icon name="chev" size={15} />
         </button>}
-        {visiblePlanBlock && <PlanProgressPopover block={visiblePlanBlock}
-          openOverride={itemOpen?.(`plan:${visiblePlanBlock.item_id}`)}
+        {inlinePlanBlock && <PlanProgressPopover block={inlinePlanBlock}
+          openOverride={itemOpen?.(`plan:${inlinePlanBlock.item_id}`)}
           onOpenChange={(next) => onItemOpenChange?.(
-            `plan:${visiblePlanBlock.item_id}`, next)}
+            `plan:${inlinePlanBlock.item_id}`, next)}
           detailLoading={detailLoading}
           onNeedDetail={needsAuthoritativeDetail && !detailLoading
             ? requestDetail : undefined} />}

--- a/web/src/components/ProcessTimeline.tsx
+++ b/web/src/components/ProcessTimeline.tsx
@@ -1,4 +1,6 @@
 import {
+  lazy,
+  Suspense,
   useEffect,
   useRef,
   useState,
@@ -32,7 +34,10 @@ import {
   PointerTapGuard,
   releaseDraggedPointer,
 } from "../pointer-tap";
-import { PlanProgressPopover } from "./PlanProgressPopover";
+
+const PlanProgressPopover = lazy(() => import("./PlanProgressPopover").then(
+  ({ PlanProgressPopover: Popover }) => ({ default: Popover }),
+));
 
 function durationLabel(ms: number): string {
   const seconds = Math.max(0, Math.round(ms / 1000));
@@ -854,13 +859,20 @@ export function ProcessTimeline({ blocks, done, active, durationMs, startTs, don
           <span className="turn-process-count">{countLabel}</span>
           <Icon name="chev" size={15} />
         </button>}
-        {inlinePlanBlock && <PlanProgressPopover block={inlinePlanBlock}
-          openOverride={itemOpen?.(`plan:${inlinePlanBlock.item_id}`)}
-          onOpenChange={(next) => onItemOpenChange?.(
-            `plan:${inlinePlanBlock.item_id}`, next)}
-          detailLoading={detailLoading}
-          onNeedDetail={needsAuthoritativeDetail && !detailLoading
-            ? requestDetail : undefined} />}
+        {inlinePlanBlock && <Suspense fallback={
+          <span className="plan-progress-control" role="status"
+            aria-label="正在加载计划进度">
+            <span className="plan-progress-trigger" aria-hidden="true" />
+          </span>
+        }>
+          <PlanProgressPopover block={inlinePlanBlock}
+            openOverride={itemOpen?.(`plan:${inlinePlanBlock.item_id}`)}
+            onOpenChange={(next) => onItemOpenChange?.(
+              `plan:${inlinePlanBlock.item_id}`, next)}
+            detailLoading={detailLoading}
+            onNeedDetail={needsAuthoritativeDetail && !detailLoading
+              ? requestDetail : undefined} />
+        </Suspense>}
       </div>
       {showOuterDisclosure && open && <div className="process-timeline">
         {visibleDetailError && (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -549,32 +549,33 @@ button.message-image-error{ font:inherit; cursor:pointer; }
 .plan-progress-popover{ position:fixed; z-index:78; overflow:auto; box-sizing:border-box;
   padding:13px; border:1px solid var(--border-strong); border-radius:15px; color:var(--text);
   background:var(--surface); box-shadow:var(--shadow-lg); animation:panel-in .15s var(--ease); }
-.plan-progress-popover>header{ display:flex; align-items:center; gap:9px; }
-.plan-progress-popover>header>span:nth-child(2){ min-width:0; flex:1; display:flex; flex-direction:column; }
-.plan-progress-popover>header b{ font-size:13px; }
-.plan-progress-popover>header small{ color:var(--faint); font-size:10.5px; }
-.plan-progress-popover>header strong{ flex:none; color:var(--dim); font:10.5px/1 var(--mono); }
+.plan-progress-popover.compact{ padding:11px; border-radius:13px; }
+.plan-progress-content>header{ display:flex; align-items:center; gap:9px; }
+.plan-progress-content>header>span:nth-child(2){ min-width:0; flex:1; display:flex; flex-direction:column; }
+.plan-progress-content>header b{ font-size:13px; }
+.plan-progress-content>header small{ color:var(--faint); font-size:10.5px; }
+.plan-progress-content>header strong{ flex:none; color:var(--dim); font:10.5px/1 var(--mono); }
 .plan-progress-mark{ width:29px; height:29px; display:grid; place-items:center; flex:none;
   border-radius:9px; color:var(--accent); background:var(--accent-weak); }
 .plan-progress-mark.complete{ color:var(--ok); background:var(--ok-weak); }
 .plan-progress-mark.failed{ color:var(--danger); background:var(--danger-weak); }
-.plan-progress-popover>p{ margin:10px 1px 8px; color:var(--dim); font-size:11.5px;
+.plan-progress-content>p{ margin:10px 1px 8px; color:var(--dim); font-size:11.5px;
   line-height:1.45; white-space:pre-wrap; overflow-wrap:anywhere; }
 .plan-progress-fallback{ margin:9px 0 0; padding:9px 10px; border-radius:9px; overflow:auto;
   color:var(--dim); background:var(--raised); font:11.5px/1.5 var(--mono); white-space:pre-wrap;
   overflow-wrap:anywhere; }
-.plan-progress-popover>ol{ display:flex; flex-direction:column; gap:1px; margin:9px 0 0; padding:0; list-style:none; }
-.plan-progress-popover>ol li{ display:grid; grid-template-columns:22px minmax(0,1fr); gap:7px;
+.plan-progress-content>ol{ display:flex; flex-direction:column; gap:1px; margin:9px 0 0; padding:0; list-style:none; }
+.plan-progress-content>ol li{ display:grid; grid-template-columns:22px minmax(0,1fr); gap:7px;
   align-items:flex-start; padding:6px 5px; border-radius:8px; color:var(--dim); font-size:12px; line-height:1.4; }
-.plan-progress-popover>ol li>span:first-child{ width:20px; height:20px; display:grid; place-items:center;
+.plan-progress-content>ol li>span:first-child{ width:20px; height:20px; display:grid; place-items:center;
   color:var(--faint); }
-.plan-progress-popover>ol li>span:last-child{ overflow-wrap:anywhere; }
-.plan-progress-popover li.plan-step-completed{ color:var(--faint); }
-.plan-progress-popover li.plan-step-completed>span:first-child{ color:var(--ok); }
-.plan-progress-popover li.plan-step-inProgress{ color:var(--text); background:var(--accent-weak); font-weight:600; }
-.plan-progress-popover li.plan-step-inProgress>span:first-child i{ width:8px; height:8px; border-radius:50%;
+.plan-progress-content>ol li>span:last-child{ overflow-wrap:anywhere; }
+.plan-progress-content li.plan-step-completed{ color:var(--faint); }
+.plan-progress-content li.plan-step-completed>span:first-child{ color:var(--ok); }
+.plan-progress-content li.plan-step-inProgress{ color:var(--text); background:var(--accent-weak); font-weight:600; }
+.plan-progress-content li.plan-step-inProgress>span:first-child i{ width:8px; height:8px; border-radius:50%;
   background:var(--accent); box-shadow:0 0 0 4px color-mix(in srgb,var(--accent) 16%,transparent); animation:pulse 1.4s ease-in-out infinite; }
-.plan-progress-popover li.plan-step-pending>span:first-child em{ font-style:normal; font:9.5px/1 var(--mono); }
+.plan-progress-content li.plan-step-pending>span:first-child em{ font-style:normal; font:9.5px/1 var(--mono); }
 .plan-progress-empty{ padding:18px 4px 8px; color:var(--faint); font-size:12px; text-align:center; }
 .process-timeline{ position:relative; display:flex; flex-direction:column; gap:3px; margin:2px 0 5px 15px;
   padding:5px 0 5px 17px; border-left:1.5px solid var(--border-strong); }

--- a/web/src/plan-progress.ts
+++ b/web/src/plan-progress.ts
@@ -1,0 +1,310 @@
+import type { Block, ProcessBlock, Turn } from "./domain/conversation.ts";
+import type { ThreadGoal } from "./protocol.ts";
+import { mergeDetailWithLiveTail } from "./history-merge.ts";
+
+export interface TurnPlanProgress {
+  turnId: string;
+  block: ProcessBlock;
+  detailLoading: boolean;
+  needsDetail: boolean;
+  /** Millisecond start time of the user turn that owns this Plan. */
+  turnStartedAt?: number;
+  /** False only when a durable snapshot was rebound to a later unrelated turn. */
+  ownerMatchesTurn?: boolean;
+}
+
+export type TurnPlanProgressSource = "runtime" | "history";
+
+export interface ScopedTurnPlanProgress extends TurnPlanProgress {
+  source: TurnPlanProgressSource;
+}
+
+const MAX_SESSION_PLAN_PROGRESS = 128;
+
+function turnOwnsProgress(turn: Turn, turnId: string): boolean {
+  return [
+    turn.id,
+    turn.clientMsgId,
+    turn.historyTurnId,
+    turn.forkPointId,
+  ].some((candidate) => candidate === turnId);
+}
+
+function copyProgress(
+  progress: TurnPlanProgress,
+  source: TurnPlanProgressSource,
+): ScopedTurnPlanProgress {
+  return {
+    ...progress,
+    source,
+    block: {
+      ...progress.block,
+      plan: progress.block.plan?.map((entry) => ({ ...entry })),
+    },
+  };
+}
+
+/** Keep the latest structured Plan independently for each visited session.
+ *
+ * Codex's full turn detail currently omits update_plan. The summary page and
+ * live stream still carry the Plan, so retaining one bounded display snapshot
+ * prevents a detail read followed by A -> B -> A navigation from losing the
+ * session-level control. Entries are discarded after their owning turn is
+ * authoritatively absent, when a completed Plan is followed by a new user
+ * turn, or when an invalidation explicitly clears the sid.
+ */
+export class SessionPlanProgressCache {
+  private readonly entries = new Map<string, ScopedTurnPlanProgress>();
+  private readonly maxEntries: number;
+
+  constructor(maxEntries = MAX_SESSION_PLAN_PROGRESS) {
+    this.maxEntries = maxEntries;
+  }
+
+  resolve({
+    sid,
+    runtime,
+    history,
+    runtimeTurns,
+    historyTurns,
+    recovering,
+    runtimeLoading,
+  }: {
+    sid: string;
+    runtime: TurnPlanProgress | null;
+    history: TurnPlanProgress | null;
+    runtimeTurns: readonly Turn[];
+    historyTurns: readonly Turn[];
+    recovering: boolean;
+    runtimeLoading: boolean;
+  }): ScopedTurnPlanProgress | null {
+    const selected = runtime ?? history;
+    if (selected) {
+      const selectedTurns = runtime ? runtimeTurns : historyTurns;
+      const newerTurns = runtime ? [] : runtimeTurns;
+      if (completedPlanHasNewerTurn(
+        selected, selectedTurns, newerTurns)) {
+        this.entries.delete(sid);
+        return null;
+      }
+      const entry = copyProgress(
+        selected, runtime ? "runtime" : "history");
+      this.entries.delete(sid);
+      this.entries.set(sid, entry);
+      while (this.entries.size > this.maxEntries) {
+        const oldest = this.entries.keys().next().value;
+        if (typeof oldest !== "string") break;
+        this.entries.delete(oldest);
+      }
+      return entry;
+    }
+
+    const retained = this.entries.get(sid);
+    if (!retained) return null;
+    const turns = retained.source === "history" ? historyTurns : runtimeTurns;
+    const owner = turns.find((turn) => turnOwnsProgress(
+      turn, retained.turnId));
+    const newerTurns = retained.source === "history" ? runtimeTurns : [];
+    if (owner && completedPlanHasNewerTurn(
+      retained, turns, newerTurns)) {
+      this.entries.delete(sid);
+      return null;
+    }
+    if (!owner && !recovering && !runtimeLoading) {
+      this.entries.delete(sid);
+      return null;
+    }
+    // Touch on focus so the bounded cache evicts genuinely old sessions first.
+    this.entries.delete(sid);
+    const resolved = {
+      ...retained,
+      detailLoading: owner?.detailLoading === true,
+      needsDetail: owner
+        ? !owner.detailLoaded && (owner.detailEventCount ?? 0) > 0
+        : retained.needsDetail,
+    };
+    this.entries.set(sid, resolved);
+    return resolved;
+  }
+
+  clear(sid: string): void {
+    this.entries.delete(sid);
+  }
+
+  rekey(oldSid: string, sid: string): void {
+    if (oldSid === sid) return;
+    const retained = this.entries.get(oldSid);
+    if (!retained) return;
+    this.entries.delete(oldSid);
+    this.entries.delete(sid);
+    this.entries.set(sid, retained);
+  }
+}
+
+/** Resolve the newest plan-bearing turn in a conversation projection.
+ *
+ * Codex records a task plan on the turn which created it, while later steer or
+ * follow-up turns can continue an unfinished task without repeating that plan.
+ * Search turns newest-first so old sessions keep their latest active monitor,
+ * but retire a completed Plan as soon as the next user turn begins.
+ */
+export function latestPlanProgress(
+  turns: readonly Turn[],
+): TurnPlanProgress | null {
+  for (let index = turns.length - 1; index >= 0; index--) {
+    const progress = turnPlanProgress(turns[index]);
+    if (!progress) continue;
+    return completedPlanHasNewerTurn(progress, turns) ? null : progress;
+  }
+  return null;
+}
+
+function completedGoalAtMs(
+  goal: ThreadGoal | null | undefined,
+): number | null {
+  if (goal?.status !== "complete"
+      || typeof goal.updatedAt !== "number"
+      || !Number.isFinite(goal.updatedAt)) return null;
+  // The Goal API uses epoch seconds; conversation Turn timestamps use epoch
+  // milliseconds throughout the reducer and IndexedDB projection.
+  return goal.updatedAt * 1000;
+}
+
+function turnHasUserContent(turn: Turn): boolean {
+  return turn.prompt.trim().length > 0
+    || (turn.images?.length ?? 0) > 0
+    || (turn.imageRefs?.length ?? 0) > 0
+    || (turn.files?.length ?? 0) > 0;
+}
+
+/** A completed Goal retires from passive presentation on the next user turn. */
+export function completedGoalHasNewerUserTurn(
+  goal: ThreadGoal | null | undefined,
+  turns: readonly Turn[],
+): boolean {
+  const completedAt = completedGoalAtMs(goal);
+  if (completedAt == null) return false;
+  return turns.some((turn) => turnHasUserContent(turn)
+    && typeof turn.ts === "number" && Number.isFinite(turn.ts)
+    && turn.ts > completedAt);
+}
+
+/** Only a Plan from after the completion boundary may outlive the old Goal. */
+export function planFollowsCompletedGoal(
+  goal: ThreadGoal | null | undefined,
+  progress: TurnPlanProgress,
+): boolean {
+  const completedAt = completedGoalAtMs(goal);
+  return completedAt != null
+    && typeof progress.turnStartedAt === "number"
+    && Number.isFinite(progress.turnStartedAt)
+    && progress.turnStartedAt > completedAt
+    && progress.ownerMatchesTurn !== false;
+}
+
+function completedPlanHasNewerTurn(
+  progress: TurnPlanProgress,
+  turns: readonly Turn[],
+  newerTurns: readonly Turn[] = [],
+): boolean {
+  if (!planProgressPresentation(progress.block).complete) return false;
+  const ownerIndex = turns.findIndex((turn) =>
+    turnOwnsProgress(turn, progress.turnId));
+  if (ownerIndex >= 0
+      && turns.slice(ownerIndex + 1).some(turnHasUserContent)) return true;
+  if (newerTurns.length === 0) return false;
+  const newerOwnerIndex = newerTurns.findIndex((turn) =>
+    turnOwnsProgress(turn, progress.turnId));
+  if (newerOwnerIndex >= 0) {
+    return newerTurns.slice(newerOwnerIndex + 1).some(turnHasUserContent);
+  }
+  const ownerStartedAt = progress.turnStartedAt
+    ?? (ownerIndex >= 0 ? turns[ownerIndex].ts : undefined);
+  return newerTurns.some((turn) => !turnOwnsProgress(turn, progress.turnId)
+    && turnHasUserContent(turn)
+    && (ownerStartedAt == null || turn.ts == null || turn.ts > ownerStartedAt));
+}
+
+function turnPlanProgress(turn: Turn): TurnPlanProgress | null {
+  const preferCompletedDetail = turn.done
+    && !turn.detailRestorePending && !turn.detailRestoreIncomplete;
+  const plansOnly = (blocks: readonly Block[]) =>
+    blocks.filter((block): block is ProcessBlock =>
+      block.kind === "process" && block.processKind === "plan");
+  const withArchive = mergeDetailWithLiveTail(
+    plansOnly(turn.detailProjection?.blocks ?? []),
+    plansOnly(turn.liveSpillBlocks ?? []),
+    preferCompletedDetail,
+  );
+  const blocks = mergeDetailWithLiveTail(
+    withArchive,
+    plansOnly(turn.blocks),
+    preferCompletedDetail,
+  );
+  // Match ProcessTimeline: prefer the newest structured update, while still
+  // supporting older app-server records which only contain free-form detail.
+  const block = [...blocks].reverse().find((candidate) =>
+    candidate.kind === "process" && candidate.plan != null) ?? blocks.at(-1);
+  if (!block) return null;
+  // plansOnly() makes every merged block a ProcessBlock. Keep the narrowing
+  // explicit at this module boundary so future merge helpers can stay generic.
+  if (block.kind !== "process") return null;
+  return {
+    turnId: turn.id,
+    block,
+    detailLoading: turn.detailLoading === true,
+    needsDetail: !turn.detailLoaded && (turn.detailEventCount ?? 0) > 0,
+    turnStartedAt: turn.ts,
+    ownerMatchesTurn: !block.turn_id
+      || turnOwnsProgress(turn, block.turn_id),
+  };
+}
+
+export interface PlanProgressPresentation {
+  completed: number;
+  total: number;
+  currentStep: string | null;
+  failed: boolean;
+  complete: boolean;
+  progress: number;
+  progressLabel: string;
+  stateLabel: string;
+  description: string | null;
+  fallbackDetail: string | null;
+}
+
+export function planProgressPresentation(
+  block: ProcessBlock,
+  detailLoading = false,
+): PlanProgressPresentation {
+  const steps = block.plan ?? [];
+  const completed = steps.filter((entry) =>
+    entry.status === "completed").length;
+  const current = steps.find((entry) => entry.status === "inProgress");
+  const failed = ["failed", "declined", "cancelled", "interrupted"]
+    .includes(block.status);
+  // A successful terminal turn does not imply that unfinished structured plan
+  // steps ran; step state remains authoritative whenever it exists.
+  const complete = !failed && steps.length > 0 && completed === steps.length;
+  const progress = steps.length > 0
+    ? Math.min(100, completed / steps.length * 100)
+    : 0;
+  return {
+    completed,
+    total: steps.length,
+    currentStep: current?.step ?? null,
+    failed,
+    complete,
+    progress,
+    progressLabel: steps.length > 0
+      ? `${completed} / ${steps.length}`
+      : block.done ? "已记录" : "执行中",
+    stateLabel: detailLoading ? "正在同步" : failed ? "执行异常"
+      : complete ? "全部完成" : block.done ? "执行已结束"
+        : current ? "正在执行" : "等待执行",
+    description: block.explanation || block.summary || null,
+    fallbackDetail: steps.length === 0
+      ? block.detail || block.output || block.progress || null
+      : null,
+  };
+}

--- a/web/src/protocol.ts
+++ b/web/src/protocol.ts
@@ -260,6 +260,9 @@ export interface SessionInfo {
   native_session_id?: string | null;
   codex_profile_id?: string | null;
   codex_profile_label?: string | null;
+  completion_id?: string | null;
+  completion_unread?: boolean | null;
+  completion_revision?: number | null;
 }
 export interface ListSessions extends Base { type: "list_sessions"; engine?: Engine; space?: Space }
 export interface SwitchSession extends Base { type: "switch_session"; session_id: string; engine?: Engine; space?: Space }
@@ -445,6 +448,8 @@ export interface SetGoal extends Base {
   token_budget?: number | null;
 }
 export interface ClearGoal extends Base { type: "clear_goal" }
+export interface DismissGoal extends Base { type: "dismiss_goal"; goal_id: string }
+export interface AcknowledgeCompletion extends Base { type: "acknowledge_completion"; completion_id: string }
 export interface GetStatus extends Base { type: "get_status" }
 export interface ThreadGoal {
   threadId: string;
@@ -462,7 +467,19 @@ export interface ThreadGoal {
   setAt?: number;
   tokensAtStart?: number;
 }
-export interface GoalState extends Base { type: "goal_state"; goal?: ThreadGoal | null; request_id?: string | null }
+export interface GoalState extends Base {
+  type: "goal_state";
+  goal?: ThreadGoal | null;
+  goal_id?: string | null;
+  dismissed?: boolean;
+  request_id?: string | null;
+}
+export interface CompletionState extends Base {
+  type: "completion_state";
+  completion_id?: string | null;
+  unread?: boolean;
+  revision?: number;
+}
 export interface StatusThread {
   thread_id: string;
   session_id?: string | null;
@@ -551,14 +568,14 @@ export interface ContextReport extends Base {
 
 export type ServerEvent =
   | Pong | CommandAck | ReplayStart | ReplayEnd | Snapshot | StateEvent | QueryQueueState | QueuedQueryDetail | QueuedQueryUpdated | Model | Effort | Fast | CollaborationMode | BtwOpened | Perm | PermissionProfiles | PermissionProfile | WebSearch | ContextReport | DiffReport | FilePreview | FileSaveResult | PreviewAsset | PreviewAuthorizationRequired | PreviewAuthorizationResult | History | TurnDetail | HistoryImage | HistoryInvalidated | ArtifactInvalidated | Models | EngineCapabilities | TakeoverState | SessionControl
-  | AskUser | AskUserClosed | GoalState | StatusReport | Notice | RateLimitUpdate | RollbackResult
+  | AskUser | AskUserClosed | GoalState | CompletionState | StatusReport | Notice | RateLimitUpdate | RollbackResult
   | SessionList | SessionListInvalidated | SessionActivity | SessionFocus | SessionRekey | SessionForked | SessionMigrated | WorkDashboard | WorkArtifacts
   | DirList
   | UserMsg | TurnSteered | AssistantMsgStart | Delta | ToolUse | ToolDelta | ToolResult | AssistantMsgEnd
   | ProcessEvent | TurnPlan | TurnDiff | TurnBinding
   | TurnEnd | ErrorMsg | WrapperDisconnected | WrapperReconnected | Hello;
 
-export const PROTOCOL_VERSION = 33;
+export const PROTOCOL_VERSION = 34;
 
 const CONTROL_MODES = new Set<ControlMode>([
   "remote", "codex_shared", "claude_broker", "external_cli", "agent_view", "desktop",

--- a/web/src/reducer.ts
+++ b/web/src/reducer.ts
@@ -305,6 +305,13 @@ export interface SessionRuntime {
   contextRequestId: string | null;
   contextError: string | null;
   goal: ThreadGoal | null;
+  goalId: string | null;
+  goalDismissed: boolean;
+  completion: {
+    id: string | null;
+    unread: boolean;
+    revision: number;
+  } | null;
   statusReport: StatusReport | null;
   statusRequestId: string | null;
   statusError: string | null;
@@ -415,6 +422,7 @@ export function createRuntime(): SessionRuntime {
     historyNewestId: null,
     pendingQuestion: null, contextReport: null,
     contextRequestId: null, contextError: null, goal: null,
+    goalId: null, goalDismissed: false, completion: null,
     statusReport: null, statusRequestId: null, statusError: null,
     notices: [], sendMode: "steer",
     queue: [], pendingSend: null, failedDeferred: [],
@@ -1489,6 +1497,24 @@ function patch(state: AppState, sid: string | null | undefined,
   }
   fn(rt);
   return { ...state, runtimes: { ...state.runtimes, [key]: rt } };
+}
+
+function applyCompletionProjection(
+  runtime: SessionRuntime,
+  incoming: { id: string | null; unread: boolean; revision: number },
+): void {
+  if (!runtime.completion
+      || incoming.revision > runtime.completion.revision) {
+    runtime.completion = incoming;
+    return;
+  }
+  if (incoming.revision === runtime.completion.revision
+      && incoming.id === runtime.completion.id
+      && incoming.unread === runtime.completion.unread) {
+    return;
+  }
+  // A same-revision conflict is malformed; retain the state already accepted
+  // from this wrapper instead of allowing delivery order to toggle a badge.
 }
 
 /** Install one authoritative control value without allowing an older or
@@ -2913,9 +2939,31 @@ function reduceEvent(
             effort: null,
           }
           : state.newChat;
+      let runtimes = state.runtimes;
+      for (const session of sessions) {
+        if (session.completion_revision == null
+            || session.completion_unread == null) continue;
+        const current = runtimes[session.session_id];
+        // The sidebar reads cold receipts directly from the catalog. Only
+        // merge the revision into an already-resident runtime; allocating one
+        // placeholder per unread row would either defeat the memory bound or
+        // let pruning make durable badges disappear immediately.
+        if (!current) continue;
+        const runtime = { ...current };
+        applyCompletionProjection(runtime, {
+          id: session.completion_id ?? null,
+          unread: session.completion_unread,
+          revision: session.completion_revision,
+        });
+        if (runtime.completion !== current?.completion) {
+          if (runtimes === state.runtimes) runtimes = { ...state.runtimes };
+          runtimes[session.session_id] = runtime;
+        }
+      }
       return {
         ...state,
         sessions,
+        runtimes,
         cwdByScope,
         codexProfiles,
         defaultCodexProfileId,
@@ -4147,7 +4195,19 @@ function reduceEvent(
         }
       });
     case "goal_state":
-      return patch(state, e.sid, (rt) => { rt.goal = e.goal ?? null; });
+      return patch(state, e.sid, (rt) => {
+        rt.goal = e.goal ?? null;
+        rt.goalId = e.goal_id ?? null;
+        rt.goalDismissed = e.dismissed === true;
+      }, true);
+    case "completion_state":
+      return patch(state, e.sid, (rt) => {
+        applyCompletionProjection(rt, {
+          id: e.completion_id ?? null,
+          unread: e.unread === true,
+          revision: e.revision ?? 0,
+        });
+      }, true);
     case "rollback_result": {
       const next = patch(state, e.sid, (rt) => {
         const succeeded = [e.conversation, e.files].filter(

--- a/web/src/scoped-goal-ui.ts
+++ b/web/src/scoped-goal-ui.ts
@@ -154,23 +154,27 @@ export function reconcileGoalUiPreference(
   key: string,
   goal: ThreadGoal | null | undefined,
   now = Date.now(),
+  authoritativeDismissed = false,
 ): { preferences: GoalUiPreferences; revealed: boolean } {
   const current = preferences[key];
   if (!current?.known) {
     if (!goal) return { preferences, revealed: false };
     return {
-      preferences: rememberGoalUi(preferences, key, now),
-      revealed: true,
+      preferences: authoritativeDismissed
+        ? dismissGoalUi(preferences, key, goal, now)
+        : rememberGoalUi(preferences, key, now),
+      revealed: !authoritativeDismissed,
     };
   }
   const identity = goalStableIdentity(goal);
-  const hidden = !!identity && current.hiddenGoal === identity;
+  const hidden = authoritativeDismissed
+    || (!!identity && current.hiddenGoal === identity);
   const next = boundPreferences({
     ...preferences,
     [key]: {
       known: true,
       seenAt: now,
-      ...(hidden ? { hiddenGoal: current.hiddenGoal } : {}),
+      ...(hidden && identity ? { hiddenGoal: identity } : {}),
     },
   });
   return { preferences: next, revealed: !!goal && !hidden };

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -1076,6 +1076,31 @@ export class RelayWs {
     this.send({ v: PROTOCOL_VERSION, type: "clear_goal", ts: nowTs(), ...this.sidObj() });
   }
 
+  sendDismissGoalTo(sid: string, goalId: string): string | null {
+    return this.sendTracked({
+      v: PROTOCOL_VERSION,
+      type: "dismiss_goal",
+      sid,
+      goal_id: goalId,
+      client_id: this.clientId,
+      ts: nowTs(),
+    });
+  }
+
+  sendAcknowledgeCompletionTo(
+    sid: string,
+    completionId: string,
+  ): string | null {
+    return this.sendTracked({
+      v: PROTOCOL_VERSION,
+      type: "acknowledge_completion",
+      sid,
+      completion_id: completionId,
+      client_id: this.clientId,
+      ts: nowTs(),
+    });
+  }
+
   sendListSessions(engine?: "claude" | "codex", space: Space = "code"): boolean {
     const targetEngine = engine ?? "claude";
     const obj: Record<string, unknown> = { v: PROTOCOL_VERSION, type: "list_sessions", ts: nowTs() };

--- a/web/tests/history-browser.fixture.tsx
+++ b/web/tests/history-browser.fixture.tsx
@@ -65,6 +65,11 @@ import { GoalPanel } from "../src/components/GoalPanel";
 import { ProcessTimeline } from "../src/components/ProcessTimeline";
 import { SessionsSidebar } from "../src/components/SessionsSidebar";
 import { useMobileViewport } from "../src/use-mobile-viewport";
+import {
+  completedGoalHasNewerUserTurn,
+  latestPlanProgress,
+  type TurnPlanProgress,
+} from "../src/plan-progress";
 
 const LONG_PERMISSION_PROFILE_ID =
   `custom-profile-${"authorization-boundary-".repeat(12)}`.slice(0, 256);
@@ -218,6 +223,21 @@ function timelineTurn(id: string): Turn {
         done: true,
       },
       ...finalTurn(id, 3).blocks,
+    ],
+  };
+}
+
+function persistentPlanTurn(): Turn {
+  const base = timelineTurn("persistent-plan");
+  const plan = base.blocks[0];
+  return {
+    ...base,
+    done: false,
+    doneTs: undefined,
+    blocks: [
+      plan.kind === "process" ? { ...plan, done: false } : plan,
+      ...base.blocks.slice(1, -1),
+      streamingTurn("persistent-plan-output", 180).blocks[0],
     ],
   };
 }
@@ -1027,6 +1047,8 @@ function HistoryConversationBrowserFixture() {
   const pageCount = Math.max(1, Number(params.get("pages") ?? "1"));
   const large = largeCount > 0;
   const timeline = params.has("timeline");
+  const persistentPlan = params.has("persistent-plan");
+  const historicalPlan = params.has("historical-plan");
   const interactiveTimeline = params.has("interactive-timeline");
   const dualImage = params.has("dual-image");
   const compactTools = params.has("compact-tools");
@@ -1110,6 +1132,14 @@ function HistoryConversationBrowserFixture() {
           finalTurn(`f${index + 1}`, 4)),
       ];
     }
+    if (persistentPlan) return [persistentPlanTurn()];
+    if (historicalPlan) {
+      return [
+        timelineTurn("historical-plan"),
+        ...Array.from({ length: 8 }, (_, index) =>
+          finalTurn(`historical-followup-${index + 1}`, 3)),
+      ];
+    }
     if (interactiveTimeline) {
       return [
         timelineTurn("timeline"),
@@ -1122,7 +1152,7 @@ function HistoryConversationBrowserFixture() {
     detailScrollCancel, dualImage,
     interactiveTimeline, math, streamingMath,
     deepBrowse, invalidMermaid, large, largeCount, mermaid, mermaidHistory,
-    timeline,
+    historicalPlan, persistentPlan, timeline,
   ]);
   const [sid, setSid] = useState("history-browser-session-a");
   const [sessions, setSessions] = useState<Record<string, FixtureSession>>({
@@ -1131,7 +1161,7 @@ function HistoryConversationBrowserFixture() {
       cursor: initialA[0]?.id ?? "",
       hasMore: !compactTools && !detailPaging && !invalidMermaid && !large && !mermaid
         && !mermaidHistory && !math && !streamingMath && !timeline && !deepBrowse
-        && !delayedHistoryAvailability,
+        && !delayedHistoryAvailability && !historicalPlan,
       pagesLoaded: 0,
       hasNewer: deepBrowse,
       newerPagesLoaded: 0,
@@ -1227,6 +1257,8 @@ function HistoryConversationBrowserFixture() {
   const [migrationPickerConfirmed, setMigrationPickerConfirmed] =
     useState<string | null>(null);
   const active = sessions[sid];
+  const fixedPlanProgress = persistentPlan || historicalPlan
+    ? latestPlanProgress(active.turns) : null;
   const revealOlderHistory = useCallback(() => {
     setSessions((current) => ({
       ...current,
@@ -1817,8 +1849,16 @@ function HistoryConversationBrowserFixture() {
           onTextSelectionGuardChange={updateTextSelectionGuard}
           onEdit={() => {}}
           onGetDiff={() => {}}
+          externalPlanProgress={fixedPlanProgress ? {
+            turnId: fixedPlanProgress.turnId,
+            itemId: fixedPlanProgress.block.item_id,
+          } : null}
         />
       )}
+      {fixedPlanProgress && <GoalPanel engine="codex" goal={null}
+        revealed={false} open={false} plan={fixedPlanProgress}
+        onOpen={() => {}} onClose={() => {}} onDismiss={() => {}}
+        onSave={() => {}} onClear={() => {}} />}
       {composerResize && (
         <div data-testid="fixture-composer" style={{
           flex: "none",
@@ -1925,8 +1965,12 @@ export function HistoryBrowserFixture() {
   const planUi = params.get("plan-ui");
   if (params.has("profile-sidebar")) return <ProfileSidebarFixture />;
   if (planUi) return <PlanUiFixture mode={planUi} />;
+  if (params.has("plan-lifecycle")) return <PlanLifecycleFixture />;
   if (params.has("goal-ui")) {
-    return <GoalUiFixture status={params.get("goal-status")} />;
+    return <GoalUiFixture status={params.get("goal-status")}
+      withPlan={params.has("plan")} hidden={params.has("goal-hidden")}
+      longGoal={params.has("goal-long")}
+      newerTurn={params.has("goal-next-turn")} />;
   }
   if (params.has("header-menu")) {
     return <UsageActivityBrowserFixture
@@ -2014,6 +2058,46 @@ function ProfileSidebarFixture() {
   );
 }
 
+function PlanLifecycleFixture() {
+  const [turns, setTurns] = useState<Turn[]>(() => [{
+    id: "completed-plan-turn",
+    prompt: "完成当前任务",
+    done: true,
+    blocks: [{
+      kind: "process",
+      item_id: "completed-plan-item",
+      processKind: "plan",
+      phase: "end",
+      status: "succeeded",
+      title: "计划",
+      plan: [
+        { step: "实现功能", status: "completed" },
+        { step: "完成验证", status: "completed" },
+      ],
+      done: true,
+    }],
+  }]);
+  const plan = latestPlanProgress(turns);
+  return (
+    <main style={{ height: "100dvh", display: "flex", flexDirection: "column" }}>
+      <button type="button" data-testid="send-next-plan-message"
+        onClick={() => setTurns((current) => [...current, {
+          id: "next-user-turn",
+          prompt: "开始下一个问题",
+          done: false,
+          blocks: [],
+        }])}>
+        send next message
+      </button>
+      <div style={{ flex: 1 }} />
+      <GoalPanel engine="codex" goal={null} revealed={false} open={false}
+        plan={plan} onOpen={() => {}} onClose={() => {}}
+        onDismiss={() => {}} onSave={() => {}} onClear={() => {}} />
+      <div className="composer"><div className="composer-in" /></div>
+    </main>
+  );
+}
+
 function MobileViewportHistoryConversationBrowserFixture() {
   useMobileViewport();
   return <HistoryConversationBrowserFixture />;
@@ -2075,33 +2159,78 @@ function PlanUiFixture({ mode }: { mode: string }) {
           window.setTimeout(() => {
             setAuthoritative(true);
             setRefreshing(false);
-          }, 150);
+          // Leave the provisional frame observable even on the slower mobile
+          // WebKit project before replacing it with authoritative detail.
+          }, 800);
           return true;
         } : undefined} />
     </main>
   );
 }
 
-function GoalUiFixture({ status }: { status: string | null }) {
+function GoalUiFixture({ status, withPlan, hidden, longGoal, newerTurn }: {
+  status: string | null;
+  withPlan: boolean;
+  hidden: boolean;
+  longGoal: boolean;
+  newerTurn: boolean;
+}) {
   const [open, setOpen] = useState(false);
-  const [revealed, setRevealed] = useState(true);
+  const [revealed, setRevealed] = useState(!hidden && status !== "none");
+  const [planDetailRequests, setPlanDetailRequests] = useState(0);
   const loading = status === "loading";
-  const goalStatus = status === "blocked" ? "blocked" : "active";
-  const goal: ThreadGoal | null = loading ? null : {
+  const goalStatus = status === "blocked" ? "blocked"
+    : status === "complete" ? "complete" : "active";
+  const goal: ThreadGoal | null = loading || status === "none" ? null : {
     threadId: "goal-fixture-thread",
-    objective: "完成 protocol v30 发布并验证所有终端同步升级",
+    objective: longGoal
+      ? "按照计划完成所有功能模块；每个模块验证无误后分别提交并推送，确保核心行为一致。".repeat(8)
+      : "完成 protocol v30 发布并验证所有终端同步升级",
     status: goalStatus,
     engine: "codex",
     tokenBudget: 100_000,
     tokensUsed: 37_000,
     timeUsedSeconds: 321,
+    updatedAt: 1_800_000_000,
     lastReason: "已完成协议兼容性检查，正在验证三端同步状态。",
   };
+  const plan: TurnPlanProgress | null = withPlan ? {
+    turnId: "goal-fixture-turn",
+    block: {
+      kind: "process",
+      item_id: "goal-fixture-plan",
+      processKind: "plan",
+      phase: "update",
+      status: "running",
+      title: "计划",
+      explanation: "让任务进度始终可以从会话底部查看。",
+      plan: [
+        { step: "定位计划状态", status: "completed" },
+        { step: "实现固定入口", status: "inProgress" },
+        { step: "完成浏览器回归", status: "pending" },
+      ],
+      done: false,
+    },
+    detailLoading: false,
+    needsDetail: true,
+  } : null;
+  const completedGoalRetired = completedGoalHasNewerUserTurn(
+    goal,
+    newerTurn ? [{
+      id: "goal-fixture-next-turn",
+      prompt: "开始 Goal 之后的新任务",
+      blocks: [],
+      done: false,
+      ts: 1_800_000_001_000,
+    }] : [],
+  );
   return (
     <main style={{ height: "100dvh", display: "flex", flexDirection: "column" }}>
       <div data-testid="goal-fixture-content" style={{ flex: 1 }} />
+      <output data-testid="plan-detail-requests">{planDetailRequests}</output>
       <GoalPanel engine="codex" goal={goal} revealed={revealed} open={open}
-        loading={loading}
+        loading={loading} completedGoalRetired={completedGoalRetired} plan={plan}
+        onLoadPlanDetail={() => setPlanDetailRequests((value) => value + 1)}
         onOpen={() => setOpen(true)} onClose={() => setOpen(false)}
         onDismiss={() => setRevealed(false)} onSave={() => setOpen(false)}
         onClear={() => setRevealed(false)} />

--- a/web/tests/history-browser.spec.ts
+++ b/web/tests/history-browser.spec.ts
@@ -3013,6 +3013,40 @@ test("plan progress uses a compact popover that closes outside", async ({
   await expect(popover).toHaveCount(0);
 });
 
+test("a long active turn keeps its plan beside the composer", async ({ page }) => {
+  await page.goto("/tests/history-browser.html?persistent-plan=1");
+  const thread = page.locator(".thread");
+  await thread.evaluate((node) => { node.scrollTop = node.scrollHeight; });
+  await expect.poll(() => thread.evaluate((node) => node.scrollTop))
+    .toBeGreaterThan(200);
+  await expect(page.locator('[data-turn-id="persistent-plan"]')
+    .getByRole("button", { name: /查看计划进度/ })).toHaveCount(0);
+
+  const chip = page.getByRole("button", { name: /查看计划进度/ });
+  await expect(chip).toBeVisible();
+  await chip.click();
+  await expect(page.getByRole("dialog", { name: "计划进度" }))
+    .toContainText("验证计划弹层");
+});
+
+test("an old session lifts its earlier plan out of the first message", async ({
+  page,
+}, testInfo) => {
+  await page.goto("/tests/history-browser.html?historical-plan=1");
+
+  const chip = page.getByRole("button", { name: /查看计划进度/ });
+  await expect(chip).toBeVisible();
+  await scrollThreadToEdge(page, "start", testInfo.project.name);
+  const planTurn = page.locator('[data-turn-id="historical-plan"]');
+  await expect(planTurn).toBeVisible();
+  await expect(planTurn.getByRole("button", { name: /查看计划进度/ }))
+    .toHaveCount(0);
+
+  await chip.click();
+  await expect(page.getByRole("dialog", { name: "计划进度" }))
+    .toContainText("验证计划弹层");
+});
+
 test("iOS pointercancel releases the plan trigger without opening it", async ({
   page,
 }, testInfo) => {
@@ -3070,6 +3104,128 @@ test("only the selected plan block moves into the compact popover", async ({
   await page.goto("/tests/history-browser.html?plan-ui=mixed");
   await page.locator(".turn-process-head").click();
   await expect(page.getByText("旧版计划", { exact: true })).toBeVisible();
+});
+
+test("a turn plan without a Goal stays in a compact session-level strip", async ({
+  page,
+}) => {
+  await page.goto("/tests/history-browser.html?goal-ui=1&goal-status=none&plan=1");
+  const chip = page.getByRole("button", { name: /查看计划进度/ });
+  await expect(chip).toBeVisible();
+  await expect(chip).toContainText("实现固定入口");
+  const box = await chip.boundingBox();
+  if (!box) throw new Error("plan strip has no geometry");
+  expect(box.height).toBeLessThanOrEqual(42);
+
+  await chip.click();
+  await expect(page.getByTestId("plan-detail-requests")).toHaveText("1");
+  const dialog = page.getByRole("dialog", { name: "计划进度" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText("1 / 3");
+  await expect(dialog).toContainText("完成浏览器回归");
+  await expect(page.locator(".scrim.show")).toHaveCount(0);
+  await expect(page.locator(".plan-sheet")).toHaveCount(0);
+  const dialogBox = await dialog.boundingBox();
+  if (!dialogBox) throw new Error("plan popover has no geometry");
+  // Fractional device scaling can report 320.000015px for a 320px CSS box.
+  expect(dialogBox.width).toBeLessThan(321);
+  expect(await dialog.evaluate((node) =>
+    getComputedStyle(node).animationName)).toBe("panel-in");
+  const openChipBox = await chip.boundingBox();
+  if (!openChipBox) throw new Error("open plan strip has no geometry");
+  expect(Math.abs(openChipBox.x - box.x)).toBeLessThan(1);
+  expect(Math.abs(openChipBox.y - box.y)).toBeLessThan(1);
+
+  await chip.click();
+  await expect(dialog).toHaveCount(0);
+});
+
+test("a completed session Plan disappears when the next message begins", async ({
+  page,
+}) => {
+  await page.goto("/tests/history-browser.html?plan-lifecycle=1");
+  const chip = page.getByRole("button", { name: /查看计划进度/ });
+  await expect(chip).toBeVisible();
+  await expect(chip.locator(".plan-chip-ring.complete")).toHaveCount(1);
+  await expect(chip).toContainText("2 / 2");
+
+  await page.getByTestId("send-next-plan-message").click();
+  await expect(chip).toHaveCount(0);
+});
+
+test("an existing Goal owns the turn plan in its detail sheet", async ({
+  page,
+}) => {
+  await page.goto("/tests/history-browser.html?goal-ui=1&plan=1");
+  await expect(page.getByRole("button", { name: /查看计划进度/ }))
+    .toHaveCount(0);
+  await page.getByRole("button", { name: /查看 Goal/ }).click();
+  const dialog = page.getByRole("dialog", { name: "Codex Goal" });
+  const planEntry = dialog.getByRole("button", { name: /查看计划进度/ });
+  await expect(planEntry).toBeVisible();
+  await expect(planEntry).toContainText("实现固定入口");
+  await expect(page.getByTestId("plan-detail-requests")).toHaveText("0");
+  await planEntry.click();
+  await expect(page.getByTestId("plan-detail-requests")).toHaveText("1");
+  await expect(dialog.getByLabel("计划执行状态")).toContainText("1 / 3");
+  await expect(dialog.getByLabel("计划执行状态"))
+    .toContainText("实现固定入口");
+});
+
+test("a completed Goal keeps the Plan from its own final turn", async ({
+  page,
+}) => {
+  await page.goto("/tests/history-browser.html?goal-ui=1&goal-status=complete&plan=1");
+  await expect(page.getByRole("button", { name: /查看 Goal/ })).toBeVisible();
+  await expect(page.getByRole("button", { name: /查看计划进度/ }))
+    .toHaveCount(0);
+
+  await page.getByRole("button", { name: /查看 Goal/ }).click();
+  await expect(page.getByRole("dialog", { name: "Codex Goal" })
+    .getByRole("button", { name: /查看计划进度/ })).toBeVisible();
+});
+
+test("a new turn retires its completed Goal and owns a standalone Plan", async ({
+  page,
+}) => {
+  await page.goto(
+    "/tests/history-browser.html?goal-ui=1&goal-status=complete&plan=1&goal-next-turn=1",
+  );
+  await expect(page.getByRole("button", { name: /查看 Goal/ })).toHaveCount(0);
+
+  const plan = page.getByRole("button", { name: /查看计划进度/ });
+  await expect(plan).toBeVisible();
+  await expect(plan).toContainText("实现固定入口");
+  await plan.click();
+  await expect(page.getByRole("dialog", { name: "计划进度" }))
+    .toContainText("完成浏览器回归");
+  await expect(page.getByRole("dialog", { name: "Codex Goal" })).toHaveCount(0);
+});
+
+test("a long Goal keeps its merged plan in the detail sheet first viewport", async ({
+  page,
+}) => {
+  await page.goto("/tests/history-browser.html?goal-ui=1&plan=1&goal-long=1");
+  await page.getByRole("button", { name: /查看 Goal/ }).click();
+
+  const dialog = page.getByRole("dialog", { name: "Codex Goal" });
+  const planEntry = dialog.getByRole("button", { name: /查看计划进度/ });
+  await expect(planEntry).toContainText("实现固定入口");
+  await expect(planEntry).toBeInViewport();
+  await expect(dialog.locator(".goal-sheet-scroll"))
+    .toHaveJSProperty("scrollTop", 0);
+  await planEntry.click();
+  await expect(dialog.getByLabel("计划执行状态"))
+    .toContainText("实现固定入口");
+});
+
+test("a hidden Goal cannot make the current plan inaccessible", async ({
+  page,
+}) => {
+  await page.goto("/tests/history-browser.html?goal-ui=1&goal-hidden=1&plan=1");
+  await expect(page.getByRole("button", { name: /查看 Goal/ })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /查看计划进度/ }))
+    .toBeVisible();
 });
 
 test("goal entry stays compact and opens its editor", async ({ page }) => {

--- a/web/tests/history-browser.spec.ts
+++ b/web/tests/history-browser.spec.ts
@@ -1245,11 +1245,29 @@ test("the first runtime browse page stays staged until wheel idle", async ({
   await waitForScrollIdle(page);
   const before = await readingAnchor(page);
 
-  await viewport.dispatchEvent("wheel", { deltaY: -80 });
-  await expect(page.getByTestId("load-count")).toHaveText("1");
-  await page.waitForTimeout(100);
-  await expect(page.locator('[data-turn-id="n8"]')).toHaveCount(0);
-  await expect(page.getByTestId("history-page-activity")).toBeVisible();
+  await viewport.evaluate((node) => {
+    const target = node as HTMLElement & { __wheelLease?: number };
+    const signalWheel = () => target.dispatchEvent(new WheelEvent("wheel", {
+      bubbles: true,
+      deltaY: -80,
+    }));
+    signalWheel();
+    target.__wheelLease = window.setInterval(signalWheel, 50);
+  });
+  try {
+    await expect(page.getByTestId("load-count")).toHaveText("1");
+    await page.waitForTimeout(100);
+    await expect(page.locator('[data-turn-id="n8"]')).toHaveCount(0);
+    await expect(page.getByTestId("history-page-activity")).toBeVisible();
+  } finally {
+    await viewport.evaluate((node) => {
+      const target = node as HTMLElement & { __wheelLease?: number };
+      if (target.__wheelLease != null) {
+        window.clearInterval(target.__wheelLease);
+        delete target.__wheelLease;
+      }
+    });
+  }
 
   await expect(page.locator('[data-turn-id="n8"]')).toBeAttached();
   await expect(page.getByTestId("history-page-activity")).toHaveCount(0);
@@ -1271,13 +1289,12 @@ test("older history becoming available during a wheel gesture is restored once",
   await viewport.evaluate((node) => { node.scrollTop = 0; });
   const before = await readingAnchor(page);
   await viewport.dispatchEvent("wheel", { deltaY: -80 });
-  await page.getByTestId("reveal-older-history").click();
 
-  await expect(page.getByText("正在恢复历史…")).toBeVisible();
   const pending = await readingAnchor(page);
   expect(pending.id).toBe(before.id);
   expect(Math.abs(pending.offset - before.offset)).toBeLessThan(2);
   await expect(page.getByTestId("load-count")).toHaveText("0");
+  await page.getByTestId("reveal-older-history").click();
   await expect(page.getByTestId("load-count")).toHaveText("1");
   await expect(page.locator('[data-turn-id="n8"]')).toBeAttached();
   await page.waitForTimeout(250);
@@ -1311,7 +1328,7 @@ test("one click loads every turn-detail page without collapsing or jumping", asy
   page,
 }) => {
   await page.goto(
-    "/tests/history-browser.html?detail-paging=1&delay=80&growth-delay=180",
+    "/tests/history-browser.html?detail-paging=1&delay=1000&growth-delay=180",
   );
   const header = page.locator(".turn-process-head");
   await expect(header).toHaveAttribute("aria-expanded", "false");
@@ -1338,7 +1355,7 @@ test("a loading process can collapse and reopen without issuing a duplicate read
   page,
 }) => {
   await page.goto(
-    "/tests/history-browser.html?detail-paging=1&delay=500&growth-delay=180",
+    "/tests/history-browser.html?detail-paging=1&delay=10000&growth-delay=180",
   );
   const header = page.locator(".turn-process-head");
   await header.click();

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -42,9 +42,13 @@ import {
 } from "../src/history-browse.ts";
 import {
   acknowledgeCompletion,
+  acknowledgeMatchingCompletion,
+  catalogCompletionProjection,
+  completionAcknowledgementId,
   completionBadgeKind,
   discardBtwCompletionReceipts,
   markCompletionUnread,
+  newestCompletionProjection,
   rekeyCompletionReceipts,
 } from "../src/completion-badges.ts";
 import { imageDimensions } from "../src/img.ts";
@@ -71,6 +75,7 @@ import {
 } from "../src/cache.ts";
 import {
   boundRuntimeTurns,
+  MAX_RUNTIME_SESSIONS,
   MAX_RUNTIME_TURNS,
   pruneRuntimeMap,
 } from "../src/runtime-bounds.ts";
@@ -283,6 +288,15 @@ assert.equal(discoveredGoal.revealed, true,
   "an authoritative Goal must reveal itself on a new browser or device");
 assert.equal(discoveredGoal.preferences[goalScopeA]?.known, true,
   "Goal discovery must survive a refresh without requiring /goal");
+const remotelyDismissedGoal = reconcileGoalUiPreference(
+  {}, goalScopeOtherMachine, persistedGoal, 10, true);
+assert.equal(remotelyDismissedGoal.revealed, false,
+  "a server dismissal must hide the same Goal on a fresh device");
+assert.equal(
+  remotelyDismissedGoal.preferences[goalScopeOtherMachine]?.hiddenGoal,
+  goalStableIdentity(persistedGoal),
+  "the fresh device caches only the opaque local Goal fingerprint",
+);
 let goalPreferences = rememberGoalUi(discoveredGoal.preferences, goalScopeA, 10);
 let reconciledGoal = reconcileGoalUiPreference(
   goalPreferences, goalScopeA, persistedGoal, 11);
@@ -386,13 +400,107 @@ assert.ok(sessionActivityTime("1752746400000") > sessionActivityTime("1752746399
   "millisecond and second timestamps must share one ordering scale");
 
 let completionReceipts = markCompletionUnread(
-  {}, "parent-a", "parent-a", "main");
+  {}, "parent-a", "parent-a", "main", "turn-a");
 completionReceipts = markCompletionUnread(
   completionReceipts, "parent-a", "btw-a", "btw");
 completionReceipts = markCompletionUnread(
   completionReceipts, "parent-b", "btw-b", "btw");
 assert.equal(completionBadgeKind(completionReceipts["parent-a"]), "both");
 assert.equal(completionBadgeKind(completionReceipts["parent-b"]), "btw");
+assert.equal(completionBadgeKind(
+  { main: true, mainCompletionId: "turn-new", mainTurnEndSeq: 10,
+    mainTurnEndGeneration: "generation-1", btwSids: [] }, false), "main",
+  "a newer local completion remains visible while its authoritative frame is delayed");
+assert.equal(completionBadgeKind(
+  { main: false, mainCompletionId: null, mainTurnEndSeq: null,
+    mainTurnEndGeneration: null, btwSids: [] }, true), "main",
+  "an authoritative unread completion remains visible without a local fallback");
+assert.equal(completionAcknowledgementId(
+  completionReceipts["parent-a"], undefined), "turn-a",
+  "a missed completion_state can be acknowledged from its turn_end fallback");
+assert.equal(completionAcknowledgementId(
+  completionReceipts["parent-a"], { id: "turn-new", unread: true }),
+  "turn-new", "a newer authoritative completion wins over the fallback id");
+const newerLocalCompletion = markCompletionUnread(
+  {}, "catalog-race", "catalog-race", "main", "turn-new");
+const staleReadProjection = newestCompletionProjection(undefined, {
+  id: "turn-old", unread: false, revision: 2,
+});
+assert.equal(acknowledgeMatchingCompletion(
+  newerLocalCompletion, "catalog-race", staleReadProjection),
+newerLocalCompletion,
+"a delayed catalog acknowledgement cannot clear a newer local completion");
+assert.equal(acknowledgeMatchingCompletion(
+  newerLocalCompletion, "catalog-race",
+  { id: "turn-new", unread: false, revision: 4 },
+)["catalog-race"], undefined,
+"the matching authoritative read receipt clears its local fallback");
+const newerRuntimeProjection = newestCompletionProjection(
+  { id: "turn-new", unread: true, revision: 5 },
+  { id: "turn-old", unread: false, revision: 4 },
+);
+assert.equal(acknowledgeMatchingCompletion(
+  newerLocalCompletion, "catalog-race", newerRuntimeProjection),
+newerLocalCompletion,
+"runtime revision ordering rejects an older catalog acknowledgement");
+const firstIdentitylessLocalCompletion = markCompletionUnread(
+  {}, "identityless", "identityless", "main", null, 40, "generation-1");
+const identitylessLocalCompletion = markCompletionUnread(
+  firstIdentitylessLocalCompletion,
+  "identityless", "identityless", "main", null, 50, "generation-1",
+);
+assert.equal(
+  identitylessLocalCompletion.identityless.mainTurnEndSeq, 50,
+  "a second null-id completion advances its causal TurnEnd boundary",
+);
+assert.equal(acknowledgeMatchingCompletion(
+  identitylessLocalCompletion, "identityless",
+  { id: "generated-old", unread: false, revision: 3 },
+), identitylessLocalCompletion,
+"an unordered catalog receipt cannot clear a null-id local completion");
+assert.equal(acknowledgeMatchingCompletion(
+  identitylessLocalCompletion, "identityless",
+  { id: "generated-old", unread: false, revision: 3 },
+  { authoritativeSeq: 41, authoritativeGeneration: "generation-1" },
+), identitylessLocalCompletion,
+"an older ordered receipt cannot clear the next null-id completion");
+assert.equal(acknowledgeMatchingCompletion(
+  identitylessLocalCompletion, "identityless",
+  { id: "generated-new", unread: false, revision: 5 },
+  { authoritativeSeq: 51, authoritativeGeneration: "generation-2" },
+), identitylessLocalCompletion,
+"sequence numbers from another wrapper generation are not comparable");
+assert.equal(acknowledgeMatchingCompletion(
+  identitylessLocalCompletion, "identityless",
+  { id: "generated-new", unread: false, revision: 5 },
+  { authoritativeSeq: 51, authoritativeGeneration: "generation-1" },
+)["identityless"], undefined,
+"a causally later CompletionState clears a null-id local fallback");
+const identifiedLocalCompletion = markCompletionUnread(
+  {}, "cleared", "cleared", "main", "turn-cleared", 60, "generation-1");
+assert.equal(acknowledgeMatchingCompletion(
+  identifiedLocalCompletion, "cleared",
+  { id: null, unread: false, revision: 6 },
+), identifiedLocalCompletion,
+"an unordered catalog clear cannot remove an identified local completion");
+assert.equal(acknowledgeMatchingCompletion(
+  identifiedLocalCompletion, "cleared",
+  { id: null, unread: false, revision: 6 },
+  { authoritativeSeq: 59, authoritativeGeneration: "generation-1" },
+), identifiedLocalCompletion,
+"an older clear cannot remove the next identified local completion");
+assert.equal(acknowledgeMatchingCompletion(
+  identifiedLocalCompletion, "cleared",
+  { id: null, unread: false, revision: 6 },
+  { authoritativeSeq: 61, authoritativeGeneration: "generation-2" },
+), identifiedLocalCompletion,
+"a clear from another wrapper generation cannot remove a local completion");
+assert.equal(acknowledgeMatchingCompletion(
+  identifiedLocalCompletion, "cleared",
+  { id: null, unread: false, revision: 6 },
+  { authoritativeSeq: 61, authoritativeGeneration: "generation-1" },
+)["cleared"], undefined,
+"a causally later clear removes an identified local completion");
 completionReceipts = acknowledgeCompletion(
   completionReceipts, "parent-a", { main: true });
 assert.equal(completionBadgeKind(completionReceipts["parent-a"]), "btw",
@@ -405,15 +513,17 @@ completionReceipts = rekeyCompletionReceipts(
   completionReceipts, "parent-b", "parent-real");
 assert.equal(completionReceipts["parent-b"], undefined);
 assert.deepEqual(completionReceipts["parent-real"], {
-  main: false, btwSids: ["btw-b"],
+  main: false, mainCompletionId: null, mainTurnEndSeq: null,
+  mainTurnEndGeneration: null, btwSids: ["btw-b"],
 });
 completionReceipts = markCompletionUnread(
-  completionReceipts, "parent-main", "parent-main", "main");
+  completionReceipts, "parent-main", "parent-main", "main", "turn-main");
 completionReceipts = discardBtwCompletionReceipts(completionReceipts);
 assert.equal(completionReceipts["parent-real"], undefined,
   "a wrapper restart removes receipts for destroyed ephemeral BTW forks");
 assert.deepEqual(completionReceipts["parent-main"], {
-  main: true, btwSids: [],
+  main: true, mainCompletionId: "turn-main", mainTurnEndSeq: null,
+  mainTurnEndGeneration: null, btwSids: [],
 }, "main-session completion receipts survive a wrapper restart");
 
 const processTap = new PointerTapGuard(8);
@@ -1049,6 +1159,12 @@ assert.match(historyAppSource,
 assert.match(historyAppSource,
   /const completedGoalRequest = msg\.request_id[\s\S]{0,300}goalRecoveryRequestsRef\.current\.delete\([\s\S]{0,120}completedGoalRequest\.scopeKey/,
   "a successful Goal recovery must release its focus-scoped dedupe key");
+assert.match(historyAppSource,
+  /legacyDismissed[\s\S]{0,500}sendDismissGoalTo\(/,
+  "a device-local Goal dismissal must migrate into shared wrapper state");
+assert.match(historyAppSource,
+  /completionAcknowledgementId\([\s\S]{0,320}sendAcknowledgeCompletionTo\(/,
+  "viewing a completed session must acknowledge it through the wrapper");
 const codexGoalDescription = commandsFor("codex").flatMap((command) =>
   "slash" in command && command.slash === "goal" ? [command.ds] : [])[0] ?? "";
 assert.match(codexGoalDescription, /\/goal resume/,
@@ -3118,6 +3234,140 @@ try {
   } as ServerEvent);
   assert.equal(createRuntime().sendMode, "steer",
     "Codex running input uses steer mode by default");
+  let desktopCompletion = reduce(initialState, {
+    type: "event",
+    event: event({
+      type: "completion_state",
+      sid: "shared-completion",
+      completion_id: "turn-1",
+      unread: true,
+      revision: 1,
+    }),
+  });
+  let phoneCompletion = reduce(initialState, {
+    type: "event",
+    event: event({
+      type: "completion_state",
+      sid: "shared-completion",
+      completion_id: "turn-1",
+      unread: true,
+      revision: 1,
+    }),
+  });
+  const sharedAcknowledgement = event({
+    type: "completion_state",
+    sid: "shared-completion",
+    completion_id: "turn-1",
+    unread: false,
+    revision: 2,
+  });
+  desktopCompletion = reduce(desktopCompletion, {
+    type: "event", event: sharedAcknowledgement,
+  });
+  phoneCompletion = reduce(phoneCompletion, {
+    type: "event", event: sharedAcknowledgement,
+  });
+  assert.equal(
+    desktopCompletion.runtimes["shared-completion"].completion?.unread,
+    false,
+  );
+  assert.equal(
+    phoneCompletion.runtimes["shared-completion"].completion?.unread,
+    false,
+    "one authoritative acknowledgement clears every browser projection",
+  );
+  const staleCompletion = reduce(phoneCompletion, {
+    type: "event",
+    event: event({
+      type: "completion_state",
+      sid: "shared-completion",
+      completion_id: "turn-1",
+      unread: true,
+      revision: 1,
+    }),
+  });
+  assert.equal(
+    staleCompletion.runtimes["shared-completion"].completion?.unread,
+    false,
+    "a replayed old unread receipt cannot resurrect a cleared badge",
+  );
+  const coldCatalogRepair = reduce(phoneCompletion, {
+    type: "event",
+    event: event({
+      type: "session_list",
+      engine: "codex",
+      space: "code",
+      sessions: [{
+        session_id: "shared-completion",
+        completion_id: "turn-1",
+        completion_unread: false,
+        completion_revision: 3,
+      }],
+    }),
+  });
+  assert.equal(
+    coldCatalogRepair.runtimes["shared-completion"].completion?.revision,
+    3,
+    "a cold catalog repairs a browser which missed the live acknowledgement",
+  );
+  const coldUnreadCatalog = reduce(initialState, {
+    type: "event",
+    event: event({
+      type: "session_list",
+      engine: "claude",
+      space: "code",
+      sessions: [{
+        session_id: "cold-unread",
+        completion_id: "turn-cold",
+        completion_unread: true,
+        completion_revision: 1,
+      }],
+    }),
+  });
+  assert.equal(
+    coldUnreadCatalog.runtimes["cold-unread"],
+    undefined,
+    "a cold receipt must not allocate an otherwise empty runtime",
+  );
+  assert.equal(
+    newestCompletionProjection(
+      undefined,
+      catalogCompletionProjection(coldUnreadCatalog.sessions.find(
+        (session: { session_id: string }) => (
+          session.session_id === "cold-unread"))),
+    )?.unread,
+    true,
+    "an unread cold session must be visible before it is resumed",
+  );
+  const manyColdCatalog = reduce(initialState, {
+    type: "event",
+    event: event({
+      type: "session_list",
+      engine: "claude",
+      space: "code",
+      sessions: Array.from(
+        { length: MAX_RUNTIME_SESSIONS + 5 },
+        (_, index) => ({
+          session_id: `cold-unread-${index}`,
+          completion_id: `turn-cold-${index}`,
+          completion_unread: true,
+          completion_revision: 1,
+        }),
+      ),
+    }),
+  });
+  const prunedColdCatalog = reduce(manyColdCatalog, {
+    type: "prune_runtimes", protectedSids: [],
+  });
+  assert.equal(Object.keys(prunedColdCatalog.runtimes).length, 0);
+  assert.equal(prunedColdCatalog.sessions.filter((session: {
+    completion_id?: string | null;
+    completion_unread?: boolean | null;
+    completion_revision?: number | null;
+  }) => (
+    catalogCompletionProjection(session)?.unread === true
+  )).length, MAX_RUNTIME_SESSIONS + 5,
+    "pruning cannot hide durable cold completion receipts from the sidebar");
   const migrationOwner = {
     scopeKey: "machine:code:codex",
     machineId: "machine",

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -123,6 +123,7 @@ import type {
   ServerEvent,
   SessionList,
   SessionControl,
+  ThreadGoal,
 } from "../src/protocol.ts";
 import type { Block, Turn } from "../src/reducer.ts";
 import { clampPanelWidth, resolveSidebarSwipe } from "../src/responsive-layout.ts";
@@ -157,6 +158,13 @@ import {
 } from "../src/composer-submit.ts";
 import { workContextMetrics } from "../src/work-context.ts";
 import { processBlocks } from "../src/process-blocks.ts";
+import {
+  completedGoalHasNewerUserTurn,
+  latestPlanProgress,
+  planFollowsCompletedGoal,
+  planProgressPresentation,
+  SessionPlanProgressCache,
+} from "../src/plan-progress.ts";
 import { PointerTapGuard } from "../src/pointer-tap.ts";
 import {
   cacheSkillCatalog,
@@ -1038,6 +1046,9 @@ assert.deepEqual(matchCommands("pla", "codex", "work"), []);
 assert.match(historyAppSource,
   /command\.kind === "resume"[\s\S]{0,300}focusedEngine === "codex"[\s\S]{0,160}sendSetGoal\(null, "active", null\)/,
   "Codex /goal resume must reactivate the existing Goal without replacing its objective");
+assert.match(historyAppSource,
+  /const completedGoalRequest = msg\.request_id[\s\S]{0,300}goalRecoveryRequestsRef\.current\.delete\([\s\S]{0,120}completedGoalRequest\.scopeKey/,
+  "a successful Goal recovery must release its focus-scoped dedupe key");
 const codexGoalDescription = commandsFor("codex").flatMap((command) =>
   "slash" in command && command.slash === "goal" ? [command.ds] : [])[0] ?? "";
 assert.match(codexGoalDescription, /\/goal resume/,
@@ -13391,26 +13402,339 @@ try {
   ));
   assert.match(failedLoadedPageMarkup, /role="alert"/,
     "a later detail-page failure remains visible after the first page loaded");
+  const planOnlyBlock: Block = {
+    kind: "process",
+    item_id: "plan-only",
+    processKind: "plan",
+    phase: "end",
+    status: "succeeded",
+    title: "执行计划",
+    plan: [{ step: "检查实现", status: "completed" }],
+    done: true,
+  };
   const planOnlyMarkup = renderToStaticMarkup(createElement(ProcessTimeline, {
     engine: "codex",
     done: true,
     openOverride: true,
-    blocks: [{
-      kind: "process",
-      item_id: "plan-only",
-      processKind: "plan",
-      phase: "end",
-      status: "succeeded",
-      title: "执行计划",
-      plan: [{ step: "检查实现", status: "completed" }],
-      done: true,
-    }],
+    blocks: [planOnlyBlock],
   }));
   assert.match(planOnlyMarkup, /plan-progress-trigger/,
     "a plan-only timeline keeps the compact plan control");
   assert.doesNotMatch(planOnlyMarkup, /turn-process-head/,
     "a plan-only timeline does not advertise an empty outer disclosure");
   assert.doesNotMatch(planOnlyMarkup, />1 项</);
+  const externalPlanOnlyMarkup = renderToStaticMarkup(createElement(
+    ProcessTimeline, {
+      engine: "codex",
+      done: true,
+      blocks: [planOnlyBlock],
+      externalPlanItemId: "plan-only",
+    },
+  ));
+  assert.equal(externalPlanOnlyMarkup, "",
+    "the session-level strip removes its plan control from the message row");
+
+  const restoredPlan = latestPlanProgress([{
+    id: "restored-plan-turn",
+    prompt: "执行任务",
+    done: false,
+    detailEventCount: 4,
+    detailLoaded: false,
+    blocks: [{
+      kind: "process",
+      item_id: "legacy-plan",
+      processKind: "plan",
+      phase: "end",
+      status: "succeeded",
+      title: "旧计划",
+      detail: "旧版自由文本计划",
+      done: true,
+    }],
+    detailProjection: {
+      segments: [], capped: false, hasMore: false,
+      oldestCursor: null, hasNewer: false, newerCursor: null,
+      blocks: [{
+        kind: "process",
+        item_id: "structured-plan",
+        processKind: "plan",
+        phase: "update",
+        status: "running",
+        title: "计划",
+        plan: [
+          { step: "读取状态", status: "completed" },
+          { step: "显示固定入口", status: "inProgress" },
+        ],
+        done: false,
+      }],
+    },
+  }]);
+  assert.equal(restoredPlan?.block.item_id, "structured-plan",
+    "the fixed strip reads the authoritative structured plan projection");
+  assert.equal(restoredPlan?.needsDetail, true,
+    "opening a cached fixed strip still requests authoritative detail");
+  assert.equal(planProgressPresentation(restoredPlan!.block).progressLabel,
+    "1 / 2");
+  assert.equal(latestPlanProgress([{
+    id: "planned-turn", prompt: "先规划", done: true,
+    blocks: [planOnlyBlock],
+  }, {
+    id: "compact-continuation", prompt: "", done: true,
+    terminalSource: "compact_continuation", blocks: [],
+  }])?.block.item_id, "plan-only",
+  "a promptless assistant or compaction continuation preserves a completed Plan");
+  assert.equal(latestPlanProgress([{
+    id: "planned-turn", prompt: "先规划", done: true,
+    blocks: [planOnlyBlock],
+  }, {
+    id: "new-turn", prompt: "新的无计划问题", done: false, blocks: [],
+  }]), null,
+  "the next user turn retires a completed task monitor");
+  const completedGoal: ThreadGoal = {
+    threadId: "completed-goal-thread",
+    objective: "完成旧任务",
+    status: "complete",
+    engine: "codex",
+    tokensUsed: 10,
+    timeUsedSeconds: 20,
+    updatedAt: 1_800_000_000,
+  };
+  const oldGoalPlan = latestPlanProgress([{
+    id: "old-goal-plan-turn",
+    prompt: "执行旧 Goal",
+    done: false,
+    ts: 1_799_999_990_000,
+    blocks: [planOnlyBlock],
+  }]);
+  const nextGoalPlan = latestPlanProgress([{
+    id: "next-plan-turn",
+    prompt: "开始新任务",
+    done: false,
+    ts: 1_800_000_001_000,
+    blocks: [{ ...planOnlyBlock, item_id: "next-plan" }],
+  }]);
+  assert.equal(completedGoalHasNewerUserTurn(completedGoal, [{
+    id: "goal-assistant-continuation", prompt: "", done: true,
+    ts: 1_800_000_001_000, blocks: [],
+  }]), false, "assistant-only Goal continuation cannot retire its Goal");
+  assert.equal(completedGoalHasNewerUserTurn(completedGoal, [{
+    id: "next-goal-user-turn", prompt: "开始新任务", done: false,
+    ts: 1_800_000_001_000, blocks: [],
+  }]), true, "the first later user turn retires a completed Goal");
+  assert.equal(completedGoalHasNewerUserTurn(completedGoal, [{
+    id: "next-goal-image-turn", prompt: "", done: false,
+    ts: 1_800_000_001_000, blocks: [],
+    images: [{ media_type: "image/png", data: "image" }],
+  }]), true, "an image-only user turn retires a completed Goal");
+  assert.equal(completedGoalHasNewerUserTurn(completedGoal, [{
+    id: "next-goal-image-ref-turn", prompt: "", done: false,
+    ts: 1_800_000_001_000, blocks: [],
+    imageRefs: [{
+      image_id: "image-ref", media_type: "image/png",
+      width: 1, height: 1, byte_size: 1,
+    }],
+  }]), true, "a history image-only user turn retires a completed Goal");
+  assert.equal(completedGoalHasNewerUserTurn(completedGoal, [{
+    id: "next-goal-file-turn", prompt: "", done: false,
+    ts: 1_800_000_001_000, blocks: [],
+    files: [{ filename: "task.txt", data: "task" }],
+  }]), true, "a file-only user turn retires a completed Goal");
+  assert.equal(planFollowsCompletedGoal(completedGoal, oldGoalPlan!), false,
+    "the Goal's own Plan stays attached after completion");
+  assert.equal(planFollowsCompletedGoal(completedGoal, nextGoalPlan!), true,
+    "a later user turn's Plan is independent from the completed Goal");
+  const reboundOldGoalPlan = latestPlanProgress([{
+    id: "next-plan-turn",
+    prompt: "开始新任务",
+    done: false,
+    ts: 1_800_000_001_000,
+    blocks: [{
+      ...planOnlyBlock,
+      item_id: "rebound-old-plan",
+      turn_id: "old-goal-plan-turn",
+    }],
+  }]);
+  assert.equal(
+    planFollowsCompletedGoal(completedGoal, reboundOldGoalPlan!), false,
+    "a durable old-Goal snapshot rebound onto the newest turn stays retired",
+  );
+  const activePlanBlock: Block = {
+    ...planOnlyBlock,
+    item_id: "active-plan",
+    phase: "update",
+    status: "running",
+    plan: [
+      { step: "检查实现", status: "completed" },
+      { step: "完成验证", status: "inProgress" },
+    ],
+    done: false,
+  };
+  assert.equal(latestPlanProgress([{
+    id: "active-plan-turn", prompt: "继续任务", done: false,
+    blocks: [activePlanBlock],
+  }, {
+    id: "active-follow-up", prompt: "补充要求", done: false, blocks: [],
+  }])?.turnId, "active-plan-turn",
+  "a follow-up does not hide an unfinished task monitor");
+  assert.equal(latestPlanProgress([{
+    id: "older-plan", prompt: "旧任务", done: true,
+    blocks: [planOnlyBlock],
+  }, {
+    id: "newer-plan", prompt: "新任务", done: false,
+    blocks: [{ ...planOnlyBlock, item_id: "newer-plan-item" }],
+  }])?.turnId, "newer-plan",
+  "the newest plan-bearing turn wins when a session contains several plans");
+  const planCache = new SessionPlanProgressCache(4);
+  const planOwnerAfterDetail: Turn = {
+    id: restoredPlan!.turnId,
+    prompt: "执行任务",
+    done: false,
+    detailEventCount: 4,
+    detailLoaded: true,
+    // The official full-turn projection omits update_plan.
+    blocks: [],
+  };
+  assert.equal(planCache.resolve({
+    sid: "plan-session-a",
+    runtime: restoredPlan,
+    history: null,
+    runtimeTurns: [planOwnerAfterDetail],
+    historyTurns: [planOwnerAfterDetail],
+    recovering: false,
+    runtimeLoading: false,
+  })?.block.item_id, "structured-plan");
+  assert.equal(planCache.resolve({
+    sid: "plan-session-b",
+    runtime: null,
+    history: null,
+    runtimeTurns: [],
+    historyTurns: [],
+    recovering: false,
+    runtimeLoading: false,
+  }), null, "a plan from session A must never leak into session B");
+  const refocusedPlan = planCache.resolve({
+    sid: "plan-session-a",
+    runtime: null,
+    history: null,
+    runtimeTurns: [planOwnerAfterDetail],
+    historyTurns: [planOwnerAfterDetail],
+    recovering: false,
+    runtimeLoading: false,
+  });
+  assert.equal(refocusedPlan?.block.item_id, "structured-plan",
+    "A -> B -> A navigation retains the Plan omitted by full turn detail");
+  assert.equal(planProgressPresentation(refocusedPlan!.block).progressLabel,
+    "1 / 2");
+  assert.equal(refocusedPlan?.needsDetail, false,
+    "the retained Plan follows its owner's current detail state");
+  const completedPlanCache = new SessionPlanProgressCache(2);
+  const completedPlanOwner: Turn = {
+    id: "completed-plan-turn",
+    prompt: "完成计划",
+    done: true,
+    blocks: [planOnlyBlock],
+  };
+  const completedPlan = latestPlanProgress([completedPlanOwner]);
+  assert.ok(completedPlan);
+  assert.equal(completedPlanCache.resolve({
+    sid: "completed-plan-session",
+    runtime: completedPlan,
+    history: null,
+    runtimeTurns: [completedPlanOwner],
+    historyTurns: [completedPlanOwner],
+    recovering: false,
+    runtimeLoading: false,
+  })?.block.item_id, "plan-only",
+  "a completed Plan stays visible before the next user message");
+  const nextUserTurn: Turn = {
+    id: "next-user-turn",
+    prompt: "开始下一个问题",
+    done: false,
+    blocks: [],
+  };
+  assert.equal(completedPlanCache.resolve({
+    sid: "completed-plan-session",
+    runtime: latestPlanProgress([completedPlanOwner, nextUserTurn]),
+    history: null,
+    runtimeTurns: [completedPlanOwner, nextUserTurn],
+    historyTurns: [completedPlanOwner, nextUserTurn],
+    recovering: false,
+    runtimeLoading: false,
+  }), null,
+  "the cache cannot resurrect a completed Plan after the next message");
+  const browsedCompletedPlanCache = new SessionPlanProgressCache(2);
+  assert.equal(browsedCompletedPlanCache.resolve({
+    sid: "browsed-completed-plan",
+    runtime: null,
+    history: completedPlan,
+    runtimeTurns: [{
+      id: "live-next-user-turn",
+      prompt: "实时的新任务",
+      done: false,
+      ts: 2_000,
+      blocks: [],
+    }],
+    historyTurns: [{ ...completedPlanOwner, ts: 1_000 }],
+    recovering: false,
+    runtimeLoading: false,
+  }), null,
+  "a live user turn retires a completed Plan found on an older history page");
+  assert.equal(browsedCompletedPlanCache.resolve({
+    sid: "browsed-promptless-plan",
+    runtime: null,
+    history: completedPlan,
+    runtimeTurns: [{
+      id: "live-promptless-continuation",
+      prompt: "",
+      done: true,
+      ts: 2_000,
+      terminalSource: "compact_continuation",
+      blocks: [],
+    }],
+    historyTurns: [{ ...completedPlanOwner, ts: 1_000 }],
+    recovering: false,
+    runtimeLoading: false,
+  })?.block.item_id, "plan-only",
+  "a live promptless continuation preserves a browsed completed Plan");
+  assert.equal(planCache.resolve({
+    sid: "plan-session-a",
+    runtime: null,
+    history: null,
+    runtimeTurns: [],
+    historyTurns: [],
+    recovering: false,
+    runtimeLoading: true,
+  })?.block.item_id, "structured-plan",
+  "runtime eviction keeps the Plan visible while authoritative history reloads");
+  planCache.clear("plan-session-a");
+  assert.equal(planCache.resolve({
+    sid: "plan-session-a",
+    runtime: null,
+    history: null,
+    runtimeTurns: [planOwnerAfterDetail],
+    historyTurns: [planOwnerAfterDetail],
+    recovering: false,
+    runtimeLoading: false,
+  }), null, "history invalidation clears a stale retained Plan");
+  planCache.resolve({
+    sid: "tmp-plan-session",
+    runtime: restoredPlan,
+    history: null,
+    runtimeTurns: [planOwnerAfterDetail],
+    historyTurns: [planOwnerAfterDetail],
+    recovering: false,
+    runtimeLoading: false,
+  });
+  planCache.rekey("tmp-plan-session", "real-plan-session");
+  assert.equal(planCache.resolve({
+    sid: "real-plan-session",
+    runtime: null,
+    history: null,
+    runtimeTurns: [planOwnerAfterDetail],
+    historyTurns: [planOwnerAfterDetail],
+    recovering: false,
+    runtimeLoading: false,
+  })?.block.item_id, "structured-plan",
+  "capturing a real session id preserves the temporary session's Plan");
   const declinedMarkup = renderToStaticMarkup(createElement(ProcessTimeline, {
     blocks: [{ kind: "process", item_id: "approval-denied", processKind: "hook",
       phase: "end", status: "declined", title: "Hook 已拒绝", done: false }],
@@ -15340,8 +15664,11 @@ assert.equal(
 const appSource = readFileSync(resolve(process.cwd(), "src/App.tsx"), "utf8");
 assert.doesNotMatch(appSource, /<Suspense fallback=\{null\}>[\s\S]{0,120}<GoalPanel/,
   "Goal lazy loading must keep a stable chip placeholder");
-assert.match(appSource, /fallback=\{\(goalUi\?\.revealed \|\| goalUi\?\.open\)[\s\S]{0,160}goal-suspense/,
-  "a remembered Goal entry stays visible while its component chunk loads");
+assert.match(appSource,
+  /fallback=\{\(\(goalUi\?\.revealed && !completedGoalRetired\)[\s\S]{0,120}\|\| goalUi\?\.open \|\| planProgress\)[\s\S]{0,180}goal-suspense/,
+  "a remembered non-retired Goal or current Plan stays visible while its component chunk loads");
+assert.match(appSource, /externalPlanProgress=\{planProgress/,
+  "the session strip must explicitly take ownership from the message row");
 assert.match(appSource, /recoverableReads\.retry\(\["goal", key\]/,
   "a transient Goal read failure must be retried in the same connection");
 assert.doesNotMatch(appSource,


### PR DESCRIPTION
## Summary

This PR makes session Plan progress and presentation acknowledgements durable and consistent across browsers.

- Persist the latest Codex Plan snapshot in bounded wrapper-owned storage so it survives session switches, browser reconnects, and wrapper restarts.
- Surface active Plan progress in a compact session strip or inside the matching Goal detail, and retire completed Plan/Goal state at the next user-turn boundary.
- Move main-session completion acknowledgements and exact Goal-generation dismissals into wrapper-owned state so an action in one browser is reflected by every connected browser without hiding a newer replacement.
- Upgrade the coordinated Wrapper/Relay/Web wire protocol to v34 for the new presentation commands and snapshot fields on top of the latest v33 upstream protocol.
- Make the asynchronous history-browser coverage deterministic by explicitly controlling gesture, availability, and loading-state windows.
- Defer optional Plan and `/btw` panels so the rebased feature remains within the production startup bundle budget.

## Behavior and safety

- Both private stores are atomic and bounded, validate persisted shapes and identifiers, and follow session rekey, migration, and deletion lifecycles.
- Plan history is restored from the wrapper local projection without resuming the engine or creating a model turn.
- Completion and Goal receipts carry exact identities and monotonic revisions, so delayed acknowledgements cannot clear a newer completion or dismiss a replacement Goal.
- Retried Goal dismissals recompute against the current generation instead of replaying a cached state, so a replacement Goal cannot be hidden after a lost acknowledgement.
- Text, inline-image, persisted-image-reference, and file-only submissions all establish the next user-turn boundary for retiring a completed Goal.
- Completed Plans survive promptless assistant and compaction continuations, and retire only after a later turn contains actual user content.
- Replayed owner boundaries preserve completed Plans across browser, history, and native Codex turn identifiers by consulting the same-generation `TurnBinding`.
- A completed Plan found while browsing older history is also checked against newer live turns, so history navigation cannot resurrect progress from a superseded task.
- Completed Plan snapshots without a provable owner are never rebound to the latest history turn; only unfinished turnless Plans may use that fallback.
- Fresh snapshots and live broadcasts use the same authoritative wrapper state, keeping reconnect and multi-browser behavior aligned.
- Multi-account Codex session keys use the upstream profile-aware routing identity for every Plan and presentation read/write.
- A local `turn_end` fallback retains its exact completion identity, so viewing the session can acknowledge durable wrapper state even if the following `completion_state` frame was delayed or lost.
- Delayed catalog or read acknowledgements clear a local completion fallback only when the authoritative identity and newest revision still match it.
- Null-ID `turn_end` fallbacks use same-generation wire ordering to accept a later generated completion ID without allowing unordered catalog rows to clear them.
- Ordered same-generation completion clears also remove local fallbacks when `completion_id` is null, while unordered, older, and cross-generation clears remain inert.
- Cold unread completion receipts render directly from the bounded session catalog, so runtime pruning cannot hide them or defeat the browser runtime limit.

## Testing

- `.venv/bin/python -m pytest` — 1,751 passed, 2 skipped.
- `uvx --from ruff==0.15.13 ruff check cc_remote tests deploy` — passed.
- `npm --prefix web run build` — passed; startup entry is 512.9 KiB against the 514 KiB budget.
- `npm --prefix web run test:reliability` — passed.
- `npm --prefix web run test:history-browser` — 220 passed, 20 expected platform skips.
- `npm --prefix web run lint` — passed.
- Deployment script `bash -n`, `shellcheck -x`, and `git diff --check` — passed.
