### PR TITLE
fix(codex): retire ghost sessions and preserve failed turns

### DIFF
--- a/cc_remote/wrapper/codex_external.py
+++ b/cc_remote/wrapper/codex_external.py
@@ -967,7 +967,7 @@ def parse_turn_markers(data: bytes, partial: bytes = b"") -> TurnMarkers:
             reason = str(payload.get("reason") or "").lower()
             status = (
                 "completed"
-                if kind == "task_complete"
+                if kind == "task_complete" and payload.get("error") is None
                 else "interrupted"
                 if kind == "task_cancelled" or (
                     kind == "turn_aborted"

--- a/cc_remote/wrapper/codex_lifecycle.py
+++ b/cc_remote/wrapper/codex_lifecycle.py
@@ -28,7 +28,9 @@ from typing import Callable, Iterable
 from cc_remote.protocol import CodexTerminalFence
 
 
-_SCHEMA_VERSION = 1
+# v1 could persist task_complete(error=...) as a successful terminal.
+# Rebuild these source-derived fences instead of replaying a false success.
+_SCHEMA_VERSION = 2
 _FILENAME = "codex-terminal-ledger.json"
 _SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$")
 _MAX_FILE_BYTES = 2 * 1024 * 1024

--- a/cc_remote/wrapper/codex_sessions.py
+++ b/cc_remote/wrapper/codex_sessions.py
@@ -378,6 +378,48 @@ def codex_session_presence(
     return row is not None
 
 
+def codex_session_confirmed_missing(
+    session_id: str,
+    *,
+    codex_home: str | os.PathLike[str] | None = None,
+) -> bool:
+    """Prove absence from both the readable catalog and rollout roots.
+
+    A truncated listing, locked DB, unreadable directory, or symlink is not
+    evidence of deletion. Do not use the best-effort history glob for this.
+    """
+    home = _codex_home(codex_home)
+    if codex_session_presence(session_id, codex_home=home) is not False:
+        return False
+    scanned = 0
+
+    def failed_scan(error: OSError) -> None:
+        raise error
+
+    try:
+        for root in _session_roots(home):
+            try:
+                mode = os.lstat(root).st_mode
+            except FileNotFoundError:
+                continue
+            if not stat.S_ISDIR(mode):
+                return False
+            for directory, dirs, files in os.walk(root, onerror=failed_scan):
+                scanned += 1 + len(dirs) + len(files)
+                if scanned > 100_000:
+                    return False
+                if any(os.path.islink(os.path.join(directory, name))
+                       for name in dirs):
+                    return False
+                if any(session_id in name and name.endswith(".jsonl")
+                       for name in files):
+                    return False
+    except OSError:
+        return False
+    # A create/archive transaction may have committed while scanning.
+    return codex_session_presence(session_id, codex_home=home) is False
+
+
 def codex_thread_archive_states(
     session_ids: Iterable[str],
     *,

--- a/cc_remote/wrapper/codex_stream.py
+++ b/cc_remote/wrapper/codex_stream.py
@@ -2768,6 +2768,8 @@ class CodexStreamTranslator:
             self._close_open(out)
             turn = p.get("turn") or {}
             st = turn.get("status") or "completed"
+            if st == "completed" and turn.get("error") is not None:
+                st = "failed"
             # A failed turn may carry provider diagnostics in turn.error. Keep
             # those on the local engine boundary and emit only stable product
             # copy (the error notification above may not fire for every mode).
@@ -3220,6 +3222,11 @@ _RATE_LIMIT_TURN_FAILURE = "请求过于频繁或当前额度受限，请稍后�
 _TIMEOUT_TURN_FAILURE = "请求超时，请重新尝试。"
 _UPSTREAM_TURN_FAILURE = "Codex 上游服务暂时不可用，请稍后重试。"
 _NETWORK_TURN_FAILURE = "网络连接异常，请检查网络后重试。"
+_POLICY_TURN_FAILURE = (
+    "上游模型因安全策略拒绝了本次请求（cyber_policy）。"
+    "这不是本地权限或网络错误；请核实并说明任务背景与授权范围，"
+    "若属误判请向服务提供方反馈。"
+)
 
 
 def _provider_failure_message(error: object) -> str:
@@ -3233,6 +3240,12 @@ def _provider_failure_message(error: object) -> str:
         else ""
     )
     combined = f"{message} {details}"[:8192].lower()
+    info = error.get("codexErrorInfo", error.get("codex_error_info"))
+    if info in ("cyberPolicy", "cyber_policy") or (
+        isinstance(info, dict)
+        and ("cyberPolicy" in info or "cyber_policy" in info)
+    ):
+        return _POLICY_TURN_FAILURE
     status = _structured_http_status(error)
     if status is None:
         status_match = re.search(r"\b([45]\d\d)\b", combined)
@@ -4903,8 +4916,18 @@ def codex_translate_history(
                         turn_visible = True
                         turn_text_visible = True
                         turn_final_visible = True
-                    emit_completed_plan_answer(line_no, raw_ts)
-                    if turn_visible:
+                    terminal_error = p.get("error")
+                    if terminal_error is None:
+                        emit_completed_plan_answer(line_no, raw_ts)
+                    if terminal_error is not None:
+                        events.append(Error(
+                            code=ERR_CC_CRASH,
+                            message=_provider_failure_message(terminal_error),
+                            msg_id=active_msg_id,
+                        ))
+                        close_turn("error", _duration(p), True,
+                                   _completed_ts(p, ts), p.get("turn_id"))
+                    elif turn_visible:
                         close_turn("success", _duration(p), False,
                                    _completed_ts(p, ts), p.get("turn_id"))
                     else:

--- a/cc_remote/wrapper/history_store.py
+++ b/cc_remote/wrapper/history_store.py
@@ -55,7 +55,9 @@ from cc_remote.protocol import ConversationTurn
 # v30 rebuilds Codex narrative rows with bounded generated-image references.
 # Binary assets and other engines' projections remain source-valid.
 # v31 rebuilds Codex failures previously cached as successful task_complete.
-_SCHEMA_VERSION = 31
+# v32 restores reviewed policy-refusal copy previously reduced to a generic
+# failure. Only Codex narrative projections need to be rebuilt.
+_SCHEMA_VERSION = 32
 _FINGERPRINT_SAMPLE_BYTES = 64 * 1024
 _DEFAULT_MAX_ENTRIES = 128
 _DEFAULT_MAX_BYTES = 64 * 1024 * 1024
@@ -125,6 +127,9 @@ _SAFE_HISTORY_TURN_FAILURES = frozenset({
     "请求过于频繁或当前额度受限，请稍后重试。",
     "请求超时，请重新尝试。",
     "Codex 上游服务暂时不可用，请稍后重试。",
+    "上游模型因安全策略拒绝了本次请求（cyber_policy）。"
+    "这不是本地权限或网络错误；请核实并说明任务背景与授权范围，"
+    "若属误判请向服务提供方反馈。",
 })
 _LEGACY_HISTORY_TURN_FAILURES = {
     "Codex 登录已失效或当前账号无权限，请重新登录后重试。":
@@ -1246,7 +1251,7 @@ class HistoryIndexStore:
     def _ensure_schema(self) -> None:
         with self._connect() as connection:
             current = int(connection.execute("PRAGMA user_version").fetchone()[0])
-            if current in range(10, 31):
+            if current in range(10, 32):
                 for table in ("history_pages", "history_turn_details"):
                     connection.execute(
                         f"DELETE FROM {table} WHERE engine='codex'")
@@ -1327,8 +1332,8 @@ class HistoryIndexStore:
                 for table in ("history_pages", "history_turn_details"):
                     connection.execute(
                         f"DELETE FROM {table} WHERE engine='codex'")
-            elif current in (21, 22, 23, 24, 25, 26, 27, 28, 29, 30):
-                # The independent v22-v31 invalidations above suffice.
+            elif current in (21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31):
+                # The independent v22-v32 invalidations above suffice.
                 pass
             elif current not in (0, _SCHEMA_VERSION):
                 # v9 changes the invariant of history_turn_details: those rows

--- a/cc_remote/wrapper/history_store.py
+++ b/cc_remote/wrapper/history_store.py
@@ -54,7 +54,8 @@ from cc_remote.protocol import ConversationTurn
 # without phase metadata. Source-complete details and binary assets remain valid.
 # v30 rebuilds Codex narrative rows with bounded generated-image references.
 # Binary assets and other engines' projections remain source-valid.
-_SCHEMA_VERSION = 30
+# v31 rebuilds Codex failures previously cached as successful task_complete.
+_SCHEMA_VERSION = 31
 _FINGERPRINT_SAMPLE_BYTES = 64 * 1024
 _DEFAULT_MAX_ENTRIES = 128
 _DEFAULT_MAX_BYTES = 64 * 1024 * 1024
@@ -1245,7 +1246,7 @@ class HistoryIndexStore:
     def _ensure_schema(self) -> None:
         with self._connect() as connection:
             current = int(connection.execute("PRAGMA user_version").fetchone()[0])
-            if current in range(10, 30):
+            if current in range(10, 31):
                 for table in ("history_pages", "history_turn_details"):
                     connection.execute(
                         f"DELETE FROM {table} WHERE engine='codex'")
@@ -1326,8 +1327,8 @@ class HistoryIndexStore:
                 for table in ("history_pages", "history_turn_details"):
                     connection.execute(
                         f"DELETE FROM {table} WHERE engine='codex'")
-            elif current in (21, 22, 23, 24, 25, 26, 27, 28, 29):
-                # The independent v22-v30 invalidations above suffice.
+            elif current in (21, 22, 23, 24, 25, 26, 27, 28, 29, 30):
+                # The independent v22-v31 invalidations above suffice.
                 pass
             elif current not in (0, _SCHEMA_VERSION):
                 # v9 changes the invariant of history_turn_details: those rows

--- a/cc_remote/wrapper/machine.py
+++ b/cc_remote/wrapper/machine.py
@@ -315,7 +315,8 @@ from cc_remote.wrapper.codex_sessions import (
     CODEX_EXACT_CATALOG_MAX_IDS,
     list_codex_sessions, codex_exact_catalog_rows, codex_session_cwd,
     codex_rollout_path, codex_model, codex_effort, codex_session_settings,
-    codex_session_presence, codex_current_provider,
+    codex_session_presence, codex_session_confirmed_missing,
+    codex_current_provider,
     codex_thread_archive_states, codex_thread_catalog_row,
     codex_thread_parent_maps, codex_thread_rollout_record,
 )
@@ -25853,7 +25854,7 @@ class WrapperMachine:
                 for row in normalized
                 if isinstance(row.get("native_session_id"), str)
             }
-            for ctx in self.sessions.values():
+            for ctx in tuple(self.sessions.values()):
                 if (
                     ctx.engine != "codex"
                     or ctx.btw
@@ -25877,6 +25878,8 @@ class WrapperMachine:
                         existing["summary"] = title
                     if title and not existing.get("first_prompt"):
                         existing["first_prompt"] = title
+                    continue
+                if await self._prune_missing_codex_context(ctx):
                     continue
                 try:
                     rollout_path = self._codex_rollout_for_wire(wire_sid)
@@ -29893,6 +29896,118 @@ class WrapperMachine:
         async with self._conversation_tree_mutation_lock(engine, sid):
             return await self._handle_delete_session_locked(cmd)
 
+    async def _prune_missing_codex_context(
+        self, ctx: SessionContext,
+    ) -> bool:
+        """Retire an idle orphan, never resume a missing native thread.
+
+        List omission alone is not proof: protect in-flight/queued turns,
+        unmaterialized live threads, and unavailable native state. This path
+        only forgets private projections; it never deletes native data.
+        """
+        if (ctx.engine != "codex" or ctx.space != "code" or ctx.btw
+                or not ctx.session_id or not self._is_resident_context(ctx)
+                or self._session_delete_busy(ctx)
+                or ctx.query_lock.locked()
+                or not callable(getattr(ctx.sdk, "disconnect", None))):
+            return False
+        profile = self._codex_profile_for_ctx(ctx)
+        native_sid = ctx.session_id
+        sid = self._codex_wire_sid(profile, native_sid)
+        home = self._codex_home(profile)
+        async with ctx.query_lock:
+            if (not self._is_resident_context(ctx)
+                    or self._session_delete_busy(ctx)):
+                return False
+            if not await asyncio.to_thread(
+                codex_session_confirmed_missing, native_sid, codex_home=home,
+            ):
+                return False
+            proc = getattr(ctx.sdk, "proc", None)
+            if proc is not None and proc.returncode is None:
+                # An idle native thread may not have materialized a rollout
+                # yet. A live handle must affirm exact absence, not merely
+                # time out or return a provider/auth error.
+                try:
+                    await asyncio.wait_for(
+                        ctx.sdk.read_thread_parent(native_sid), timeout=5,
+                    )
+                except CodexAppServerError as exc:
+                    if exc.code != -32600 or exc.message not in {
+                        f"thread not found: {native_sid}",
+                        f"no rollout found for thread id {native_sid}",
+                    }:
+                        return False
+                except Exception:
+                    return False
+                else:
+                    return False
+            if (self._session_delete_busy(ctx)
+                    or not await asyncio.to_thread(
+                        codex_session_confirmed_missing,
+                        native_sid, codex_home=home,
+                    )):
+                return False
+            try:
+                intent = await asyncio.to_thread(
+                    self._codex_forks.begin_delete, sid)
+            except ForkJournalError:
+                return False
+            self.sessions.pop(ctx.key, None)
+            if self.focused_sid in {ctx.key, sid}:
+                self.focused_sid = None
+            self._watch.pop(sid, None)
+            self._codex_sidebar_watches.pop(sid, None)
+            self._codex_thread_started_hints.pop((profile.id, native_sid), None)
+            self._notification_titles.pop(sid, None)
+            self._invalidate_codex_session_catalog()
+            try:
+                await ctx.sdk.disconnect()
+            except Exception as exc:
+                log.warning("orphan Codex proxy cleanup failed",
+                            session_id=sid, error_type=type(exc).__name__)
+            await self._cleanup_codex_steer_attachments(ctx)
+            await self._cleanup_deleted_codex_checkpoint(ctx, sid)
+            try:
+                await asyncio.to_thread(self._codex_turn_leases.release, sid)
+            except Exception as exc:
+                log.warning("orphan Codex lease cleanup failed",
+                            session_id=sid, error_type=type(exc).__name__)
+            self._purge_preview_image_snapshots(ctx.preview_snapshot_token)
+            self._invalidate_session_history(ctx, sid)
+            await self._drop_preview_session("codex", sid)
+            for store, args in (
+                (self._codex_controls, (sid,)),
+                (self._session_plans, (sid,)),
+                (self._session_presentation, ("codex", sid)),
+            ):
+                if store is not None:
+                    try:
+                        await asyncio.to_thread(store.delete, *args)
+                    except Exception as exc:
+                        log.warning("orphan Codex projection cleanup failed",
+                                    session_id=sid,
+                                    error_type=type(exc).__name__)
+            if self._session_pins is not None:
+                try:
+                    await asyncio.to_thread(
+                        self._session_pins.set_pinned, "codex", sid, False)
+                except SessionPinStoreError:
+                    log.warning("orphan Codex pin cleanup failed",
+                                session_id=sid)
+            if intent is not None:
+                try:
+                    await asyncio.to_thread(
+                        self._codex_forks.finish_delete, sid)
+                except ForkJournalError:
+                    # The pending tombstone still prevents fork replay.
+                    log.warning("orphan Codex tombstone finalization failed",
+                                session_id=sid)
+        # All browsers refresh, not only the tab that clicked Delete.
+        await self._invalidate_session_list("codex", "code")
+        log.info("removed missing Codex resident", session_id=sid)
+        return True
+
     async def _handle_delete_session_locked(self, cmd):
         """Delete one native session without confusing Code and Work roots."""
         sid = self._resolve_session_alias(cmd.session_id) or cmd.session_id
@@ -29976,6 +30091,10 @@ class WrapperMachine:
                 **({} if home is None else {"codex_home": home}),
             )
             if rollout_record is None:
+                resident = self._ctx_by_sid(sid)
+                if (resident is not None
+                        and await self._prune_missing_codex_context(resident)):
+                    return await self._handle_list_sessions(cmd)
                 return await self._send_code_delete_error(
                     cmd,
                     sid,

--- a/cc_remote/wrapper/machine.py
+++ b/cc_remote/wrapper/machine.py
@@ -486,6 +486,9 @@ def _codex_terminal_status(message: dict) -> str:
     params = message.get("params")
     turn = params.get("turn") if isinstance(params, dict) else None
     status = turn.get("status") if isinstance(turn, dict) else None
+    if isinstance(turn, dict) and turn.get("error") is not None:
+        if not status or status == "completed":
+            return "failed"
     return status if isinstance(status, str) and status else "completed"
 
 

--- a/cc_remote/wrapper/machine.py
+++ b/cc_remote/wrapper/machine.py
@@ -29951,12 +29951,33 @@ class WrapperMachine:
                         native_sid, codex_home=home,
                     )):
                 return False
-            try:
-                intent = await asyncio.to_thread(
-                    self._codex_forks.begin_delete, sid)
-            except ForkJournalError:
-                return False
-            self.sessions.pop(ctx.key, None)
+            # Queue submissions use emit_lock -> queued_query_lock, not
+            # query_lock. Let them run during the scans, then atomically either
+            # preserve accepted work or retire the context before a new submit
+            # can pass its residency check. Keep journal I/O in this boundary.
+            async with ctx.emit_lock:
+                async with ctx.queued_query_lock:
+                    if (not self._is_resident_context(ctx)
+                            or self._session_delete_busy(ctx)):
+                        return False
+                    try:
+                        intent = await asyncio.to_thread(
+                            self._codex_forks.begin_delete, sid)
+                    except ForkJournalError:
+                        return False
+                    # A native client can become active during journal I/O.
+                    if (not self._is_resident_context(ctx)
+                            or self._session_delete_busy(ctx)):
+                        if intent == "delete_pending":
+                            try:
+                                await asyncio.to_thread(
+                                    self._codex_forks.abort_delete, sid)
+                            except ForkJournalError:
+                                log.warning(
+                                    "orphan Codex tombstone rollback failed",
+                                    session_id=sid)
+                        return False
+                    self.sessions.pop(ctx.key, None)
             if self.focused_sid in {ctx.key, sid}:
                 self.focused_sid = None
             self._watch.pop(sid, None)

--- a/cc_remote/wrapper/machine.py
+++ b/cc_remote/wrapper/machine.py
@@ -29927,6 +29927,18 @@ class WrapperMachine:
             ):
                 return False
             proc = getattr(ctx.sdk, "proc", None)
+
+            def shared_probe_stale() -> bool:
+                # A proxy exit is not proof that the shared daemon lost its
+                # thread. Keep exact-absence evidence bound to this live proxy
+                # through the final retirement boundary.
+                return self._codex_shared_affinity(ctx) and (
+                    proc is None or proc.returncode is not None
+                    or getattr(ctx.sdk, "proc", None) is not proc
+                )
+
+            if shared_probe_stale():
+                return False
             if proc is not None and proc.returncode is None:
                 # An idle native thread may not have materialized a rollout
                 # yet. A live handle must affirm exact absence, not merely
@@ -29946,6 +29958,7 @@ class WrapperMachine:
                 else:
                     return False
             if (self._session_delete_busy(ctx)
+                    or shared_probe_stale()
                     or not await asyncio.to_thread(
                         codex_session_confirmed_missing,
                         native_sid, codex_home=home,
@@ -29958,7 +29971,8 @@ class WrapperMachine:
             async with ctx.emit_lock:
                 async with ctx.queued_query_lock:
                     if (not self._is_resident_context(ctx)
-                            or self._session_delete_busy(ctx)):
+                            or self._session_delete_busy(ctx)
+                            or shared_probe_stale()):
                         return False
                     try:
                         intent = await asyncio.to_thread(
@@ -29967,7 +29981,8 @@ class WrapperMachine:
                         return False
                     # A native client can become active during journal I/O.
                     if (not self._is_resident_context(ctx)
-                            or self._session_delete_busy(ctx)):
+                            or self._session_delete_busy(ctx)
+                            or shared_probe_stale()):
                         if intent == "delete_pending":
                             try:
                                 await asyncio.to_thread(

--- a/tests/test_codex_lifecycle.py
+++ b/tests/test_codex_lifecycle.py
@@ -42,6 +42,22 @@ def test_persistent_terminal_survives_restart_and_append(tmp_path):
     ) == (_fence("turn-1", duration_ms=42),)
 
 
+def test_legacy_success_fences_are_rebuilt_after_error_semantics_change(tmp_path):
+    rollout = tmp_path / "rollout.jsonl"
+    rollout.write_bytes(b'{"type":"task_complete","error":{}}\n')
+    ledger = CodexTerminalLedger(tmp_path)
+    ledger.persist("session-1", _fence("turn-1"), rollout)
+    raw = json.loads(ledger.path.read_text())
+    raw["version"] = 1
+    ledger.path.write_text(json.dumps(raw))
+    restarted = CodexTerminalLedger(tmp_path)
+    assert restarted.snapshot("session-1", rollout, revision="a" * 32) == ()
+    restarted.persist("session-1", _fence("turn-1", "failed"), rollout)
+    assert restarted.snapshot(
+        "session-1", rollout, revision="a" * 32,
+    ) == (_fence("turn-1", "failed"),)
+
+
 def test_terminal_witness_rejects_truncate_rotate_and_rollback(tmp_path):
     rollout = tmp_path / "rollout.jsonl"
     original = b"prefix\nterminal-boundary\n"

--- a/tests/test_codex_missing_sessions.py
+++ b/tests/test_codex_missing_sessions.py
@@ -150,6 +150,7 @@ async def test_loaded_or_uncertain_native_thread_is_retained(
 @pytest.mark.asyncio
 async def test_live_handle_must_confirm_exact_missing_identity(monkeypatch):
     machine, _, ctx = _resident(monkeypatch)
+    ctx.sdk.shared_daemon_affinity = True
     ctx.sdk.proc = SimpleNamespace(returncode=None)
     ctx.sdk.read_thread_parent.side_effect = CodexAppServerError({
         "code": -32600, "message": f"no rollout found for thread id {SID}",
@@ -283,3 +284,70 @@ async def test_native_activity_during_retirement_preserves_fork_replay(monkeypat
     assert machine.sessions[SID] is ctx
     abort.assert_awaited_once_with(SID)
     ctx.sdk.disconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("proxy", [None, "exited"])
+async def test_shared_session_survives_proxy_reconnect_gap(monkeypatch, proxy):
+    machine, _, ctx = _resident(monkeypatch)
+    ctx.sdk.shared_daemon_affinity = True
+    ctx.sdk.proc = None if proxy is None else SimpleNamespace(returncode=1)
+    machine._notification_titles[SID] = "keep shared session"
+    assert not await machine._prune_missing_codex_context(ctx)
+    assert machine.sessions[SID] is ctx
+    assert machine.focused_sid == SID
+    assert machine._notification_titles[SID] == "keep shared session"
+    ctx.sdk.disconnect.assert_not_awaited()
+    ctx.sdk.read_thread_parent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["probe", "scan", "journal"])
+@pytest.mark.parametrize("replacement", [False, True])
+async def test_shared_proxy_change_invalidates_orphan_retirement(
+    monkeypatch, boundary, replacement,
+):
+    machine, _, ctx = _resident(monkeypatch)
+    ctx.sdk.shared_daemon_affinity = True
+    ctx.sdk.proc = SimpleNamespace(returncode=None)
+    original_to_thread = asyncio.to_thread
+    missing = machine_module.codex_session_confirmed_missing
+    begin = machine._codex_forks.begin_delete
+    abort = machine._codex_forks.abort_delete = AsyncMock()
+    scans = 0
+
+    def restart_proxy():
+        if replacement:
+            ctx.sdk.proc = SimpleNamespace(returncode=None)
+        else:
+            ctx.sdk.proc.returncode = 1
+
+    async def read_thread(thread_id):
+        if boundary == "probe":
+            restart_proxy()
+        raise CodexAppServerError({
+            "code": -32600, "message": f"thread not found: {thread_id}",
+        })
+
+    async def restart_at_boundary(function, *args, **kwargs):
+        nonlocal scans
+        if function is missing:
+            scans += 1
+            if boundary == "scan" and scans == 2:
+                restart_proxy()
+        if function == begin and boundary == "journal":
+            restart_proxy()
+            return "delete_pending"
+        if function is abort:
+            return await abort(*args, **kwargs)
+        return await original_to_thread(function, *args, **kwargs)
+
+    ctx.sdk.read_thread_parent.side_effect = read_thread
+    monkeypatch.setattr(machine_module.asyncio, "to_thread", restart_at_boundary)
+    assert not await machine._prune_missing_codex_context(ctx)
+    assert machine.sessions[SID] is ctx
+    ctx.sdk.disconnect.assert_not_awaited()
+    if boundary == "journal":
+        abort.assert_awaited_once_with(SID)
+    else:
+        abort.assert_not_awaited()

--- a/tests/test_codex_missing_sessions.py
+++ b/tests/test_codex_missing_sessions.py
@@ -1,0 +1,182 @@
+"""Missing catalog rows must not resurrect idle wrapper-only sessions."""
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cc_remote.protocol import DeleteSession, SessionListInvalidated
+from cc_remote.wrapper import codex_sessions, machine as machine_module
+from cc_remote.wrapper.codex_handle import CodexAppServerError
+from tests.test_multisession import _mk_ctx, _mk_machine
+
+
+SID = "11111111-1111-4111-8111-111111111111"
+
+
+def _home(tmp_path):
+    home = tmp_path / "codex"
+    home.mkdir()
+    with sqlite3.connect(home / "state_5.sqlite") as db:
+        db.execute("CREATE TABLE threads (id TEXT PRIMARY KEY)")
+    return home
+
+
+def test_confirm_missing_requires_readable_db_and_both_rollout_roots(tmp_path):
+    home = _home(tmp_path)
+    missing = codex_sessions.codex_session_confirmed_missing
+    assert missing(SID, codex_home=home)
+    for root in ("sessions", "archived_sessions"):
+        folder = home / root / "2026"
+        folder.mkdir(parents=True)
+        path = folder / f"rollout-{SID}.jsonl"
+        path.write_text("{}\n")
+        assert not missing(SID, codex_home=home)
+        path.unlink()
+    with sqlite3.connect(home / "state_5.sqlite") as db:
+        db.execute("INSERT INTO threads VALUES (?)", (SID,))
+    assert not missing(SID, codex_home=home)
+
+
+def test_missing_or_corrupt_db_cannot_prove_deletion(tmp_path):
+    assert not codex_sessions.codex_session_confirmed_missing(
+        SID, codex_home=tmp_path)
+    (tmp_path / "state_5.sqlite").write_bytes(b"not sqlite")
+    assert not codex_sessions.codex_session_confirmed_missing(
+        SID, codex_home=tmp_path)
+
+
+def test_environment_home_is_used_for_both_db_and_rollout(
+    tmp_path, monkeypatch,
+):
+    home = _home(tmp_path)
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    (home / "sessions").mkdir()
+    (home / "sessions" / f"rollout-{SID}.jsonl").write_text("{}\n")
+    assert not codex_sessions.codex_session_confirmed_missing(SID)
+
+
+def test_failed_or_symlinked_scan_cannot_prove_deletion(tmp_path, monkeypatch):
+    home = _home(tmp_path)
+    (home / "sessions").mkdir()
+    (home / "sessions" / "linked").symlink_to(tmp_path)
+    assert not codex_sessions.codex_session_confirmed_missing(
+        SID, codex_home=home)
+    (home / "sessions" / "linked").unlink()
+
+    def denied(*args, **kwargs):
+        raise PermissionError("cannot inspect root")
+
+    monkeypatch.setattr(codex_sessions.os, "walk", denied)
+    assert not codex_sessions.codex_session_confirmed_missing(
+        SID, codex_home=home)
+
+
+def _resident(monkeypatch):
+    machine, transport = _mk_machine()
+    ctx = _mk_ctx(SID, SID)
+    ctx.engine = "codex"
+    ctx.codex_checkpoint = False
+    ctx.sdk = SimpleNamespace(
+        proc=None, disconnect=AsyncMock(), read_thread_parent=AsyncMock(),
+        turn_active=False, turn_start_pending=False,
+    )
+    machine.sessions[SID] = ctx
+    machine.focused_sid = SID
+    monkeypatch.setattr(machine_module, "codex_session_confirmed_missing",
+                        lambda *args, **kwargs: True)
+    return machine, transport, ctx
+
+
+@pytest.mark.asyncio
+async def test_deleted_resident_is_evicted_and_all_clients_invalidated(
+    monkeypatch,
+):
+    machine, transport, ctx = _resident(monkeypatch)
+    machine._watch[SID] = object()
+    machine._notification_titles[SID] = "orphan"
+    healthy = _mk_ctx("healthy", "healthy")
+    machine.sessions["healthy"] = healthy
+    assert await machine._prune_missing_codex_context(ctx)
+    assert SID not in machine.sessions
+    assert machine.sessions["healthy"] is healthy
+    assert machine.focused_sid is None
+    assert SID not in machine._watch
+    assert SID not in machine._notification_titles
+    ctx.sdk.disconnect.assert_awaited_once()
+    ctx.sdk.read_thread_parent.assert_not_awaited()
+    hints = [e for e in transport.sent if isinstance(e, SessionListInvalidated)]
+    assert len(hints) == 1 and hints[0].to is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("protected", ["running", "turn", "pending", "queued"])
+async def test_busy_or_queued_orphan_is_never_pruned(monkeypatch, protected):
+    machine, _, ctx = _resident(monkeypatch)
+    if protected == "running":
+        ctx.state = "running"
+    elif protected == "turn":
+        ctx.sdk.turn_active = True
+    elif protected == "pending":
+        ctx.sdk.turn_start_pending = True
+    else:
+        monkeypatch.setattr(machine, "_session_has_deferred_query_ownership",
+                            lambda candidate: candidate is ctx)
+    assert not await machine._prune_missing_codex_context(ctx)
+    assert machine.sessions[SID] is ctx
+    ctx.sdk.disconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [None, RuntimeError("timeout"),
+                                  CodexAppServerError({
+                                      "code": -32600, "message": "unauthorized",
+                                  })])
+async def test_loaded_or_uncertain_native_thread_is_retained(
+    monkeypatch, error,
+):
+    machine, _, ctx = _resident(monkeypatch)
+    ctx.sdk.proc = SimpleNamespace(returncode=None)
+    ctx.sdk.read_thread_parent.side_effect = error
+    assert not await machine._prune_missing_codex_context(ctx)
+    assert machine.sessions[SID] is ctx
+
+
+@pytest.mark.asyncio
+async def test_live_handle_must_confirm_exact_missing_identity(monkeypatch):
+    machine, _, ctx = _resident(monkeypatch)
+    ctx.sdk.proc = SimpleNamespace(returncode=None)
+    ctx.sdk.read_thread_parent.side_effect = CodexAppServerError({
+        "code": -32600, "message": f"no rollout found for thread id {SID}",
+    })
+    assert await machine._prune_missing_codex_context(ctx)
+
+
+@pytest.mark.asyncio
+async def test_delete_orphan_never_attempts_resume_or_native_delete(
+    monkeypatch,
+):
+    machine, _, ctx = _resident(monkeypatch)
+    machine._cold_codex_delete_context = AsyncMock(
+        side_effect=AssertionError("must not resume"))
+    machine._handle_list_sessions = AsyncMock()
+    await machine._handle_delete_session(DeleteSession(
+        session_id=SID, engine="codex", space="code", client_id="browser-a",
+    ))
+    assert SID not in machine.sessions
+    machine._cold_codex_delete_context.assert_not_awaited()
+    machine._handle_list_sessions.assert_awaited_once()
+    ctx.sdk.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_overlay_deleted_resident(monkeypatch):
+    machine, _, ctx = _resident(monkeypatch)
+    monkeypatch.setattr(machine_module, "list_codex_sessions",
+                        AsyncMock(return_value=[]))
+    rows, _ = await machine._read_codex_profile_catalog()
+    assert all(row["native_session_id"] != SID for row in rows)
+    assert SID not in machine.sessions
+    ctx.sdk.disconnect.assert_awaited_once()

--- a/tests/test_codex_missing_sessions.py
+++ b/tests/test_codex_missing_sessions.py
@@ -1,13 +1,16 @@
 """Missing catalog rows must not resurrect idle wrapper-only sessions."""
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
-from cc_remote.protocol import DeleteSession, SessionListInvalidated
+from cc_remote.protocol import (
+    CommandAck, DeleteSession, Error, Query, SessionListInvalidated,
+)
 from cc_remote.wrapper import codex_sessions, machine as machine_module
 from cc_remote.wrapper.codex_handle import CodexAppServerError
 from tests.test_multisession import _mk_ctx, _mk_machine
@@ -180,3 +183,103 @@ async def test_refresh_does_not_overlay_deleted_resident(monkeypatch):
     assert all(row["native_session_id"] != SID for row in rows)
     assert SID not in machine.sessions
     ctx.sdk.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["scan", "journal"])
+@pytest.mark.parametrize("delivery", ["queue", "replace"])
+async def test_queue_submission_and_orphan_retirement_are_atomic(
+    monkeypatch, boundary, delivery,
+):
+    machine, transport, ctx = _resident(monkeypatch)
+    paused, resume, submitting = (
+        asyncio.Event(), asyncio.Event(), asyncio.Event())
+    to_thread = asyncio.to_thread
+    missing = machine_module.codex_session_confirmed_missing
+    scans = 0
+
+    async def pause_retirement(function, *args, **kwargs):
+        nonlocal scans
+        if function is missing:
+            scans += 1
+        if ((boundary == "scan" and function is missing and scans == 2)
+                or (boundary == "journal"
+                    and function == machine._codex_forks.begin_delete)):
+            paused.set()
+            await resume.wait()
+        return await to_thread(function, *args, **kwargs)
+
+    enqueue = machine._enqueue_deferred_query
+
+    async def submit(candidate, command):
+        submitting.set()
+        return await enqueue(candidate, command)
+
+    # Exercise the real command ACK, queue locks and drain worker; only the
+    # native engine boundary is unavailable. Accepted work must stay retained.
+    machine._handle_immediate_query = AsyncMock(return_value=Error(
+        code="not_running", message="test engine unavailable"))
+    monkeypatch.setattr(machine_module.asyncio, "to_thread", pause_retirement)
+    monkeypatch.setattr(machine, "_enqueue_deferred_query", submit)
+    pruning = asyncio.create_task(machine._prune_missing_codex_context(ctx))
+    submission = None
+    try:
+        await asyncio.wait_for(paused.wait(), 2)
+        command = Query(
+            sid=SID, prompt="keep this queued prompt", msg_id="queued-race",
+            delivery=delivery, cmd_id="queue-command", client_id="browser-a",
+        )
+        submission = asyncio.create_task(machine._process_command(command))
+        await asyncio.wait_for(submitting.wait(), 2)
+        if boundary == "scan":
+            # The expensive absence scan must not block queue acceptance.
+            await asyncio.wait_for(asyncio.shield(submission), 2)
+        resume.set()
+        removed = await asyncio.wait_for(pruning, 2)
+        await asyncio.wait_for(submission, 2)
+        if boundary == "scan":
+            assert not removed
+            assert machine.sessions[SID] is ctx
+            assert [q.msg_id for q in ctx.queued_queries] == [command.msg_id]
+            assert machine._queued_query_count == 1
+            assert any(isinstance(e, CommandAck)
+                       and e.cmd_id == command.cmd_id for e in transport.sent)
+            ctx.sdk.disconnect.assert_not_awaited()
+        else:
+            assert removed and SID not in machine.sessions
+            assert ctx.queued_queries == []
+            assert machine._queued_query_count == 0
+            assert any(isinstance(e, Error) and e.code == "not_running"
+                       and e.msg_id == command.msg_id for e in transport.sent)
+            machine._handle_immediate_query.assert_not_awaited()
+    finally:
+        resume.set()
+        tasks = [task for task in (
+            pruning, submission, ctx.queued_query_drain_task,
+        ) if task is not None]
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_native_activity_during_retirement_preserves_fork_replay(monkeypatch):
+    machine, _, ctx = _resident(monkeypatch)
+    original_to_thread = asyncio.to_thread
+    begin = machine._codex_forks.begin_delete
+    abort = machine._codex_forks.abort_delete = AsyncMock()
+
+    async def native_activity(function, *args, **kwargs):
+        if function == begin:
+            ctx.sdk.turn_active = True
+            return "delete_pending"
+        if function is abort:
+            return await abort(*args, **kwargs)
+        return await original_to_thread(function, *args, **kwargs)
+
+    monkeypatch.setattr(machine_module.asyncio, "to_thread", native_activity)
+    assert not await machine._prune_missing_codex_context(ctx)
+    assert machine.sessions[SID] is ctx
+    abort.assert_awaited_once_with(SID)
+    ctx.sdk.disconnect.assert_not_awaited()

--- a/tests/test_codex_provider_terminals.py
+++ b/tests/test_codex_provider_terminals.py
@@ -1,0 +1,100 @@
+"""Provider refusals stay failed across live, history, and ownership replay."""
+import json
+
+import pytest
+
+from cc_remote.protocol import Error, TurnEnd
+from cc_remote.wrapper.codex_external import parse_turn_markers
+from cc_remote.wrapper.machine import _codex_terminal_status
+from cc_remote.wrapper.codex_stream import (
+    CodexStreamTranslator,
+    _provider_failure_message,
+    codex_translate_history,
+)
+
+
+@pytest.mark.parametrize("info", ["cyber_policy", "cyberPolicy",
+                                  {"cyberPolicy": {}}])
+@pytest.mark.parametrize("key", ["codexErrorInfo", "codex_error_info"])
+def test_policy_error_is_not_auth_network_or_retry_advice(info, key):
+    message = _provider_failure_message({
+        key: info, "message": "403 stream disconnected secret-token",
+    })
+    assert "cyber_policy" in message
+    assert "secret-token" not in message
+    assert "请重试" not in message
+    assert "凭据" not in message
+
+
+def _record(kind, **payload):
+    return {"type": "event_msg", "timestamp": "2026-09-08T08:00:00Z",
+            "payload": {"type": kind, "turn_id": "turn-1", **payload}}
+
+
+@pytest.mark.parametrize("visible", [False, True])
+@pytest.mark.parametrize("error", [
+    {"codex_error_info": "cyber_policy", "message": "private provider text"},
+    {"message": "500 private provider text"},
+])
+def test_failed_task_complete_history_and_fence_agree(tmp_path, visible, error):
+    records = [
+        _record("task_started"),
+        _record("user_message", message="Inspect OpenSBI IPI logic"),
+    ]
+    if visible:
+        records.append(_record("agent_message", message="Checking the code"))
+    records.append(_record("task_complete", error=error))
+    raw = "".join(json.dumps(row) + "\n" for row in records)
+    path = tmp_path / "rollout.jsonl"
+    path.write_text(raw)
+    events, _ = codex_translate_history(str(path), 8000)
+    errors = [event for event in events if isinstance(event, Error)]
+    ends = [event for event in events if isinstance(event, TurnEnd)]
+    assert len(errors) == 1 and len(ends) == 1
+    assert ends[0].result.is_error and ends[0].result.subtype == "error"
+    assert "private provider text" not in errors[0].message
+    if "codex_error_info" in error:
+        assert "cyber_policy" in errors[0].message
+    markers = parse_turn_markers(raw.encode())
+    assert markers.terminals[0].status == "failed"
+
+
+@pytest.mark.parametrize("status", ["failed", "completed"])
+def test_live_policy_failure_finishes_and_next_turn_can_succeed(status):
+    translator = CodexStreamTranslator(8000)
+    events = translator.feed({"method": "turn/completed", "params": {
+        "turn": {"id": "turn-1", "status": status, "error": {
+            "codexErrorInfo": "cyberPolicy", "message": "private text",
+        }},
+    }})
+    assert any(isinstance(e, Error) and "cyber_policy" in e.message
+               for e in events)
+    assert any(isinstance(e, TurnEnd) and e.result.is_error for e in events)
+    # A new translator is the wrapper's per-query boundary. No policy error
+    # may leak into the next user-initiated turn or fabricate a retry.
+    next_turn = CodexStreamTranslator(8000)
+    next_turn.feed({"method": "item/agentMessage/delta", "params": {
+        "itemId": "answer-2", "delta": "The supplied log shows an IPI.",
+    }})
+    events = next_turn.feed({"method": "turn/completed", "params": {
+        "turn": {"id": "turn-2", "status": "completed", "error": None},
+    }})
+    assert any(isinstance(e, TurnEnd) and not e.result.is_error for e in events)
+
+
+def test_wrapper_cannot_synthesize_success_over_provider_error():
+    assert _codex_terminal_status({"params": {"turn": {
+        "status": "completed", "error": {"codexErrorInfo": "cyberPolicy"},
+    }}}) == "failed"
+
+
+def test_null_task_complete_error_remains_successful(tmp_path):
+    raw = "".join(json.dumps(row) + "\n" for row in [
+        _record("task_started"), _record("user_message", message="hello"),
+        _record("task_complete", error=None, last_agent_message="done"),
+    ])
+    path = tmp_path / "rollout.jsonl"
+    path.write_text(raw)
+    events, _ = codex_translate_history(str(path), 8000)
+    assert all(not e.result.is_error for e in events if isinstance(e, TurnEnd))
+    assert parse_turn_markers(raw.encode()).terminals[0].status == "completed"

--- a/tests/test_codex_provider_terminals.py
+++ b/tests/test_codex_provider_terminals.py
@@ -1,11 +1,16 @@
 """Provider refusals stay failed across live, history, and ownership replay."""
 import json
+import sqlite3
 
 import pytest
 
 from cc_remote.protocol import Error, TurnEnd
 from cc_remote.wrapper.codex_external import parse_turn_markers
 from cc_remote.wrapper.machine import _codex_terminal_status
+from cc_remote.wrapper.history_store import (
+    HistoryIndexStore, HistorySourceFingerprint, MaterializedHistoryPage,
+    _historical_turn_failure, materialize_history_turns,
+)
 from cc_remote.wrapper.codex_stream import (
     CodexStreamTranslator,
     _provider_failure_message,
@@ -55,6 +60,9 @@ def test_failed_task_complete_history_and_fence_agree(tmp_path, visible, error):
     assert "private provider text" not in errors[0].message
     if "codex_error_info" in error:
         assert "cyber_policy" in errors[0].message
+    summaries = materialize_history_turns([
+        event.model_dump(mode="json") for event in events])
+    assert summaries[0]["error"] == errors[0].message
     markers = parse_turn_markers(raw.encode())
     assert markers.terminals[0].status == "failed"
 
@@ -98,3 +106,47 @@ def test_null_task_complete_error_remains_successful(tmp_path):
     events, _ = codex_translate_history(str(path), 8000)
     assert all(not e.result.is_error for e in events if isinstance(e, TurnEnd))
     assert parse_turn_markers(raw.encode()).terminals[0].status == "completed"
+
+
+def test_policy_summary_accepts_only_the_reviewed_product_copy():
+    message = _provider_failure_message({"codexErrorInfo": "cyberPolicy"})
+    assert _historical_turn_failure(message) == message
+    for raw in ("cyber_policy private provider text", message + " secret-token"):
+        assert _historical_turn_failure(raw) == "该轮未正常结束"
+
+
+def test_cached_policy_failure_is_rebuilt_once_without_changing_rollout(tmp_path):
+    path = tmp_path / "rollout.jsonl"
+    raw = "".join(json.dumps(row) + "\n" for row in [
+        _record("task_started"), _record("user_message", message="inspect code"),
+        _record("task_complete", error={"codex_error_info": "cyber_policy"}),
+    ])
+    path.write_text(raw)
+    source = HistorySourceFingerprint.capture(path)
+    events, _ = codex_translate_history(str(path), 8000)
+    wire = tuple(event.model_dump(mode="json") for event in events)
+    repaired = materialize_history_turns(wire)
+    stale = dict(repaired[0], error="该轮未正常结束")
+    page = MaterializedHistoryPage(
+        events=wire, turns=(stale,), has_more=False,
+        oldest_id=stale["id"], newest_id=stale["id"],
+    )
+    state = tmp_path / "state"
+    store = HistoryIndexStore(state)
+    assert store.put_page("session", "codex", source,
+                          before=None, limit=4, page=page)
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("PRAGMA user_version=31")
+    migrated = HistoryIndexStore(state)
+    assert migrated.get_page("session", "codex", source,
+                             before=None, limit=4) is None
+    rebuilt = MaterializedHistoryPage(
+        events=wire, turns=repaired, has_more=False,
+        oldest_id=stale["id"], newest_id=stale["id"],
+    )
+    assert migrated.put_page("session", "codex", source,
+                             before=None, limit=4, page=rebuilt)
+    assert HistoryIndexStore(state).get_page(
+        "session", "codex", source, before=None, limit=4) == rebuilt
+    assert "cyber_policy" in repaired[0]["error"]
+    assert path.read_text() == raw

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -466,7 +466,7 @@ def test_v19_migration_rebuilds_history_and_adds_agent_details(tmp_path):
     assert migrated.get_page(
         "session-1", "claude", source, before=None, limit=4) is None
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
         assert connection.execute(
             "SELECT COUNT(*) FROM history_agent_details").fetchone()[0] == 0
 
@@ -494,7 +494,7 @@ def test_v20_migration_rebuilds_codex_and_claude_identity_projections(tmp_path):
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
         for table in ("history_pages", "history_turn_details"):
             assert connection.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE engine='claude'"
@@ -555,7 +555,7 @@ def test_v21_migration_rebuilds_claude_alias_and_codex_process_projections(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
         for table in ("history_pages", "history_turn_details"):
             assert connection.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE engine='claude'"
@@ -612,7 +612,7 @@ def test_v22_migration_applies_codex_and_claude_projection_repairs(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
         for table in ("history_pages", "history_turn_details"):
             assert connection.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE engine='claude'"
@@ -674,7 +674,7 @@ def test_recent_migration_applies_codex_and_claude_projection_repairs(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
         for table in ("history_pages", "history_turn_details"):
             assert connection.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE engine='claude'"
@@ -704,7 +704,7 @@ def test_recent_migration_applies_codex_and_claude_projection_repairs(
     ) == agent_events
 
 
-@pytest.mark.parametrize("old_version", [25, 26, 27, 28, 29])
+@pytest.mark.parametrize("old_version", [25, 26, 27, 28, 29, 30])
 def test_async_question_migration_preserves_assets_and_unchanged_claude_history(
     tmp_path, old_version,
 ):
@@ -745,7 +745,7 @@ def test_async_question_migration_preserves_assets_and_unchanged_claude_history(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
         for table in ("history_pages", "history_turn_details"):
             assert connection.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE engine='claude'"
@@ -854,7 +854,7 @@ def test_legacy_migration_rebuilds_all_derived_history_rows(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
         for table in (
             "history_pages",
             "history_turn_details",
@@ -901,7 +901,7 @@ def test_v10_migration_invalidates_changed_projection_rows(tmp_path):
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
         for table in (
             "history_pages", "history_turn_details", "history_image_assets",
         ):
@@ -952,7 +952,7 @@ def test_v11_migration_invalidates_claude_pages_and_adds_compact_index(
         "claude-session", "claude", source, before=None, limit=4,
     ) is None
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
         tables = {
             row[0] for row in connection.execute(
                 "SELECT name FROM sqlite_master WHERE type='table'"
@@ -998,7 +998,7 @@ def test_recent_migration_invalidates_changed_projection_rows(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
         for table in (
             "history_pages", "history_turn_details", "history_image_assets",
         ):
@@ -1040,7 +1040,7 @@ def test_owner_and_interrupt_alias_migration_invalidates_both_projections(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
         for table in ("history_pages", "history_turn_details"):
             assert connection.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE engine='claude'"
@@ -1104,7 +1104,7 @@ def test_recent_summary_migration_rebuilds_pages_but_preserves_source_assets(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 30
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
         assert connection.execute(
             "SELECT COUNT(*) FROM history_pages"
         ).fetchone()[0] == 0

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -466,7 +466,7 @@ def test_v19_migration_rebuilds_history_and_adds_agent_details(tmp_path):
     assert migrated.get_page(
         "session-1", "claude", source, before=None, limit=4) is None
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 32
         assert connection.execute(
             "SELECT COUNT(*) FROM history_agent_details").fetchone()[0] == 0
 
@@ -494,7 +494,7 @@ def test_v20_migration_rebuilds_codex_and_claude_identity_projections(tmp_path):
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 32
         for table in ("history_pages", "history_turn_details"):
             assert connection.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE engine='claude'"
@@ -555,7 +555,7 @@ def test_v21_migration_rebuilds_claude_alias_and_codex_process_projections(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 32
         for table in ("history_pages", "history_turn_details"):
             assert connection.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE engine='claude'"
@@ -612,7 +612,7 @@ def test_v22_migration_applies_codex_and_claude_projection_repairs(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 32
         for table in ("history_pages", "history_turn_details"):
             assert connection.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE engine='claude'"
@@ -674,7 +674,7 @@ def test_recent_migration_applies_codex_and_claude_projection_repairs(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 32
         for table in ("history_pages", "history_turn_details"):
             assert connection.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE engine='claude'"
@@ -704,7 +704,7 @@ def test_recent_migration_applies_codex_and_claude_projection_repairs(
     ) == agent_events
 
 
-@pytest.mark.parametrize("old_version", [25, 26, 27, 28, 29, 30])
+@pytest.mark.parametrize("old_version", [25, 26, 27, 28, 29, 30, 31])
 def test_async_question_migration_preserves_assets_and_unchanged_claude_history(
     tmp_path, old_version,
 ):
@@ -745,7 +745,7 @@ def test_async_question_migration_preserves_assets_and_unchanged_claude_history(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 32
         for table in ("history_pages", "history_turn_details"):
             assert connection.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE engine='claude'"
@@ -854,7 +854,7 @@ def test_legacy_migration_rebuilds_all_derived_history_rows(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 32
         for table in (
             "history_pages",
             "history_turn_details",
@@ -901,7 +901,7 @@ def test_v10_migration_invalidates_changed_projection_rows(tmp_path):
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 32
         for table in (
             "history_pages", "history_turn_details", "history_image_assets",
         ):
@@ -952,7 +952,7 @@ def test_v11_migration_invalidates_claude_pages_and_adds_compact_index(
         "claude-session", "claude", source, before=None, limit=4,
     ) is None
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 32
         tables = {
             row[0] for row in connection.execute(
                 "SELECT name FROM sqlite_master WHERE type='table'"
@@ -998,7 +998,7 @@ def test_recent_migration_invalidates_changed_projection_rows(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 32
         for table in (
             "history_pages", "history_turn_details", "history_image_assets",
         ):
@@ -1040,7 +1040,7 @@ def test_owner_and_interrupt_alias_migration_invalidates_both_projections(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 32
         for table in ("history_pages", "history_turn_details"):
             assert connection.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE engine='claude'"
@@ -1104,7 +1104,7 @@ def test_recent_summary_migration_rebuilds_pages_but_preserves_source_assets(
 
     migrated = HistoryIndexStore(state_dir)
     with sqlite3.connect(migrated.path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 31
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 32
         assert connection.execute(
             "SELECT COUNT(*) FROM history_pages"
         ).fetchone()[0] == 0

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -3105,7 +3105,7 @@ export function ChatView({ sid, turns: incomingTurns, engine = "claude", loading
               {fileChips(t)}
               {t.done && t.interrupted && !t.error
                 && <div className="note interrupted">— 已打断 —</div>}
-              {t.error && <div className="note interrupted">{
+              {t.error && <div className="note interrupted turn-failure">{
                 presentHistoricalTurnProblem(t.error)
               }</div>}
             </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -932,6 +932,8 @@ html.panel-resizing,html.panel-resizing *{ cursor:col-resize !important; user-se
 .note::before,.note::after{ content:""; position:absolute; top:50%; width:calc(50% - 70px); height:1px; background:var(--border); }
 .note::before{ left:0 } .note::after{ right:0 }
 .note.interrupted{ color:var(--danger); }
+.note.turn-failure{ text-align:left; overflow-wrap:anywhere; }
+.note.turn-failure::before,.note.turn-failure::after{ display:none; }
 
 /* EMPTY STATE */
 .empty{ flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center;

--- a/web/src/problem-presentation.ts
+++ b/web/src/problem-presentation.ts
@@ -15,6 +15,9 @@ const SAFE_TURN_FAILURE_MESSAGES = new Set([
   "请求过于频繁或当前额度受限，请稍后重试。",
   "请求超时，请重新尝试。",
   "Codex 上游服务暂时不可用，请稍后重试。",
+  "上游模型因安全策略拒绝了本次请求（cyber_policy）。"
+    + "这不是本地权限或网络错误；请核实并说明任务背景与授权范围，"
+    + "若属误判请向服务提供方反馈。",
 ]);
 
 function safeTurnFailureMessage(message: string): string | null {

--- a/web/tests/history-browser.spec.ts
+++ b/web/tests/history-browser.spec.ts
@@ -153,6 +153,45 @@ async function mockRightPanelRelay(
   return { commands, emit: (message: PanelRelayEvent) => emit(message) };
 }
 
+test("policy refusal remains specific through live delivery and history reload", async ({ page }, testInfo) => {
+  const message = "上游模型因安全策略拒绝了本次请求（cyber_policy）。"
+    + "这不是本地权限或网络错误；请核实并说明任务背景与授权范围，"
+    + "若属误判请向服务提供方反馈。";
+  const turns: NonNullable<Extract<ServerEvent, { type: "history" }>["turns"]> = [];
+  const relay = await mockRightPanelRelay(page, { retained: false, seedTurns: turns });
+  await page.goto("/");
+  await expect(page.locator(".composer textarea")).toBeEnabled();
+  relay.emit({ type: "user_msg", sid: "layout-parent", msg_id: "policy-user", prompt: "检查这段代码" });
+  relay.emit({ type: "state", sid: "layout-parent", state: "running", msg_id: "policy-user" });
+  relay.emit({ type: "error", sid: "layout-parent", code: "cc_crash", message, msg_id: "policy-user" });
+  relay.emit({ type: "turn_end", sid: "layout-parent", turn_id: "policy-turn",
+    result: { subtype: "error", duration_ms: 20, is_error: true } });
+  relay.emit({ type: "state", sid: "layout-parent", state: "idle" });
+  const problem = page.locator(".turn .note.interrupted");
+  await expect(problem).toHaveText(message);
+  await expect(page.locator(".composer textarea")).toBeEnabled();
+  expect(relay.commands.filter(c => c.type === "query" || c.type === "steer")).toHaveLength(0);
+
+  turns.push({ id: "policy-user", forkPointId: "policy-turn", prompt: "检查这段代码",
+    blocks: [], done: true, error: message, detailEventCount: 0, detailLoaded: true },
+  { id: "followup-user", forkPointId: "followup-turn", prompt: "解释现有日志",
+    blocks: [{ kind: "text", message_id: "followup-answer", text: "日志说明已完成。",
+      channel: "final", done: true }], done: true, detailEventCount: 0, detailLoaded: true });
+  await page.reload();
+  await expect(problem).toHaveCount(1);
+  await expect(problem).toHaveText(message);
+  await expect(page.locator('[data-turn-id="followup-user"]')).toContainText("日志说明已完成。");
+  await expect(page.locator('[data-turn-id="followup-user"] .note.interrupted')).toHaveCount(0);
+  for (const theme of ["light", "dark"]) {
+    await page.evaluate(value => document.documentElement.setAttribute("data-theme", value), theme);
+    await expect(problem).toBeVisible();
+    expect(await problem.evaluate(node => node.scrollWidth <= node.clientWidth + 1)).toBe(true);
+    expect(await problem.evaluate(node => getComputedStyle(node, "::before").display)).toBe("none");
+    expect(await problem.evaluate(node => getComputedStyle(node, "::after").display)).toBe("none");
+    await page.screenshot({ path: testInfo.outputPath(`policy-refusal-${theme}.png`) });
+  }
+});
+
 test("destroyed BTW stays readable after refresh with disabled input and a working new-chat button", async ({ page }, testInfo) => {
   const relay = await mockRightPanelRelay(page, { visible: true, btwReadOnly: true });
   await page.goto("/");

--- a/web/tests/notices-rate-limits.test.ts
+++ b/web/tests/notices-rate-limits.test.ts
@@ -340,6 +340,17 @@ try {
     /crash|warning|wrapper|private|traceback|secret/i);
 
   const hiddenDiagnostic = "provider crash at /private/token; see wrapper logs";
+  const policyFailure = "上游模型因安全策略拒绝了本次请求（cyber_policy）。"
+    + "这不是本地权限或网络错误；请核实并说明任务背景与授权范围，"
+    + "若属误判请向服务提供方反馈。";
+  assert.equal(presentTurnProblem({ code: "cc_crash", message: policyFailure }),
+    policyFailure);
+  assert.equal(presentHistoricalTurnProblem(policyFailure), policyFailure);
+  for (const message of [policyFailure + " secret-token", "cyber_policy private diagnostic"]) {
+    assert.equal(presentTurnProblem({ code: "cc_crash", message }),
+      "本次回复未完成，请重试。");
+    assert.equal(presentHistoricalTurnProblem(message), "该轮未正常结束");
+  }
   assert.equal(presentTurnProblem({ code: "cc_crash", message: hiddenDiagnostic }),
     "本次回复未完成，请重试。");
   for (const safeMessage of [


### PR DESCRIPTION
## Summary

This change fixes two Codex session consistency problems:

- An idle wrapper-only session could be restored to the sidebar after its
  native catalog row and rollout had already been deleted. Deleting the
  orphan could then fail before the stale resident was removed.
- A persisted `task_complete` record containing a provider error was treated
  as a successful completion. Live errors, refreshed history and source-bound
  terminal fences could therefore disagree about the same turn.

## Changes

- Prove absence from the selected account's readable state database and both
  active/archived rollout roots. Incomplete scans and I/O failures fail closed.
- Protect running and queued turns. A connected idle native thread must
  confirm exact absence, so an unmaterialized new thread is not pruned.
- Remove verified orphan residents without resuming or deleting native data,
  retire their private projections and replay state, invalidate the catalog,
  and broadcast the refresh hint to all browsers.
- Preserve provider failure outcomes in live translation, rollout replay and
  terminal recovery. Rebuild affected derived caches from their sources.
- Explain structured `cyber_policy` refusals with stable product copy instead
  of reporting a generic retry or authentication error. This does not bypass
  upstream policy, rewrite requests, or automatically retry rejected work.

## Validation

Zero-model regressions cover missing-state proof, account-home boundaries,
busy/queue protection, unmaterialized threads, uncertain native reads,
orphan deletion and sidebar refresh, provider failures with and without
partial output, subsequent user-initiated turns, and cache upgrades.

The complete local gate was executed against this source snapshot with
Node 24 and `act`:

| Check | Result |
| --- | --- |
| Python suite | 2,752 passed; 3 platform/environment-defined skips |
| Ruff 0.15.13 | Passed |
| Web build and bundle budget | Passed |
| Web reliability suite | Passed |
| History browser suite | 416 passed; 3 passed on configured retry; 23 skips |
| Viewer browser suite | 44 passed; 6 skips |
| Viewer resource/discovery tests and Web lint | Passed |
| Deployment shell syntax, ShellCheck, and diff whitespace | Passed |

Web and Deploy passed through the repository's original workflow. The
unchanged Python job was subsequently rerun without an injected CI proxy,
reusing the successful Web artifact: an existing child-environment test
assumes the parent proxy is not the same literal address as its fixture.
The continuation omitted only the already-completed Web dependency; none
of the Python job's steps or assertions were changed.

The local runner image initially lacked `iproute2`, which prevented the
Viewer tests from proving static-listener ownership. After installing the
real inspection tools, both previously failing browser cases passed twice
each, and the complete Viewer suite passed. No discovery checks were relaxed.

Three unchanged WebKit history cases required their existing configured
retry: scroll-anchor cancellation, dark-theme card borders, and async-question
reply mode. Dependency auditing also reported four advisories in the unchanged
dependency tree (two moderate and two high). No dependency or lockfile changes
are included in this PR.

## Compatibility and scope

- No wire-protocol changes, model requests, credential changes, or policy
  bypasses are introduced.
- The rebuildable history index advances from schema 30 to 31, and the
  terminal ledger from version 1 to 2, to discard cached false-success outcomes.
- Native transcripts and rollouts are not rewritten by this repair.
- The two fixes are separate, English Conventional Commits, both GPG-signed.
