### PR TITLE
fix(plan): reconcile progress lifecycle

### DIFF
--- a/web/src/plan-progress.ts
+++ b/web/src/plan-progress.ts
@@ -82,7 +82,7 @@ export class SessionPlanProgressCache {
     if (selected) {
       const selectedTurns = runtime ? runtimeTurns : historyTurns;
       const newerTurns = runtime ? [] : runtimeTurns;
-      if (completedPlanHasNewerTurn(
+      if (terminalPlanHasNewerTurn(
         selected, selectedTurns, newerTurns)) {
         this.entries.delete(sid);
         return null;
@@ -105,7 +105,7 @@ export class SessionPlanProgressCache {
     const owner = turns.find((turn) => turnOwnsProgress(
       turn, retained.turnId));
     const newerTurns = retained.source === "history" ? runtimeTurns : [];
-    if (owner && completedPlanHasNewerTurn(
+    if (owner && terminalPlanHasNewerTurn(
       retained, turns, newerTurns)) {
       this.entries.delete(sid);
       return null;
@@ -146,7 +146,8 @@ export class SessionPlanProgressCache {
  * Codex records a task plan on the turn which created it, while later steer or
  * follow-up turns can continue an unfinished task without repeating that plan.
  * Search turns newest-first so old sessions keep their latest active monitor,
- * but retire a completed Plan as soon as the next user turn begins.
+ * but retire a completed or negatively terminated Plan as soon as the next
+ * user turn begins.
  */
 export function latestPlanProgress(
   turns: readonly Turn[],
@@ -154,7 +155,7 @@ export function latestPlanProgress(
   for (let index = turns.length - 1; index >= 0; index--) {
     const progress = turnPlanProgress(turns[index]);
     if (!progress) continue;
-    return completedPlanHasNewerTurn(progress, turns) ? null : progress;
+    return terminalPlanHasNewerTurn(progress, turns) ? null : progress;
   }
   return null;
 }
@@ -202,12 +203,16 @@ export function planFollowsCompletedGoal(
     && progress.ownerMatchesTurn !== false;
 }
 
-function completedPlanHasNewerTurn(
+function terminalPlanHasNewerTurn(
   progress: TurnPlanProgress,
   turns: readonly Turn[],
   newerTurns: readonly Turn[] = [],
 ): boolean {
-  if (!planProgressPresentation(progress.block).complete) return false;
+  const presentation = planProgressPresentation(progress.block);
+  // An active unfinished Plan may span clarification turns. A negative
+  // terminal belongs to the interrupted attempt, though: keep it visible until
+  // acknowledged by the next user message, then wait for that turn's own Plan.
+  if (!presentation.complete && !presentation.failed) return false;
   const ownerIndex = turns.findIndex((turn) =>
     turnOwnsProgress(turn, progress.turnId));
   if (ownerIndex >= 0
@@ -225,30 +230,70 @@ function completedPlanHasNewerTurn(
     && (ownerStartedAt == null || turn.ts == null || turn.ts > ownerStartedAt));
 }
 
+const PLAN_STEP_RANK = {
+  pending: 0,
+  inProgress: 1,
+  completed: 2,
+} as const;
+
+/** Prove that one snapshot advances the same plan without guessing by source.
+ *
+ * Detail can race the live stream in either direction: a late response may be
+ * stale, while a completed detail page may be newer than a retained live tail.
+ * Only identical step structure gives us a safe monotonic comparison.
+ */
+function planSnapshotAdvances(
+  candidate: ProcessBlock,
+  baseline: ProcessBlock,
+): boolean {
+  if (!candidate.plan || !baseline.plan
+      || candidate.plan.length !== baseline.plan.length) return false;
+  let advanced = false;
+  for (let index = 0; index < candidate.plan.length; index += 1) {
+    const next = candidate.plan[index];
+    const previous = baseline.plan[index];
+    if (next.step !== previous.step) return false;
+    const nextRank = PLAN_STEP_RANK[next.status];
+    const previousRank = PLAN_STEP_RANK[previous.status];
+    if (nextRank < previousRank) return false;
+    if (nextRank > previousRank) advanced = true;
+  }
+  return advanced;
+}
+
 function turnPlanProgress(turn: Turn): TurnPlanProgress | null {
   const preferCompletedDetail = turn.done
     && !turn.detailRestorePending && !turn.detailRestoreIncomplete;
   const plansOnly = (blocks: readonly Block[]) =>
     blocks.filter((block): block is ProcessBlock =>
       block.kind === "process" && block.processKind === "plan");
-  const withArchive = mergeDetailWithLiveTail(
-    plansOnly(turn.detailProjection?.blocks ?? []),
+  const detailPlans = plansOnly(turn.detailProjection?.blocks ?? []);
+  const livePlans = plansOnly(mergeDetailWithLiveTail(
     plansOnly(turn.liveSpillBlocks ?? []),
-    preferCompletedDetail,
-  );
-  const blocks = mergeDetailWithLiveTail(
-    withArchive,
     plansOnly(turn.blocks),
+  ));
+  const blocks = plansOnly(mergeDetailWithLiveTail(
+    detailPlans,
+    livePlans,
     preferCompletedDetail,
-  );
+  ));
   // Match ProcessTimeline: prefer the newest structured update, while still
   // supporting older app-server records which only contain free-form detail.
-  const block = [...blocks].reverse().find((candidate) =>
+  const mergedBlock = [...blocks].reverse().find((candidate) =>
     candidate.kind === "process" && candidate.plan != null) ?? blocks.at(-1);
-  if (!block) return null;
-  // plansOnly() makes every merged block a ProcessBlock. Keep the narrowing
-  // explicit at this module boundary so future merge helpers can stay generic.
-  if (block.kind !== "process") return null;
+  if (!mergedBlock) return null;
+  let block = mergedBlock;
+  const detailSnapshot = [...detailPlans].reverse().find((candidate) =>
+    candidate.item_id === block.item_id && candidate.plan != null);
+  const liveSnapshot = [...livePlans].reverse().find((candidate) =>
+    candidate.item_id === block.item_id && candidate.plan != null);
+  if (detailSnapshot && liveSnapshot) {
+    if (planSnapshotAdvances(liveSnapshot, detailSnapshot)) {
+      block = liveSnapshot;
+    } else if (planSnapshotAdvances(detailSnapshot, liveSnapshot)) {
+      block = detailSnapshot;
+    }
+  }
   return {
     turnId: turn.id,
     block,

--- a/web/tests/history-browser.fixture.tsx
+++ b/web/tests/history-browser.fixture.tsx
@@ -1965,7 +1965,9 @@ export function HistoryBrowserFixture() {
   const planUi = params.get("plan-ui");
   if (params.has("profile-sidebar")) return <ProfileSidebarFixture />;
   if (planUi) return <PlanUiFixture mode={planUi} />;
-  if (params.has("plan-lifecycle")) return <PlanLifecycleFixture />;
+  if (params.has("plan-lifecycle")) {
+    return <PlanLifecycleFixture mode={params.get("plan-lifecycle") ?? ""} />;
+  }
   if (params.has("goal-ui")) {
     return <GoalUiFixture status={params.get("goal-status")}
       withPlan={params.has("plan")} hidden={params.has("goal-hidden")}
@@ -2058,21 +2060,23 @@ function ProfileSidebarFixture() {
   );
 }
 
-function PlanLifecycleFixture() {
+function PlanLifecycleFixture({ mode }: { mode: string }) {
+  const interrupted = mode === "interrupted";
   const [turns, setTurns] = useState<Turn[]>(() => [{
-    id: "completed-plan-turn",
-    prompt: "完成当前任务",
+    id: interrupted ? "interrupted-plan-turn" : "completed-plan-turn",
+    prompt: interrupted ? "执行后终止" : "完成当前任务",
     done: true,
+    interrupted: interrupted || undefined,
     blocks: [{
       kind: "process",
-      item_id: "completed-plan-item",
+      item_id: interrupted ? "interrupted-plan-item" : "completed-plan-item",
       processKind: "plan",
       phase: "end",
-      status: "succeeded",
+      status: interrupted ? "interrupted" : "succeeded",
       title: "计划",
       plan: [
         { step: "实现功能", status: "completed" },
-        { step: "完成验证", status: "completed" },
+        { step: "完成验证", status: interrupted ? "inProgress" : "completed" },
       ],
       done: true,
     }],

--- a/web/tests/history-browser.spec.ts
+++ b/web/tests/history-browser.spec.ts
@@ -3170,6 +3170,19 @@ test("a completed session Plan disappears when the next message begins", async (
   await expect(chip).toHaveCount(0);
 });
 
+test("an interrupted session Plan disappears when the next message begins", async ({
+  page,
+}) => {
+  await page.goto("/tests/history-browser.html?plan-lifecycle=interrupted");
+  const chip = page.getByRole("button", { name: /查看计划进度/ });
+  await expect(chip).toBeVisible();
+  await expect(chip.locator(".plan-chip-ring.failed")).toHaveCount(1);
+  await expect(chip).toContainText("1 / 2");
+
+  await page.getByTestId("send-next-plan-message").click();
+  await expect(chip).toHaveCount(0);
+});
+
 test("an existing Goal owns the turn plan in its detail sheet", async ({
   page,
 }) => {

--- a/web/tests/reliability.test.ts
+++ b/web/tests/reliability.test.ts
@@ -13825,6 +13825,59 @@ try {
     id: "active-follow-up", prompt: "补充要求", done: false, blocks: [],
   }])?.turnId, "active-plan-turn",
   "a follow-up does not hide an unfinished task monitor");
+  const interruptedPlanBlock: Block = {
+    ...activePlanBlock,
+    item_id: "interrupted-plan",
+    status: "interrupted",
+    done: true,
+  };
+  const interruptedPlanOwner: Turn = {
+    id: "interrupted-plan-turn",
+    prompt: "执行后终止",
+    done: true,
+    interrupted: true,
+    blocks: [interruptedPlanBlock],
+  };
+  assert.equal(planProgressPresentation(
+    latestPlanProgress([interruptedPlanOwner])!.block).failed, true,
+  "an interrupted Plan remains visible until the next user turn");
+  assert.equal(latestPlanProgress([interruptedPlanOwner, {
+    id: "interrupt-system-tail", prompt: "", done: true, blocks: [],
+  }])?.turnId, "interrupted-plan-turn",
+  "a promptless continuation cannot acknowledge an interrupted Plan");
+  const afterInterruptedPlan: Turn = {
+    id: "after-interrupted-plan",
+    prompt: "按新要求继续",
+    done: false,
+    blocks: [],
+  };
+  assert.equal(latestPlanProgress([
+    interruptedPlanOwner, afterInterruptedPlan,
+  ]), null,
+  "the next user turn retires the previous interrupted Plan");
+  const interruptedPlanCache = new SessionPlanProgressCache(2);
+  const interruptedProgress = latestPlanProgress([interruptedPlanOwner]);
+  assert.equal(interruptedPlanCache.resolve({
+    sid: "interrupted-plan-session",
+    runtime: interruptedProgress,
+    history: null,
+    runtimeTurns: [interruptedPlanOwner],
+    historyTurns: [interruptedPlanOwner],
+    recovering: false,
+    runtimeLoading: false,
+  })?.block.item_id, "interrupted-plan");
+  assert.equal(interruptedPlanCache.resolve({
+    sid: "interrupted-plan-session",
+    runtime: latestPlanProgress([
+      interruptedPlanOwner, afterInterruptedPlan,
+    ]),
+    history: null,
+    runtimeTurns: [interruptedPlanOwner, afterInterruptedPlan],
+    historyTurns: [interruptedPlanOwner, afterInterruptedPlan],
+    recovering: false,
+    runtimeLoading: false,
+  }), null,
+  "the retained cache cannot resurrect an acknowledged interrupted Plan");
   assert.equal(latestPlanProgress([{
     id: "older-plan", prompt: "旧任务", done: true,
     blocks: [planOnlyBlock],
@@ -13876,6 +13929,67 @@ try {
     "1 / 2");
   assert.equal(refocusedPlan?.needsDetail, false,
     "the retained Plan follows its owner's current detail state");
+  const newerLivePlan: Block = {
+    kind: "process", item_id: "shared-plan", processKind: "plan",
+    phase: "snapshot", status: "succeeded", title: "计划", done: true,
+    plan: [
+      { step: "读取状态", status: "completed" },
+      { step: "修复问题", status: "completed" },
+      { step: "完成验证", status: "inProgress" },
+    ],
+  };
+  const staleDetailPlan: Block = {
+    ...newerLivePlan,
+    plan: [
+      { step: "读取状态", status: "completed" },
+      { step: "修复问题", status: "inProgress" },
+      { step: "完成验证", status: "pending" },
+    ],
+  };
+  for (const location of ["blocks", "liveSpillBlocks"] as const) {
+    const livePlanAfterStaleDetail = latestPlanProgress([{
+      id: `late-plan-detail-${location}`,
+      prompt: "执行任务",
+      done: true,
+      blocks: location === "blocks" ? [newerLivePlan] : [],
+      liveSpillBlocks: location === "liveSpillBlocks"
+        ? [newerLivePlan] : undefined,
+      detailProjection: {
+        segments: [], capped: false, hasMore: false,
+        oldestCursor: null, hasNewer: false, newerCursor: null,
+        blocks: [staleDetailPlan],
+      },
+    }]);
+    assert.equal(planProgressPresentation(
+      livePlanAfterStaleDetail!.block).progressLabel, "2 / 3",
+    `a late detail cannot roll back the Plan in ${location}`);
+    assert.equal(planProgressPresentation(
+      livePlanAfterStaleDetail!.block).currentStep, "完成验证");
+  }
+  const completedDetailPlan: Block = {
+    ...staleDetailPlan,
+    plan: [
+      { step: "读取状态", status: "completed" },
+      { step: "修复问题", status: "completed" },
+      { step: "完成验证", status: "completed" },
+    ],
+  };
+  const completedDetailAfterStaleLive = latestPlanProgress([{
+    id: "completed-detail-after-stale-live",
+    prompt: "执行任务",
+    done: true,
+    blocks: [staleDetailPlan],
+    detailProjection: {
+      segments: [], capped: false, hasMore: false,
+      oldestCursor: null, hasNewer: false, newerCursor: null,
+      blocks: [completedDetailPlan],
+    },
+  }]);
+  assert.equal(planProgressPresentation(
+    completedDetailAfterStaleLive!.block).progressLabel, "3 / 3",
+  "completed detail cannot be rolled back by an older live snapshot");
+  assert.equal(planProgressPresentation(
+    completedDetailAfterStaleLive!.block).complete, true);
   const completedPlanCache = new SessionPlanProgressCache(2);
   const completedPlanOwner: Turn = {
     id: "completed-plan-turn",


### PR DESCRIPTION
## Summary

- reconcile racing detail and live Plan snapshots without fixed source precedence
- accept a snapshot override only when identical ordered steps advance monotonically
- retire completed or negatively terminated Plans when the next user turn begins
- preserve active unfinished Plans across clarification turns and promptless continuations
- prevent the per-session Plan cache from resurrecting a retired monitor

## Root causes

Turn detail hydration and live `turn/plan/updated` delivery can finish in either
order. Fixed source precedence therefore caused one of two regressions: a late
stale detail response could freeze an advancing Plan, or a retained stale live
snapshot could roll a completed detail Plan backward.

Separately, the presentation selector retired only completed Plans on the next
user turn. Interrupt handling correctly marked an open Plan as `interrupted`,
but that negative terminal was then treated like active unfinished work and
remained red throughout later turns unless Codex emitted another Plan.

## Behavior

- Matching structured snapshots are compared by monotonic step status. A source
  wins only when every identical step is at least as advanced and one progressed.
- Completed and failed/interrupted/cancelled/declined Plans remain visible until
  the next user message, then retire before that turn publishes its own Plan.
- Active unfinished Plans still survive clarification turns as before.
- Promptless assistant or compaction continuations do not dismiss a Plan.

## Testing

- `env -u ANTHROPIC_MODEL .venv/bin/python -m pytest` (1751 passed, 2 skipped)
- `uvx --from ruff==0.15.13 ruff check cc_remote tests deploy`
- `npm --prefix web run build`
- `npm --prefix web run test:reliability`
- `npm --prefix web run test:history-browser` (222 passed, 20 skipped)
- `npm --prefix web run lint`
- deployment script `bash -n` and `shellcheck -x` gates
- `git diff --check`

`ANTHROPIC_MODEL` is unset for pytest to match GitHub CI because the local
shell exports an alternate Claude provider model.
